### PR TITLE
fix(saving): empty `service.notify.name`s were removed

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -38,9 +38,10 @@ func TestLoad(t *testing.T) {
 	}
 
 	// Notify
-	gotNotifyTitle := (*config.Defaults.Notify["slack"].Params)["title"]
+	gotNotifyTitle := config.Defaults.Notify["slack"].GetSelfParam("title")
 	if !(wantNotifyTitle == gotNotifyTitle) {
-		t.Fatalf(`config.Defaults.Notify.Params.Title = %s, want match for %s`, gotNotifyTitle, wantNotifyTitle)
+		fmt.Println(config.Defaults.Notify["slack"])
+		t.Fatalf(`config.Defaults.Notify["slack"].Params.Title = %q, want match for %q`, gotNotifyTitle, wantNotifyTitle)
 	}
 
 	// WebHook

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -64,105 +64,105 @@ func (d *Defaults) SetDefaults() {
 	// Notify defaults.
 	d.Notify = make(shoutrrr.Slice)
 	d.Notify["discord"] = &shoutrrr.Shoutrrr{
-		Options: &notifyDefaultOptions,
-		Params:  &types.Params{"username": "Argus"},
+		Options: notifyDefaultOptions,
+		Params:  types.Params{"username": "Argus"},
 	}
 	d.Notify["discord"].InitMaps()
 	d.Notify["smtp"] = &shoutrrr.Shoutrrr{
-		Options: &notifyDefaultOptions,
-		URLFields: &map[string]string{
+		Options: notifyDefaultOptions,
+		URLFields: map[string]string{
 			"port": "25",
 		},
-		Params: &types.Params{},
+		Params: types.Params{},
 	}
 	d.Notify["smtp"].InitMaps()
 	d.Notify["googlechat"] = &shoutrrr.Shoutrrr{
-		Options: &notifyDefaultOptions,
-		Params:  &types.Params{},
+		Options: notifyDefaultOptions,
+		Params:  types.Params{},
 	}
 	d.Notify["googlechat"].InitMaps()
 	d.Notify["gotify"] = &shoutrrr.Shoutrrr{
-		Options: &notifyDefaultOptions,
-		URLFields: &map[string]string{
+		Options: notifyDefaultOptions,
+		URLFields: map[string]string{
 			"port": "443",
 		},
-		Params: &types.Params{"title": "Argus"},
+		Params: types.Params{"title": "Argus"},
 	}
 	d.Notify["gotify"].InitMaps()
 	d.Notify["ifttt"] = &shoutrrr.Shoutrrr{
-		Options: &notifyDefaultOptions,
-		Params:  &types.Params{"title": "Argus"},
+		Options: notifyDefaultOptions,
+		Params:  types.Params{"title": "Argus"},
 	}
 	d.Notify["ifttt"].InitMaps()
 	d.Notify["join"] = &shoutrrr.Shoutrrr{
-		Options: &notifyDefaultOptions,
-		Params:  &types.Params{},
+		Options: notifyDefaultOptions,
+		Params:  types.Params{},
 	}
 	d.Notify["join"].InitMaps()
 	d.Notify["mattermost"] = &shoutrrr.Shoutrrr{
-		Options: &map[string]string{
+		Options: map[string]string{
 			"message":   "<{{ service_url }}|{{ service_id }}> - {{ version }}released{% if web_url %} (<{{ web_url }}|changelog>){% endif %}",
 			"max_tries": "3",
 			"delay":     "0s",
 		},
-		URLFields: &map[string]string{
+		URLFields: map[string]string{
 			"port": "443",
 		},
-		Params: &types.Params{"username": "Argus"},
+		Params: types.Params{"username": "Argus"},
 	}
 	d.Notify["mattermost"].InitMaps()
 	d.Notify["matrix"] = &shoutrrr.Shoutrrr{
-		Options: &notifyDefaultOptions,
-		URLFields: &map[string]string{
+		Options: notifyDefaultOptions,
+		URLFields: map[string]string{
 			"port": "443",
 		},
-		Params: &types.Params{},
+		Params: types.Params{},
 	}
 	d.Notify["matrix"].InitMaps()
 	d.Notify["ops_genie"] = &shoutrrr.Shoutrrr{
-		Options: &notifyDefaultOptions,
-		Params:  &types.Params{},
+		Options: notifyDefaultOptions,
+		Params:  types.Params{},
 	}
 	d.Notify["ops_genie"].InitMaps()
 	d.Notify["pushbullet"] = &shoutrrr.Shoutrrr{
-		Options: &notifyDefaultOptions,
-		URLFields: &map[string]string{
+		Options: notifyDefaultOptions,
+		URLFields: map[string]string{
 			"port": "443",
 		},
-		Params: &types.Params{"title": "Argus"},
+		Params: types.Params{"title": "Argus"},
 	}
 	d.Notify["pushbullet"].InitMaps()
 	d.Notify["pushover"] = &shoutrrr.Shoutrrr{
-		Options: &notifyDefaultOptions,
-		Params:  &types.Params{},
+		Options: notifyDefaultOptions,
+		Params:  types.Params{},
 	}
 	d.Notify["pushover"].InitMaps()
 	d.Notify["rocketchat"] = &shoutrrr.Shoutrrr{
-		Options: &notifyDefaultOptions,
-		URLFields: &map[string]string{
+		Options: notifyDefaultOptions,
+		URLFields: map[string]string{
 			"port": "443",
 		},
-		Params: &types.Params{},
+		Params: types.Params{},
 	}
 	d.Notify["rocketchat"].InitMaps()
 	d.Notify["slack"] = &shoutrrr.Shoutrrr{
-		Options: &notifyDefaultOptions,
-		Params:  &types.Params{"botname": "Argus"},
+		Options: notifyDefaultOptions,
+		Params:  types.Params{"botname": "Argus"},
 	}
 	d.Notify["slack"].InitMaps()
 	d.Notify["team"] = &shoutrrr.Shoutrrr{
-		Options: &notifyDefaultOptions,
-		Params:  &types.Params{},
+		Options: notifyDefaultOptions,
+		Params:  types.Params{},
 	}
 	d.Notify["team"].InitMaps()
 	d.Notify["telegram"] = &shoutrrr.Shoutrrr{
-		Options: &notifyDefaultOptions,
-		Params:  &types.Params{},
+		Options: notifyDefaultOptions,
+		Params:  types.Params{},
 	}
 	d.Notify["telegram"].InitMaps()
 	d.Notify["zulip_chat"] = &shoutrrr.Shoutrrr{
-		Options: &notifyDefaultOptions,
-		Params:  &types.Params{},
+		Options: notifyDefaultOptions,
+		Params:  types.Params{},
 	}
 	d.Notify["zulip_chat"].InitMaps()
 

--- a/notifiers/shoutrrr/gets.go
+++ b/notifiers/shoutrrr/gets.go
@@ -23,47 +23,47 @@ import (
 
 // GetOption from this/Main/Defaults/HardDefaults on FiFo
 func (s *Shoutrrr) GetOption(key string) string {
-	return utils.GetFirstNonDefault((*s.Options)[key], (*s.Main.Options)[key], (*s.Defaults.Options)[key], (*s.HardDefaults.Options)[key])
+	return utils.GetFirstNonDefault(s.Options[key], s.Main.Options[key], s.Defaults.Options[key], s.HardDefaults.Options[key])
 }
 
 // GetSelfOption gets Options[key] from this Shoutrrr
 func (s *Shoutrrr) GetSelfOption(key string) string {
-	return (*s.Options)[key]
+	return s.Options[key]
 }
 
 // GetURLField from this/Main/Defaults/HardDefaults on FiFo
 func (s *Shoutrrr) GetURLField(key string) string {
-	return utils.GetFirstNonDefault((*s.URLFields)[key], (*s.Main.URLFields)[key], (*s.Defaults.URLFields)[key], (*s.HardDefaults.URLFields)[key])
+	return utils.GetFirstNonDefault(s.URLFields[key], s.Main.URLFields[key], s.Defaults.URLFields[key], s.HardDefaults.URLFields[key])
 }
 
 // GetSelfURLField gets URLFields[key] from this Shoutrrr
 func (s *Shoutrrr) GetSelfURLField(key string) string {
-	return (*s.URLFields)[key]
+	return s.URLFields[key]
 }
 
 // GetParam from this/Main/Defaults/HardDefaults on FiFo
 func (s *Shoutrrr) GetParam(key string) string {
-	return utils.GetFirstNonDefault((*s.Params)[key], (*s.Main.Params)[key], (*s.Defaults.Params)[key], (*s.HardDefaults.Params)[key])
+	return utils.GetFirstNonDefault(s.Params[key], s.Main.Params[key], s.Defaults.Params[key], s.HardDefaults.Params[key])
 }
 
 // GetSelfParam gets Params[key] from this Shoutrrr
 func (s *Shoutrrr) GetSelfParam(key string) string {
-	return (*s.Params)[key]
+	return s.Params[key]
 }
 
 // SetOption[key] to value
 func (s *Shoutrrr) SetOption(key string, value string) {
-	(*s.Options)[key] = value
+	s.Options[key] = value
 }
 
 // SetURLField[key] to value
 func (s *Shoutrrr) SetURLField(key string, value string) {
-	(*s.URLFields)[key] = value
+	s.URLFields[key] = value
 }
 
 // SetParam[key] to value
 func (s *Shoutrrr) SetParam(key string, value string) {
-	(*s.Params)[key] = value
+	s.Params[key] = value
 }
 
 // GetDelay before sending.

--- a/notifiers/shoutrrr/init.go
+++ b/notifiers/shoutrrr/init.go
@@ -44,10 +44,15 @@ func (s *Slice) Init(
 			(*s)[key] = &Shoutrrr{}
 		}
 		(*s)[key].ID = &id
+
+		if (*mains)[key] == nil {
+			(*mains)[key] = &Shoutrrr{}
+		}
+
 		// Get Type from this or the associated Main
 		notifyType := utils.GetFirstNonDefault(
 			(*s)[key].Type,
-			utils.DefaultIfNil((*mains)[key]).Type,
+			(*mains)[key].Type,
 		)
 
 		// Ensure defaults aren't nil
@@ -96,34 +101,28 @@ func (s *Shoutrrr) Init(
 // initOptions mapping, converting all keys to lowercase.
 func (s *Shoutrrr) initOptions() {
 	Options := make(map[string]string)
-	if s.Options != nil {
-		for i := range *s.Options {
-			Options[strings.ToLower(i)] = (*s.Options)[i]
-		}
+	for i := range s.Options {
+		Options[strings.ToLower(i)] = s.Options[i]
 	}
-	s.Options = &Options
+	s.Options = Options
 }
 
 // initURLFields mapping, converting all keys to lowercase.
 func (s *Shoutrrr) initURLFields() {
 	URLFields := make(map[string]string)
-	if s.URLFields != nil {
-		for i := range *s.URLFields {
-			URLFields[strings.ToLower(i)] = (*s.URLFields)[i]
-		}
+	for i := range s.URLFields {
+		URLFields[strings.ToLower(i)] = s.URLFields[i]
 	}
-	s.URLFields = &URLFields
+	s.URLFields = URLFields
 }
 
 // initParams mapping, converting all keys to lowercase.
 func (s *Shoutrrr) initParams() {
 	params := make(shoutrrr_types.Params)
-	if s.Params != nil {
-		for i := range *s.Params {
-			params[strings.ToLower(i)] = (*s.Params)[i]
-		}
+	for i := range s.Params {
+		params[strings.ToLower(i)] = s.Params[i]
 	}
-	s.Params = &params
+	s.Params = params
 }
 
 // InitMaps will initialise all maps, converting all keys to lowercase.

--- a/notifiers/shoutrrr/shoutrrr.go
+++ b/notifiers/shoutrrr/shoutrrr.go
@@ -30,15 +30,15 @@ func (s *Shoutrrr) GetParams() (params *shoutrrr_types.Params) {
 	params = &p
 
 	// Service Params
-	for key := range *s.Params {
+	for key := range s.Params {
 		cKey := fixParamKey(key)
 		(*params)[cKey] = s.GetSelfParam(key)
 	}
 
 	// Main Params
-	for key := range *s.Main.Params {
+	for key := range s.Main.Params {
 		cKey := fixParamKey(key)
-		_, exist := (*s.Params)[key]
+		_, exist := s.Params[key]
 		// Only overwrite if it doesn't exist in the level below
 		if !exist {
 			(*params)[cKey] = s.Main.GetSelfParam(key)
@@ -46,9 +46,9 @@ func (s *Shoutrrr) GetParams() (params *shoutrrr_types.Params) {
 	}
 
 	// Default Params
-	for key := range *s.Defaults.Params {
+	for key := range s.Defaults.Params {
 		cKey := fixParamKey(key)
-		_, exist := (*s.Params)[key]
+		_, exist := (s.Params)[key]
 		// Only overwrite if it doesn't exist in the level below
 		if !exist {
 			(*params)[cKey] = s.Defaults.GetSelfParam(key)
@@ -56,9 +56,9 @@ func (s *Shoutrrr) GetParams() (params *shoutrrr_types.Params) {
 	}
 
 	// HardDefault Params
-	for key := range *s.HardDefaults.Params {
+	for key := range s.HardDefaults.Params {
 		cKey := fixParamKey(key)
-		_, exist := (*s.Params)[key]
+		_, exist := s.Params[key]
 		// Only overwrite if it doesn't exist in the level below
 		if !exist {
 			(*params)[cKey] = s.HardDefaults.GetSelfParam(key)

--- a/notifiers/shoutrrr/shoutrrr_test.go
+++ b/notifiers/shoutrrr/shoutrrr_test.go
@@ -23,21 +23,22 @@ import (
 func TestShoutrrr(t *testing.T) {
 	// Test one Params
 	defaultShoutrr := Shoutrrr{
-		Options:   &map[string]string{},
-		URLFields: &map[string]string{},
-		Params:    &shoutrrr_types.Params{},
+		Options:   map[string]string{},
+		URLFields: map[string]string{},
+		Params:    shoutrrr_types.Params{},
 	}
 	test := Shoutrrr{
 		Main:         &defaultShoutrr,
 		Defaults:     &defaultShoutrr,
 		HardDefaults: &defaultShoutrr,
-		Params: &shoutrrr_types.Params{
-			"botname": "Test",
+		Params: shoutrrr_types.Params{
+			"BotName": "Test",
 		}}
 	wantedParams := map[string]string{
 		"botname": "Test",
 	}
 
+	test.initParams()
 	gotParams := test.GetParams()
 	for key := range *gotParams {
 		if (*gotParams)[key] != wantedParams[key] {
@@ -55,14 +56,15 @@ func TestShoutrrr(t *testing.T) {
 		Main:         &defaultShoutrr,
 		Defaults:     &defaultShoutrr,
 		HardDefaults: &defaultShoutrr,
-		Params: &shoutrrr_types.Params{
-			"botname": "OtherTest",
-			"icon":    "github",
+		Params: shoutrrr_types.Params{
+			"BotName": "OtherTest",
+			"Icon":    "github",
 		}}
 	wantedParams = map[string]string{
 		"botname": "OtherTest",
 		"icon":    "github",
 	}
+	test.initParams()
 	gotParams = test.GetParams()
 	for key := range *gotParams {
 		if (*gotParams)[key] != wantedParams[key] {
@@ -78,18 +80,19 @@ func TestShoutrrr(t *testing.T) {
 	// Test GetURL with one Params
 	testType := "discord"
 	testURLFields := map[string]string{
-		"token":     "bar",
-		"webhookid": "foo",
+		"Token":     "bar",
+		"WebhookID": "foo",
 	}
 	test = Shoutrrr{
 		Main:         &defaultShoutrr,
 		Defaults:     &defaultShoutrr,
 		HardDefaults: &defaultShoutrr,
 		Type:         testType,
-		URLFields:    &testURLFields,
+		URLFields:    testURLFields,
 		Params:       test.Params,
 	}
 	wantedURL := "discord://bar@foo"
+	test.initURLFields()
 	gotURL := test.GetURL()
 	if gotURL != wantedURL {
 		t.Fatalf(`Shoutrrr, GetURL - Got %v, want match for %q`, gotURL, wantedURL)
@@ -98,24 +101,65 @@ func TestShoutrrr(t *testing.T) {
 	// Test GetURL with multiple Params
 	testType = "teams"
 	testURLFields = map[string]string{
-		"group":      "something",
-		"tenant":     "foo",
-		"altid":      "bar",
-		"groupowner": "fez",
+		"Group":      "something",
+		"Tenant":     "foo",
+		"AltID":      "bar",
+		"GroupOwner": "fez",
 	}
-	testParams := &shoutrrr_types.Params{
-		"host":  "mockhost",
-		"title": "test",
+	testParams := shoutrrr_types.Params{
+		"Host":  "mockhost",
+		"Title": "test",
 	}
 	test = Shoutrrr{
 		Main:         &defaultShoutrr,
 		Defaults:     &defaultShoutrr,
 		HardDefaults: &defaultShoutrr,
 		Type:         testType,
-		URLFields:    &testURLFields,
+		URLFields:    testURLFields,
 		Params:       testParams,
 	}
 	wantedURL = "teams://something@foo/bar/fez?host=mockhost"
+	test.initParams()
+	test.initURLFields()
+	gotURL = test.GetURL()
+	if gotURL != wantedURL {
+		t.Fatalf(`Shoutrrr, GetURL - Got %v, want match for %q`, gotURL, wantedURL)
+	}
+
+	// Test Defaults
+	testType = "teams"
+	testServiceURLFields := map[string]string{
+		"Group": "something",
+	}
+	testMainURLFields := map[string]string{
+		"Group":  "main",
+		"Tenant": "foo",
+	}
+	testDefaultsURLFields := map[string]string{
+		"Group":  "default",
+		"Tenant": "default",
+		"AltID":  "bar",
+	}
+	testHardDefaultsURLFields := map[string]string{
+		"Group":      "hardDefault",
+		"Tenant":     "hardDefault",
+		"AltID":      "hardDefault",
+		"GroupOwner": "fez",
+	}
+	test = Shoutrrr{
+		Main:         &Shoutrrr{URLFields: testMainURLFields},
+		Defaults:     &Shoutrrr{URLFields: testDefaultsURLFields},
+		HardDefaults: &Shoutrrr{URLFields: testHardDefaultsURLFields},
+		Type:         testType,
+		URLFields:    testServiceURLFields,
+		Params:       testParams,
+	}
+	wantedURL = "teams://something@foo/bar/fez?host=mockhost"
+	test.initParams()
+	test.initURLFields()
+	test.Main.initURLFields()
+	test.Defaults.initURLFields()
+	test.HardDefaults.initURLFields()
 	gotURL = test.GetURL()
 	if gotURL != wantedURL {
 		t.Fatalf(`Shoutrrr, GetURL - Got %v, want match for %q`, gotURL, wantedURL)

--- a/notifiers/shoutrrr/types.go
+++ b/notifiers/shoutrrr/types.go
@@ -37,7 +37,7 @@ type Shoutrrr struct {
 
 	// Unsure whether to switch this to a base service which specific services inherit and define the Options/URLFields/Params
 	// Thinking this may be preferable as it makes adding new services much quicker/easier
-	Options   *map[string]string     `yaml:"options,omitempty"`    // Options
-	URLFields *map[string]string     `yaml:"url_fields,omitempty"` // URL Fields
-	Params    *shoutrrr_types.Params `yaml:"params,omitempty"`     // Query/Param Props
+	Options   map[string]string     `yaml:"options,omitempty"`    // Options
+	URLFields map[string]string     `yaml:"url_fields,omitempty"` // URL Fields
+	Params    shoutrrr_types.Params `yaml:"params,omitempty"`     // Query/Param Props
 }

--- a/notifiers/shoutrrr/verify.go
+++ b/notifiers/shoutrrr/verify.go
@@ -60,7 +60,7 @@ func (s *Shoutrrr) CheckValues(prefix string) (errs error) {
 	if delay := s.GetSelfOption("delay"); delay != "" {
 		// Default to seconds when an integer is provided
 		if _, err := strconv.Atoi(delay); err == nil {
-			(*s.Options)["delay"] += "s"
+			s.Options["delay"] += "s"
 		}
 		if _, err := time.ParseDuration(delay); err != nil {
 			errsOptions = fmt.Errorf("%s%s  delay: %q <invalid> (Use 'AhBmCs' duration format)\\", utils.ErrorToString(errsOptions), prefix, delay)
@@ -113,7 +113,7 @@ func (s *Shoutrrr) correctSelf() {
 		}
 	case "slack":
 		// # -> %23
-		for key := range *s.Params {
+		for key := range s.Params {
 			// https://containrrr.dev/shoutrrr/v0.5/services/slack/
 			// The format for the Color prop follows the slack docs but # needs to be escaped as %23 when passed in a URL.
 			// So #ff8000 would be %23ff8000 etc.
@@ -318,24 +318,18 @@ func (s *Slice) Print(prefix string) bool {
 func (s *Shoutrrr) Print(prefix string) {
 	utils.PrintlnIfNotDefault(s.Type, fmt.Sprintf("%stype: %s", prefix, s.Type))
 
-	if s.Options != nil && len(*s.Options) > 0 {
-		fmt.Printf("%soptions:\n", prefix)
-		for key := range *s.Options {
-			utils.PrintlnIfNotDefault(s.GetSelfOption(key), fmt.Sprintf("%s  %s: %s", prefix, key, s.GetSelfOption(key)))
-		}
+	fmt.Printf("%soptions:\n", prefix)
+	for key := range s.Options {
+		utils.PrintlnIfNotDefault(s.GetSelfOption(key), fmt.Sprintf("%s  %s: %s", prefix, key, s.GetSelfOption(key)))
 	}
 
-	if s.URLFields != nil && len(*s.URLFields) > 0 {
-		fmt.Printf("%surl_fields:\n", prefix)
-		for key := range *s.URLFields {
-			utils.PrintlnIfNotDefault(s.GetSelfURLField(key), fmt.Sprintf("%s  %s: %s", prefix, key, s.GetSelfURLField(key)))
-		}
+	fmt.Printf("%surl_fields:\n", prefix)
+	for key := range s.URLFields {
+		utils.PrintlnIfNotDefault(s.GetSelfURLField(key), fmt.Sprintf("%s  %s: %s", prefix, key, s.GetSelfURLField(key)))
 	}
 
-	if s.Params != nil && len(*s.Params) != 0 {
-		fmt.Printf("%sparams:\n", prefix)
-		for key := range *s.Params {
-			utils.PrintlnIfNotDefault(s.GetSelfParam(key), fmt.Sprintf("%s  %s: %s", prefix, key, s.GetSelfParam(key)))
-		}
+	fmt.Printf("%sparams:\n", prefix)
+	for key := range s.Params {
+		utils.PrintlnIfNotDefault(s.GetSelfParam(key), fmt.Sprintf("%s  %s: %s", prefix, key, s.GetSelfParam(key)))
 	}
 }

--- a/web/api/types/argus.go
+++ b/web/api/types/argus.go
@@ -153,11 +153,11 @@ func (n *NotifySlice) Censor() *NotifySlice {
 
 // Notify is a message w/ destination and from details.
 type Notify struct {
-	ID        *string                `json:"-"`                    // ID for this Notify sender
-	Type      string                 `json:"type,omitempty"`       // Notification type, e.g. slack
-	Options   *map[string]string     `json:"options,omitempty"`    // Options
-	URLFields *map[string]string     `json:"url_fields,omitempty"` // URL Fields
-	Params    *shoutrrr_types.Params `json:"params,omitempty"`     // Param props
+	ID        *string               `json:"-"`                    // ID for this Notify sender
+	Type      string                `json:"type,omitempty"`       // Notification type, e.g. slack
+	Options   map[string]string     `json:"options,omitempty"`    // Options
+	URLFields map[string]string     `json:"url_fields,omitempty"` // URL Fields
+	Params    shoutrrr_types.Params `json:"params,omitempty"`     // Param props
 }
 
 // Censor this Notify for sending over a WebSocket
@@ -178,9 +178,9 @@ func (n *Notify) Censor() *Notify {
 		"tokenb",
 		"webhookid",
 	}
-	if len(*n.URLFields) > 0 {
+	if len(n.URLFields) > 0 {
 		for i := range url_fields_to_censor {
-			if (*n.URLFields)[url_fields_to_censor[i]] != "" {
+			if n.URLFields[url_fields_to_censor[i]] != "" {
 				censorURLFields = true
 			}
 		}
@@ -191,9 +191,9 @@ func (n *Notify) Censor() *Notify {
 		"devices",
 		"host",
 	}
-	if len(*n.Params) > 0 {
+	if len(n.Params) > 0 {
 		for i := range params_to_censor {
-			if (*n.Params)[params_to_censor[i]] != "" {
+			if n.Params[params_to_censor[i]] != "" {
 				censorParams = true
 			}
 		}
@@ -206,21 +206,19 @@ func (n *Notify) Censor() *Notify {
 	// Censor the fields that should be censored
 	urlFields := n.URLFields
 	if censorURLFields {
-		urlFields = &map[string]string{}
-		*urlFields = utils.CopyMap(*n.URLFields)
+		urlFields = utils.CopyMap(n.URLFields)
 		for i := range url_fields_to_censor {
-			if (*urlFields)[url_fields_to_censor[i]] != "" {
-				(*urlFields)[url_fields_to_censor[i]] = "<secret>"
+			if urlFields[url_fields_to_censor[i]] != "" {
+				urlFields[url_fields_to_censor[i]] = "<secret>"
 			}
 		}
 	}
 	params := n.Params
 	if censorParams {
-		params = &shoutrrr_types.Params{}
-		*params = utils.CopyMap(*n.Params)
+		params = utils.CopyMap(n.Params)
 		for i := range params_to_censor {
-			if (*params)[params_to_censor[i]] != "" {
-				(*params)[params_to_censor[i]] = "<secret>"
+			if params[params_to_censor[i]] != "" {
+				params[params_to_censor[i]] = "<secret>"
 			}
 		}
 	}


### PR DESCRIPTION
e.g. `service.notify.something` would be removed when saving if it was empty (`{}`), meaning it's getting all its params etc from `notify.something`

(the code I wrote to remove empty mappings, e.g. `defaults: {}` was set to ignore `service.notify.something: {}`, but since 'options','url_fields','params' were pointers, they would still be encoded as when empty, they wouldn't be their default state (nil). So my code would see all of those as empty maps (e.g. `params: {}`) and remove them. It would then remove the parent as it wasn't mapping to anything anymore)

Fixed this by not making `params` etc a pointer, so they'll be in their default state when empty and won't be encoded when saved)

fixes https://github.com/release-argus/Argus/issues/75