### PR TITLE
feat(webhook): support for custom headers

### DIFF
--- a/web/api/types/argus.go
+++ b/web/api/types/argus.go
@@ -307,14 +307,15 @@ type WebHookSlice map[string]*WebHook
 
 // WebHook is a WebHook to send.
 type WebHook struct {
-	ServiceID         *string `json:"-"`                             // ID of the service this WebHook is attached to
-	Type              *string `json:"type,omitempty"`                // "github"/"url"
-	URL               *string `json:"url,omitempty"`                 // "https://example.com"
-	Secret            *string `json:"secret,omitempty"`              // "SECRET"
-	DesiredStatusCode *int    `json:"desired_status_code,omitempty"` // e.g. 202
-	Delay             *string `json:"delay,omitempty"`               // The delay before sending the WebHook.
-	MaxTries          *uint   `json:"max_tries,omitempty"`           // Number of times to attempt sending the WebHook if the desired status code is not received.
-	SilentFails       *bool   `json:"silent_fails,omitempty"`        // Whether to notify if this WebHook fails MaxTries times.
+	ServiceID         *string            `json:"-"`                             // ID of the service this WebHook is attached to
+	Type              *string            `json:"type,omitempty"`                // "github"/"url"
+	URL               *string            `json:"url,omitempty"`                 // "https://example.com"
+	Secret            *string            `json:"secret,omitempty"`              // "SECRET"
+	CustomHeaders     *map[string]string `json:"custom_headers,omitempty"`      // Custom Headers for the WebHook
+	DesiredStatusCode *int               `json:"desired_status_code,omitempty"` // e.g. 202
+	Delay             *string            `json:"delay,omitempty"`               // The delay before sending the WebHook.
+	MaxTries          *uint              `json:"max_tries,omitempty"`           // Number of times to attempt sending the WebHook if the desired status code is not received.
+	SilentFails       *bool              `json:"silent_fails,omitempty"`        // Whether to notify if this WebHook fails MaxTries times.
 }
 
 // Notifiers are the notifiers to use when a WebHook fails.

--- a/web/api/v1/websocket.go
+++ b/web/api/v1/websocket.go
@@ -611,6 +611,7 @@ func (api *API) wsConfigService(client *Client) {
 						Type:              (*service.WebHook)[index].Type,
 						URL:               (*service.WebHook)[index].URL,
 						Secret:            utils.ValueIfNotNil((*service.WebHook)[index].Secret, "<secret>"),
+						CustomHeaders:     (*service.WebHook)[index].CustomHeaders,
 						DesiredStatusCode: (*service.WebHook)[index].DesiredStatusCode,
 						Delay:             (*service.WebHook)[index].Delay,
 						MaxTries:          (*service.WebHook)[index].MaxTries,

--- a/web/ui/react-app/src/types/config.tsx
+++ b/web/ui/react-app/src/types/config.tsx
@@ -127,6 +127,7 @@ export interface WebHookType {
   type: string;
   url: string;
   secret?: string;
+  custom_headers?: Map<string, string>;
   desired_status_code?: number;
   delay?: string;
   max_tries?: number;

--- a/webhook/github.go
+++ b/webhook/github.go
@@ -33,8 +33,19 @@ type GitHub struct {
 	After  string `json:"after"`  // "RandAlphaNumericLower(40)"
 }
 
+// SetCustomHeaders of the req.
+func (w *WebHook) SetCustomHeaders(req *http.Request) {
+	if w.CustomHeaders == nil {
+		return
+	}
+
+	for key := range *w.CustomHeaders {
+		req.Header[key] = []string{(*w.CustomHeaders)[key]}
+	}
+}
+
 // SetGitHubHeaders of the req based on the payload and secret.
-func SetGitHubHeaders(req *http.Request, payload []byte, secret string) *http.Request {
+func SetGitHubHeaders(req *http.Request, payload []byte, secret string) {
 	req.Header.Set("X-GitHub-Event", "push")
 	req.Header.Set("X-GitHub-Hook-ID", utils.RandNumeric(9))
 	req.Header.Set("X-GitHub-Delivery", fmt.Sprintf("%s-%s-%s-%s-%s", utils.RandAlphaNumericLower(8), utils.RandAlphaNumericLower(4), utils.RandAlphaNumericLower(4), utils.RandAlphaNumericLower(4), utils.RandAlphaNumericLower(12)))
@@ -50,6 +61,4 @@ func SetGitHubHeaders(req *http.Request, payload []byte, secret string) *http.Re
 	hash = hmac.New(sha1.New, []byte(secret))
 	hash.Write(payload)
 	req.Header.Set("X-Hub-Signature", fmt.Sprintf("sha1=%s", hex.EncodeToString(hash.Sum(nil))))
-
-	return req
 }

--- a/webhook/init.go
+++ b/webhook/init.go
@@ -151,7 +151,8 @@ func (w *WebHook) GetRequest() (req *http.Request) {
 		}
 		req.Header.Set("Content-Type", "application/json")
 
-		req = SetGitHubHeaders(req, payload, *w.GetSecret())
+		w.SetCustomHeaders(req)
+		SetGitHubHeaders(req, payload, *w.GetSecret())
 	}
 	return
 }

--- a/webhook/types.go
+++ b/webhook/types.go
@@ -28,22 +28,23 @@ type Slice map[string]*WebHook
 
 // WebHook to send.
 type WebHook struct {
-	ID                *string      `yaml:"-"`                             // Unique across the Slice
-	ServiceID         *string      `yaml:"-"`                             // ID of the service this WebHook is attached to
-	Type              *string      `yaml:"type,omitempty"`                // "github"/"url"
-	URL               *string      `yaml:"url,omitempty"`                 // "https://example.com"
-	AllowInvalidCerts *bool        `yaml:"allow_invalid_certs,omitempty"` // default - false = Disallows invalid HTTPS certificates.
-	Secret            *string      `yaml:"secret,omitempty"`              // "SECRET"
-	DesiredStatusCode *int         `yaml:"desired_status_code,omitempty"` // e.g. 202
-	Delay             *string      `yaml:"delay,omitempty"`               // The delay before sending the WebHook.
-	MaxTries          *uint        `yaml:"max_tries,omitempty"`           // Number of times to attempt sending the WebHook if the desired status code is not received.
-	SilentFails       *bool        `yaml:"silent_fails,omitempty"`        // Whether to notify if this WebHook fails MaxTries times.
-	Failed            *bool        `yaml:"-"`                             // Whether the last send attempt failed
-	HardDefaults      *WebHook     `yaml:"-"`                             // Hardcoded default values
-	Defaults          *WebHook     `yaml:"-"`                             // Default values
-	Main              *WebHook     `yaml:"-"`                             // The Webhook that this Webhook is calling (and may override parts of)
-	Notifiers         *Notifiers   `yaml:"-"`                             // The Notify's to notify on failures
-	Announce          *chan []byte `yaml:"-"`                             // Announce to the WebSocket
+	ID                *string            `yaml:"-"`                             // Unique across the Slice
+	ServiceID         *string            `yaml:"-"`                             // ID of the service this WebHook is attached to
+	Type              *string            `yaml:"type,omitempty"`                // "github"/"url"
+	URL               *string            `yaml:"url,omitempty"`                 // "https://example.com"
+	AllowInvalidCerts *bool              `yaml:"allow_invalid_certs,omitempty"` // default - false = Disallows invalid HTTPS certificates.
+	CustomHeaders     *map[string]string `yaml:"custom_headers,omitempty"`      // Custom Headers for the WebHook
+	Secret            *string            `yaml:"secret,omitempty"`              // "SECRET"
+	DesiredStatusCode *int               `yaml:"desired_status_code,omitempty"` // e.g. 202
+	Delay             *string            `yaml:"delay,omitempty"`               // The delay before sending the WebHook.
+	MaxTries          *uint              `yaml:"max_tries,omitempty"`           // Number of times to attempt sending the WebHook if the desired status code is not received.
+	SilentFails       *bool              `yaml:"silent_fails,omitempty"`        // Whether to notify if this WebHook fails MaxTries times.
+	Failed            *bool              `yaml:"-"`                             // Whether the last send attempt failed
+	HardDefaults      *WebHook           `yaml:"-"`                             // Hardcoded default values
+	Defaults          *WebHook           `yaml:"-"`                             // Default values
+	Main              *WebHook           `yaml:"-"`                             // The Webhook that this Webhook is calling (and may override parts of)
+	Notifiers         *Notifiers         `yaml:"-"`                             // The Notify's to notify on failures
+	Announce          *chan []byte       `yaml:"-"`                             // Announce to the WebSocket
 }
 
 // Notifiers to use when their WebHook fails.


### PR DESCRIPTION
In `adnanh/webhook`:
```yaml
- id: something
  execute-command: SOMETHING.SH
  pass-arguments-to-command:
  - source: header
    name: CUSTOM_HEADER_NAME
```

in `Argus` config.yml:
```yaml
    webhook:
      some_name:
        custom_headers:
          CUSTOM_HEADER_NAME: hello123
```

would execute ["SOMETHING.SH" "hello123"]