### PR TITLE
feat(webhook): add type gitlab

### DIFF
--- a/service/verify.go
+++ b/service/verify.go
@@ -75,8 +75,8 @@ func (s *Service) CheckValues(prefix string) (errs error) {
 	if s.Defaults != nil {
 		if s.Type == nil {
 			errs = fmt.Errorf("%s%s  type: <missing> (Services require a type)\\", utils.ErrorToString(errs), prefix)
-		} else if *s.Type != "github" && *s.Type != "url" {
-			errs = fmt.Errorf("%s%s  type: %q <invalid> (Should be either 'github' or 'url')\\", utils.ErrorToString(errs), prefix, *s.Type)
+		} else if *s.Type != "github" && *s.Type != "gitlab" && *s.Type != "url" {
+			errs = fmt.Errorf("%s%s  type: %q <invalid> (Should be either 'github', 'gitlab' or 'url')\\", utils.ErrorToString(errs), prefix, *s.Type)
 		}
 	}
 

--- a/webhook/gitlab.go
+++ b/webhook/gitlab.go
@@ -1,0 +1,31 @@
+// Copyright [2022] [Argus]
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webhook
+
+import (
+	"net/http"
+	"net/url"
+)
+
+// SetGitHubHeaders of the req based on the payload and secret.
+func SetGitLabParameter(req *http.Request, secret string) {
+	q := url.Values{}
+	if req.URL.Query() != nil && len(req.URL.Query()) != 0 {
+		q = req.URL.Query()
+	}
+	q.Add("token", secret)
+	q.Add("ref", "master")
+	req.URL.RawQuery = q.Encode()
+}

--- a/webhook/init.go
+++ b/webhook/init.go
@@ -135,7 +135,8 @@ func (w *WebHook) GetMaxTries() uint {
 // GetRequest will return the WebHook http.request ready to be sent.
 func (w *WebHook) GetRequest() (req *http.Request) {
 	// GitHub style payload.
-	if w.GetType() == "github" {
+	switch w.GetType() {
+	case "github":
 		payload, err := json.Marshal(GitHub{
 			Ref:    "refs/heads/master",
 			Before: utils.RandAlphaNumericLower(40),
@@ -153,7 +154,7 @@ func (w *WebHook) GetRequest() (req *http.Request) {
 
 		w.SetCustomHeaders(req)
 		SetGitHubHeaders(req, payload, *w.GetSecret())
-	} else if w.GetType() == "gitlab" {
+	case "gitlab":
 		var err error
 		req, err = http.NewRequest(http.MethodPost, *w.GetURL(), nil)
 		if err != nil {

--- a/webhook/init.go
+++ b/webhook/init.go
@@ -134,7 +134,6 @@ func (w *WebHook) GetMaxTries() uint {
 
 // GetRequest will return the WebHook http.request ready to be sent.
 func (w *WebHook) GetRequest() (req *http.Request) {
-	// GitHub style payload.
 	switch w.GetType() {
 	case "github":
 		payload, err := json.Marshal(GitHub{

--- a/webhook/init.go
+++ b/webhook/init.go
@@ -153,6 +153,15 @@ func (w *WebHook) GetRequest() (req *http.Request) {
 
 		w.SetCustomHeaders(req)
 		SetGitHubHeaders(req, payload, *w.GetSecret())
+	} else if w.GetType() == "gitlab" {
+		var err error
+		req, err = http.NewRequest(http.MethodPost, *w.GetURL(), nil)
+		if err != nil {
+			return nil
+		}
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+		SetGitLabParameter(req, *w.GetSecret())
 	}
 	return
 }

--- a/webhook/verify.go
+++ b/webhook/verify.go
@@ -54,7 +54,8 @@ func (w *WebHook) CheckValues(prefix string) (errs error) {
 	}
 
 	if w.Main != nil {
-		if w.GetType() != "github" && w.GetType() != "gitlab" {
+		types := []string{"github", "gitlab"}
+		if !utils.Contains(types, w.GetType()) {
 			errs = fmt.Errorf("%s%stype: %q <invalid> (the only webhook type is 'github' or 'gitlab' currently)\\", utils.ErrorToString(errs), prefix, w.GetType())
 		}
 		if w.GetURL() == nil {

--- a/webhook/verify.go
+++ b/webhook/verify.go
@@ -54,8 +54,8 @@ func (w *WebHook) CheckValues(prefix string) (errs error) {
 	}
 
 	if w.Main != nil {
-		if w.GetType() != "github" {
-			errs = fmt.Errorf("%s%stype: %q <invalid> (the only webhook type is 'github' currently)\\", utils.ErrorToString(errs), prefix, w.GetType())
+		if w.GetType() != "github" && w.GetType() != "gitlab" {
+			errs = fmt.Errorf("%s%stype: %q <invalid> (the only webhook type is 'github' or 'gitlab' currently)\\", utils.ErrorToString(errs), prefix, w.GetType())
 		}
 		if w.GetURL() == nil {
 			errs = fmt.Errorf("%s%surl: <required> (here, or in webhook.%s)\\", utils.ErrorToString(errs), prefix, *w.ID)

--- a/webhook/verify.go
+++ b/webhook/verify.go
@@ -56,7 +56,7 @@ func (w *WebHook) CheckValues(prefix string) (errs error) {
 	if w.Main != nil {
 		types := []string{"github", "gitlab"}
 		if !utils.Contains(types, w.GetType()) {
-			errs = fmt.Errorf("%s%stype: %q <invalid> (the only webhook type is 'github' or 'gitlab' currently)\\", utils.ErrorToString(errs), prefix, w.GetType())
+			errs = fmt.Errorf("%s%stype: %q <invalid> (supported types = %s)\\", utils.ErrorToString(errs), prefix, w.GetType(), types)
 		}
 		if w.GetURL() == nil {
 			errs = fmt.Errorf("%s%surl: <required> (here, or in webhook.%s)\\", utils.ErrorToString(errs), prefix, *w.ID)


### PR DESCRIPTION
Add basic Support for GitLab Webhooks/Triggers.

[docs.gitlab.com/15.0/ee/ci/triggers](https://docs.gitlab.com/15.0/ee/ci/triggers/)