### PR TITLE
feat(commands,webhook): pass version to webhook or command

### DIFF
--- a/commands/announce.go
+++ b/commands/announce.go
@@ -16,18 +16,18 @@ package command
 
 import (
 	"encoding/json"
-	"strings"
 
 	api_types "github.com/release-argus/Argus/web/api/types"
 )
 
-// AnnounceCommand will announce the failed status of `c.Announce` channel
+// AnnounceCommand will announce the Command fail status to `c.Announce` channel
 // (Broadcast to all WebSocket clients).
 func (c *Controller) AnnounceCommand(index int) {
 	var payloadData []byte
 
 	commandSummary := make(map[string]*api_types.CommandSummary)
-	commandSummary[strings.Join((*c.Command)[index], " ")] = &api_types.CommandSummary{Failed: c.Failed[index]}
+	formatted := (*c.Command)[index].ApplyTemplate(c.ServiceStatus)
+	commandSummary[formatted.String()] = &api_types.CommandSummary{Failed: c.Failed[index]}
 
 	// Command success/fail
 	wsPage := "APPROVALS"
@@ -51,10 +51,11 @@ func (c *Controller) AnnounceCommand(index int) {
 // Find `command`.
 func (c *Controller) Find(command string) *int {
 	// Loop through all the Command(s)
-	for i := range *c.Command {
-		// If this command starts with the same text
-		if (*c.Command)[i].String() == command {
-			return &i
+	for key := range *c.Command {
+		formatted := (*c.Command)[key].ApplyTemplate(c.ServiceStatus)
+		// If this key is the command
+		if formatted.String() == command {
+			return &key
 		}
 	}
 	return nil

--- a/commands/announce_test.go
+++ b/commands/announce_test.go
@@ -172,15 +172,18 @@ func TestResetFails(t *testing.T) {
 		commandController.Failed[4] = &failed4
 
 		// WHEN ResetFails is called
+		failsBefore := len(commandController.Failed)
 		commandController.ResetFails()
-		// THEN all the fails become nil and the count stays the same
+		// THEN all the fails become nil
 		for _, failed := range commandController.Failed {
 			if failed != nil {
 				t.Fatalf("Reset failed, got %v", commandController.Failed)
 			}
 		}
-		if len(commandController.Failed) != len(*commandController.Command) {
-			t.Fatalf("Reset added/removed elements to the Failed list, got %v", commandController.Failed)
+		// AND the count stays the same
+		failsAfter := len(commandController.Failed)
+		if failsBefore != failsAfter {
+			t.Fatalf("Reset added/removed elements to the Failed list. Wanted %d, got %d", failsBefore, failsAfter)
 		}
 	}
 }

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -19,6 +19,7 @@ import (
 	"os/exec"
 	"time"
 
+	service_status "github.com/release-argus/Argus/service/status"
 	"github.com/release-argus/Argus/utils"
 	metrics "github.com/release-argus/Argus/web/metrics"
 )
@@ -59,8 +60,11 @@ func (c *Controller) ExecIndex(logFrom *utils.LogFrom, index int) error {
 		return nil
 	}
 
+	// Copy Command and apply Jinja templating
+	command := (*c.Command)[index].ApplyTemplate(c.ServiceStatus)
+
 	// Execute
-	err := (*c.Command)[index].Exec(logFrom)
+	err := command.Exec(logFrom)
 
 	// Set fail/not
 	failed := err != nil
@@ -92,4 +96,17 @@ func (c *Command) Exec(logFrom *utils.LogFrom) error {
 	jLog.Info(string(out), *logFrom, err == nil && string(out) != "")
 
 	return err
+}
+
+func (c *Command) ApplyTemplate(serviceStatus *service_status.Status) Command {
+	if serviceStatus == nil {
+		return *c
+	}
+
+	command := Command(make([]string, len(*c)))
+	copy(command, *c)
+	for i := range command {
+		command[i] = utils.TemplateString(command[i], utils.ServiceInfo{LatestVersion: serviceStatus.LatestVersion})
+	}
+	return command
 }

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -17,6 +17,7 @@ package command
 import (
 	"testing"
 
+	service_status "github.com/release-argus/Argus/service/status"
 	"github.com/release-argus/Argus/utils"
 )
 
@@ -42,7 +43,7 @@ func TestExec(t *testing.T) {
 		commandController := Controller{
 			ServiceID: &controllerName,
 		}
-		commandController.Init(nil, &controllerName, &Slice{Command{"ls", "/root"}}, nil)
+		commandController.Init(nil, &controllerName, nil, &Slice{Command{"ls", "/root"}}, nil)
 		{
 			// WHEN it's stringified with .String()
 			// THEN it's joined with spaces
@@ -64,7 +65,7 @@ func TestExec(t *testing.T) {
 		commandController := Controller{
 			ServiceID: &controllerName,
 		}
-		commandController.Init(nil, &controllerName, &Slice{Command{"ls"}}, nil)
+		commandController.Init(nil, &controllerName, nil, &Slice{Command{"ls"}}, nil)
 		{
 			// WHEN it's stringified with .String()
 			// THEN it's returned as the correct string
@@ -113,6 +114,49 @@ func TestExecIndex(t *testing.T) {
 		// THEN err is nil
 		if err != nil {
 			t.Fatalf(`%v command shouldn't have errored as the index was outside the bounds\n%s`, commandController.Command, err.Error())
+		}
+	}
+}
+
+func TestApplyTemplate(t *testing.T) {
+	Init(utils.NewJLog("ERROR", false))
+
+	{ // GIVEN a Controller with nil ServiceStatus
+		controllerName := "TEST"
+		commandController := Controller{
+			ServiceID: &controllerName,
+			Command: &Slice{
+				Command{"false", "{{ version }}"},
+			},
+			Failed: make(Fails, 1),
+		}
+		// WHEN ApplyTemplate is called with that nil Status
+		command := (*commandController.Command)[0].ApplyTemplate(commandController.ServiceStatus)
+		// THEN the {{ version }} var is not evaluated
+		got := command.String()
+		want := "false {{ version }}"
+		if got != want {
+			t.Fatalf(`Failed with nil Status. Got %q, wanted %q`, got, want)
+		}
+	}
+
+	{ // GIVEN a Controller with a non-nil ServiceStatus
+		controllerName := "TEST"
+		commandController := Controller{
+			ServiceID: &controllerName,
+			Command: &Slice{
+				Command{"false", "{{ version }}"},
+			},
+			Failed:        make(Fails, 1),
+			ServiceStatus: &service_status.Status{LatestVersion: "1.2.3"},
+		}
+		// WHEN ApplyTemplate is called
+		command := (*commandController.Command)[0].ApplyTemplate(commandController.ServiceStatus)
+		// THEN the {{ version }} var is evaluated
+		got := command.String()
+		want := "false 1.2.3"
+		if got != want {
+			t.Fatalf(`Failed with non-nil Status. Got %q, wanted %q`, got, want)
 		}
 	}
 }

--- a/commands/init.go
+++ b/commands/init.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/release-argus/Argus/notifiers/shoutrrr"
+	service_status "github.com/release-argus/Argus/service/status"
 	"github.com/release-argus/Argus/utils"
 	metrics "github.com/release-argus/Argus/web/metrics"
 )
@@ -27,6 +28,7 @@ import (
 func (c *Controller) Init(
 	log *utils.JLog,
 	serviceID *string,
+	serviceStatus *service_status.Status,
 	command *Slice,
 	shoutrrrNotifiers *shoutrrr.Slice,
 ) {
@@ -37,6 +39,7 @@ func (c *Controller) Init(
 		return
 	}
 
+	c.ServiceStatus = serviceStatus
 	c.Command = command
 	c.Failed = make(Fails, len(*command))
 

--- a/commands/init_test.go
+++ b/commands/init_test.go
@@ -30,6 +30,7 @@ func TestInit(t *testing.T) {
 			nil,
 			nil,
 			nil,
+			nil,
 		)
 		// THEN the controller stays nil
 		if commandController != nil {
@@ -44,6 +45,7 @@ func TestInit(t *testing.T) {
 	commandController.Init(
 		utils.NewJLog("DEBUG", false),
 		&controllerName,
+		nil,
 		&Slice{
 			Command{"false"},
 			Command{"false"},

--- a/commands/types.go
+++ b/commands/types.go
@@ -16,6 +16,7 @@ package command
 
 import (
 	"github.com/release-argus/Argus/notifiers/shoutrrr"
+	service_status "github.com/release-argus/Argus/service/status"
 	"github.com/release-argus/Argus/utils"
 )
 
@@ -31,11 +32,12 @@ type Command []string
 type Fails []*bool
 
 type Controller struct {
-	ServiceID *string      `yaml:"-"` // ID of the service this Controller is attached to
-	Command   *Slice       `yaml:"-"` // command to run (with args)
-	Failed    Fails        `yaml:"-"` // Whether the last execution attempt failed
-	Notifiers Notifiers    `yaml:"-"` // The Notify's to notify on failures
-	Announce  *chan []byte `yaml:"-"` // Announce to the WebSocket
+	ServiceID     *string                `yaml:"-"` // ID of the service this Controller is attached to
+	Command       *Slice                 `yaml:"-"` // command to run (with args)
+	Failed        Fails                  `yaml:"-"` // Whether the last execution attempt failed
+	Notifiers     Notifiers              `yaml:"-"` // The Notify's to notify on failures
+	Announce      *chan []byte           `yaml:"-"` // Announce to the WebSocket
+	ServiceStatus *service_status.Status `yaml:"-"` // Status of the Service (used for templating commands)
 }
 
 // Notifiers to use when their WebHook fails.

--- a/config/init.go
+++ b/config/init.go
@@ -68,6 +68,7 @@ func (c *Config) Init() {
 		c.Service[serviceID].CommandController.Init(
 			jLog,
 			&serviceID,
+			service.Status,
 			c.Service[serviceID].Command,
 			c.Service[serviceID].Notify,
 		)

--- a/config/init.go
+++ b/config/init.go
@@ -37,7 +37,7 @@ func (c *Config) Init() {
 	jLog.SetTimestamps(*c.Settings.GetLogTimestamps())
 	jLog.SetLevel(c.Settings.GetLogLevel())
 
-	for serviceID := range c.Service {
+	for serviceID, service := range c.Service {
 		c.Service[serviceID].Init(
 			jLog,
 			&c.Defaults.Service,
@@ -55,6 +55,7 @@ func (c *Config) Init() {
 		c.Service[serviceID].WebHook.Init(
 			jLog,
 			&serviceID,
+			service.Status,
 			&c.WebHook,
 			&c.Defaults.WebHook,
 			&c.HardDefaults.WebHook,

--- a/service/init.go
+++ b/service/init.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"time"
 
+	service_status "github.com/release-argus/Argus/service/status"
 	"github.com/release-argus/Argus/utils"
 	"github.com/release-argus/Argus/web/metrics"
 )
@@ -36,10 +37,10 @@ func (s *Service) Init(
 	jLog = log
 	s.initMetrics()
 	if s.Status == nil {
-		s.Status = &Status{}
+		s.Status = &service_status.Status{}
 	}
 	if s.Status.Fails == nil {
-		s.Status.Fails = &StatusFails{}
+		s.Status.Fails = &service_status.Fails{}
 	}
 	// Default LatestVersion to DeployedVersion
 	if s.Status.LatestVersion == "" {

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -18,6 +18,7 @@ import (
 	"regexp"
 	"testing"
 
+	service_status "github.com/release-argus/Argus/service/status"
 	"github.com/release-argus/Argus/utils"
 )
 
@@ -58,7 +59,7 @@ func TestServiceQuery(t *testing.T) {
 		RegexVersion: &serviceRegexVersion,
 		Defaults:     &Service{},
 		HardDefaults: &hardDefaults,
-		Status:       &Status{},
+		Status:       &service_status.Status{},
 	}
 
 	_, _ = service["GitHub_Query_Test"].Query()

--- a/service/status.go
+++ b/service/status.go
@@ -14,52 +14,7 @@
 
 package service
 
-import (
-	"fmt"
-	"time"
-
-	"github.com/release-argus/Argus/notifiers/shoutrrr"
-	"github.com/release-argus/Argus/utils"
-	"github.com/release-argus/Argus/webhook"
-)
-
-// Status is the current state of the Service element (version and regex misses).
-type Status struct {
-	ApprovedVersion          string       `yaml:"approved_version,omitempty"`           // The version that's been approved
-	DeployedVersion          string       `yaml:"deployed_version,omitempty"`           // Track the deployed version of the service from the last successful WebHook.
-	DeployedVersionTimestamp string       `yaml:"deployed_version_timestamp,omitempty"` // UTC timestamp of DeployedVersion being changed.
-	LatestVersion            string       `yaml:"latest_version,omitempty"`             // Latest version found from query().
-	LatestVersionTimestamp   string       `yaml:"latest_version_timestamp,omitempty"`   // UTC timestamp of LatestVersion being changed.
-	LastQueried              string       `yaml:"-"`                                    // UTC timestamp that version was last queried/checked.
-	RegexMissesContent       uint         `yaml:"-"`                                    // Counter for the number of regex misses on URL content.
-	RegexMissesVersion       uint         `yaml:"-"`                                    // Counter for the number of regex misses on version.
-	Fails                    *StatusFails `yaml:"-"`                                    // Track the Notify/WebHook fails
-	// TODO: Remove V
-	CurrentVersion          string `yaml:"current_version,omitempty"`           // Track the current version of the service from the last successful WebHook.
-	CurrentVersionTimestamp string `yaml:"current_version_timestamp,omitempty"` // UTC timestamp that the current version change was noticed.
-}
-
-// StatusFails keeps track of whether any of the notifications failed on the last version change.
-type StatusFails struct {
-	Shoutrrr *[]bool `yaml:"-"` // Track whether any of the Slice failed.
-	WebHook  *[]bool `yaml:"-"` // Track whether any of the WebHookSlice failed.
-}
-
-// Init initialises the Status vars when more than the default value is needed.
-func (s *Status) Init(
-	shoutrrrs *shoutrrr.Slice,
-	webhooks *webhook.Slice,
-) {
-	s.Fails = new(StatusFails)
-	if shoutrrrs != nil {
-		shoutrrrFails := make([]bool, len(*shoutrrrs))
-		s.Fails.Shoutrrr = &shoutrrrFails
-	}
-	if webhooks != nil {
-		webhookFails := make([]bool, len(*webhooks))
-		s.Fails.WebHook = &webhookFails
-	}
-}
+import "time"
 
 // SetDeployedVersion will set DeployedVersion as well as DeployedVersionTimestamp.
 func (s *Service) SetDeployedVersion(version string) {
@@ -75,11 +30,6 @@ func (s *Service) SetDeployedVersion(version string) {
 	s.CommandController.ResetFails()
 }
 
-// SetLastQueried will update LastQueried to now.
-func (s *Status) SetLastQueried() {
-	s.LastQueried = time.Now().UTC().Format(time.RFC3339)
-}
-
 // SetLatestVersion will set LatestVersion to `version` and LatestVersionTimestamp to s.LastQueried.
 func (s *Service) SetLatestVersion(version string) {
 	s.Status.LatestVersion = version
@@ -88,13 +38,4 @@ func (s *Service) SetLatestVersion(version string) {
 	// Clear the fail status of WebHooks/Commands
 	s.WebHook.ResetFails()
 	s.CommandController.ResetFails()
-}
-
-// Print will print the Status.
-func (s *Status) Print(prefix string) {
-	utils.PrintlnIfNotDefault(s.ApprovedVersion, fmt.Sprintf("%sapproved_version: %s", prefix, s.ApprovedVersion))
-	utils.PrintlnIfNotDefault(s.DeployedVersion, fmt.Sprintf("%sdeployed_version: %s", prefix, s.DeployedVersion))
-	utils.PrintlnIfNotDefault(s.DeployedVersionTimestamp, fmt.Sprintf("%sdeployed_version_timestamp: %q", prefix, s.DeployedVersionTimestamp))
-	utils.PrintlnIfNotDefault(s.LatestVersion, fmt.Sprintf("%slatest_version: %s", prefix, s.LatestVersion))
-	utils.PrintlnIfNotDefault(s.LatestVersionTimestamp, fmt.Sprintf("%slatest_version_timestamp: %q", prefix, s.LatestVersionTimestamp))
 }

--- a/service/status/status.go
+++ b/service/status/status.go
@@ -1,0 +1,74 @@
+// Copyright [2022] [Argus]
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service_status
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/release-argus/Argus/utils"
+)
+
+// Status is the current state of the Service element (version and regex misses).
+type Status struct {
+	ApprovedVersion          string `yaml:"approved_version,omitempty"`           // The version that's been approved
+	DeployedVersion          string `yaml:"deployed_version,omitempty"`           // Track the deployed version of the service from the last successful WebHook.
+	DeployedVersionTimestamp string `yaml:"deployed_version_timestamp,omitempty"` // UTC timestamp of DeployedVersion being changed.
+	LatestVersion            string `yaml:"latest_version,omitempty"`             // Latest version found from query().
+	LatestVersionTimestamp   string `yaml:"latest_version_timestamp,omitempty"`   // UTC timestamp of LatestVersion being changed.
+	LastQueried              string `yaml:"-"`                                    // UTC timestamp that version was last queried/checked.
+	RegexMissesContent       uint   `yaml:"-"`                                    // Counter for the number of regex misses on URL content.
+	RegexMissesVersion       uint   `yaml:"-"`                                    // Counter for the number of regex misses on version.
+	Fails                    *Fails `yaml:"-"`                                    // Track the Notify/WebHook fails
+	// TODO: Remove V
+	CurrentVersion          string `yaml:"current_version,omitempty"`           // Track the current version of the service from the last successful WebHook.
+	CurrentVersionTimestamp string `yaml:"current_version_timestamp,omitempty"` // UTC timestamp that the current version change was noticed.
+}
+
+// Fails keeps track of whether any of the notifications failed on the last version change.
+type Fails struct {
+	Shoutrrr *[]bool `yaml:"-"` // Track whether any of the Slice failed.
+	WebHook  *[]bool `yaml:"-"` // Track whether any of the WebHookSlice failed.
+}
+
+// Init initialises the Status vars when more than the default value is needed.
+func (s *Status) Init(
+	shoutrrrs int,
+	webhooks int,
+) {
+	s.Fails = new(Fails)
+	if shoutrrrs != 0 {
+		shoutrrrFails := make([]bool, shoutrrrs)
+		s.Fails.Shoutrrr = &shoutrrrFails
+	}
+	if webhooks != 0 {
+		webhookFails := make([]bool, webhooks)
+		s.Fails.WebHook = &webhookFails
+	}
+}
+
+// SetLastQueried will update LastQueried to now.
+func (s *Status) SetLastQueried() {
+	s.LastQueried = time.Now().UTC().Format(time.RFC3339)
+}
+
+// Print will print the Status.
+func (s *Status) Print(prefix string) {
+	utils.PrintlnIfNotDefault(s.ApprovedVersion, fmt.Sprintf("%sapproved_version: %s", prefix, s.ApprovedVersion))
+	utils.PrintlnIfNotDefault(s.DeployedVersion, fmt.Sprintf("%sdeployed_version: %s", prefix, s.DeployedVersion))
+	utils.PrintlnIfNotDefault(s.DeployedVersionTimestamp, fmt.Sprintf("%sdeployed_version_timestamp: %q", prefix, s.DeployedVersionTimestamp))
+	utils.PrintlnIfNotDefault(s.LatestVersion, fmt.Sprintf("%slatest_version: %s", prefix, s.LatestVersion))
+	utils.PrintlnIfNotDefault(s.LatestVersionTimestamp, fmt.Sprintf("%slatest_version_timestamp: %q", prefix, s.LatestVersionTimestamp))
+}

--- a/service/types.go
+++ b/service/types.go
@@ -20,6 +20,7 @@ import (
 	command "github.com/release-argus/Argus/commands"
 	"github.com/release-argus/Argus/conversions"
 	"github.com/release-argus/Argus/notifiers/shoutrrr"
+	service_status "github.com/release-argus/Argus/service/status"
 	"github.com/release-argus/Argus/webhook"
 )
 
@@ -52,7 +53,7 @@ type Service struct {
 	Notify                *shoutrrr.Slice        `yaml:"notify,omitempty"`              // Service-specific Shoutrrr vars.
 	WebHook               *webhook.Slice         `yaml:"webhook,omitempty"`             // Service-specific WebHook vars.
 	DeployedVersionLookup *DeployedVersionLookup `yaml:"deployed_version,omitempty"`    // Var to scrape the Service's current deployed version.
-	Status                *Status                `yaml:"status,omitempty"`              // Track the Status of this source (version and regex misses).
+	Status                *service_status.Status `yaml:"status,omitempty"`              // Track the Status of this source (version and regex misses).
 	HardDefaults          *Service               `yaml:"-"`                             // Hardcoded default values.
 	Defaults              *Service               `yaml:"-"`                             // Default values.
 	Announce              *chan []byte           `yaml:"-"`                             // Announce to the WebSocket.

--- a/service/verify.go
+++ b/service/verify.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 	"time"
 
+	service_status "github.com/release-argus/Argus/service/status"
 	"github.com/release-argus/Argus/utils"
 )
 
@@ -158,7 +159,7 @@ func (s *Service) Print(prefix string) {
 
 	s.DeployedVersionLookup.Print(prefix)
 
-	if s.Status != nil && *s.Status != (Status{}) {
+	if s.Status != nil && *s.Status != (service_status.Status{}) {
 		fmt.Printf("%sstatus:\n", prefix)
 		s.Status.Print(prefix + "  ")
 	}

--- a/web/api/v1/websocket.go
+++ b/web/api/v1/websocket.go
@@ -187,8 +187,8 @@ func (api *API) wsCommand(client *Client, payload api_types.WebSocketMessage) {
 
 	commandSummary := make(map[string]*api_types.CommandSummary, len(*api.Config.Service[*id].Command))
 	for key := range *api.Config.Service[*id].CommandController.Command {
-		command := strings.Join((*api.Config.Service[*id].CommandController.Command)[key], " ")
-		commandSummary[command] = &api_types.CommandSummary{
+		command := (*api.Config.Service[*id].CommandController.Command)[key].ApplyTemplate(api.Config.Service[*id].Status)
+		commandSummary[command.String()] = &api_types.CommandSummary{
 			Failed: api.Config.Service[*id].CommandController.Failed[key],
 		}
 	}

--- a/webhook/github.go
+++ b/webhook/github.go
@@ -39,18 +39,25 @@ func (w *WebHook) SetCustomHeaders(req *http.Request) {
 		return
 	}
 
-	for key := range *w.CustomHeaders {
-		req.Header[key] = []string{(*w.CustomHeaders)[key]}
+	serviceInfo := utils.ServiceInfo{LatestVersion: w.ServiceStatus.LatestVersion}
+	for key, value := range *w.CustomHeaders {
+		value = utils.TemplateString(value, serviceInfo)
+		req.Header[key] = []string{value}
 	}
 }
 
 // SetGitHubHeaders of the req based on the payload and secret.
 func SetGitHubHeaders(req *http.Request, payload []byte, secret string) {
-	req.Header.Set("X-GitHub-Event", "push")
-	req.Header.Set("X-GitHub-Hook-ID", utils.RandNumeric(9))
-	req.Header.Set("X-GitHub-Delivery", fmt.Sprintf("%s-%s-%s-%s-%s", utils.RandAlphaNumericLower(8), utils.RandAlphaNumericLower(4), utils.RandAlphaNumericLower(4), utils.RandAlphaNumericLower(4), utils.RandAlphaNumericLower(12)))
-	req.Header.Set("X-GitHub-Hook-Installation-Target-ID", utils.RandNumeric(9))
-	req.Header.Set("X-GitHub-Hook-Installation-Target-Type", "repository")
+	req.Header.Set("X-Github-Event", "push")
+	req.Header.Set("X-Github-Hook-Id", utils.RandNumeric(9))
+	req.Header.Set("X-Github-Delivery", fmt.Sprintf("%s-%s-%s-%s-%s",
+		utils.RandAlphaNumericLower(8),
+		utils.RandAlphaNumericLower(4),
+		utils.RandAlphaNumericLower(4),
+		utils.RandAlphaNumericLower(4),
+		utils.RandAlphaNumericLower(12)))
+	req.Header.Set("X-Github-Hook-Installation-Target-Id", utils.RandNumeric(9))
+	req.Header.Set("X-Github-Hook-Installation-Target-Type", "repository")
 
 	// X-Hub-Signature-256.
 	hash := hmac.New(sha256.New, []byte(secret))

--- a/webhook/github_test.go
+++ b/webhook/github_test.go
@@ -1,0 +1,142 @@
+// Copyright [2022] [Argus]
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webhook
+
+import (
+	"crypto/hmac"
+	"regexp"
+
+	//#nosec G505 -- GitHub's X-Hub-Signature uses SHA-1
+	"crypto/sha1"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	service_status "github.com/release-argus/Argus/service/status"
+)
+
+func TestSetCustomHeaders(t *testing.T) {
+	{ // GIVEN CustomHeaders are nil
+		req, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
+		if err != nil {
+			t.Fatalf("http.NewRequest failed - %s", err.Error())
+		}
+		webhook := WebHook{CustomHeaders: nil}
+		// WHEN SetCustomHeaders is called
+		webhook.SetCustomHeaders(req)
+		// THEN the function exits without setting any headers
+		want := 0
+		got := len(req.Header)
+		if got != want {
+			t.Fatalf("SetCustomHeaders of nil altered the Header count. Want nil, got %v", got)
+		}
+	}
+
+	{ // GIVEN CustomHeaders contain some Jinja templates
+		req, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
+		if err != nil {
+			t.Fatalf("http.NewRequest failed - %s", err.Error())
+		}
+		webhook := WebHook{
+			CustomHeaders: &map[string]string{
+				"test":      "foo",
+				"jinja_var": "bar {{ version }}-",
+				"jinja_exp": "bang {% if version == '1.2.3' %}success{% endif %} bang",
+			},
+			ServiceStatus: &service_status.Status{LatestVersion: "1.2.3"},
+		}
+		// WHEN SetCustomHeaders is called
+		webhook.SetCustomHeaders(req)
+		// THEN the headers are all set correctly
+		want := map[string]string{
+			"test":      "foo",
+			"jinja_var": "bar 1.2.3-",
+			"jinja_exp": "bang success bang",
+		}
+		for key := range *webhook.CustomHeaders {
+			if req.Header[key][0] != want[key] {
+				t.Fatalf("Pongo2 template not evaluated correctly. %s - Wanted %s, got %s", key, want[key], req.Header[key][0])
+			}
+		}
+	}
+}
+
+func TestSetGitHubHeaders(t *testing.T) {
+	{ // GIVEN a secret and GitHub payload
+		secret := "secret"
+		req, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
+		if err != nil {
+			t.Fatalf("http.NewRequest failed - %s", err.Error())
+		}
+		payload, err := json.Marshal(GitHub{
+			Ref:    "refs/heads/master",
+			Before: "0123456789012345678901234567890123456789",
+			After:  "0123456789012345678901234567890123456789",
+		})
+		if err != nil {
+			t.Fatalf("json.Marshal failed - %s", err.Error())
+		}
+		// WHEN SetGitHubHeaders is called
+		SetGitHubHeaders(req, payload, secret)
+		// THEN the GitHub headers are correctly added
+		// X-Github-Event
+		// X-Github-Hook-Installation-Target-Type
+		want := map[string]string{
+			"X-Github-Event":                         "push",
+			"X-Github-Hook-Installation-Target-Type": "repository",
+		}
+		for key := range want {
+			if req.Header[key][0] != want[key] {
+				t.Fatalf("Headers don't match. %s - Wanted %s, got %s", key, want[key], req.Header[key][0])
+			}
+		}
+		// X-Github-Hook-Id
+		regex := "^[0-9]{9}$"
+		key := "X-Github-Hook-Id"
+		if match, _ := regexp.MatchString(regex, req.Header[key][0]); !match {
+			t.Fatalf("%s - Wanted %s, got %s", key, regex, req.Header[key][0])
+		}
+		// X-Github-Delivery
+		regex = "^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$"
+		key = "X-Github-Delivery"
+		if match, _ := regexp.MatchString(regex, req.Header[key][0]); !match {
+			t.Fatalf("%s - Wanted %s, got %s", key, regex, req.Header[key][0])
+		}
+		// X-Github-Hook-Installation-Target-Id
+		regex = "^[0-9]{9}$"
+		key = "X-Github-Hook-Installation-Target-Id"
+		if match, _ := regexp.MatchString(regex, req.Header[key][0]); !match {
+			t.Fatalf("%s - Wanted %s, got %s", key, regex, req.Header[key][0])
+		}
+		// X-Hub-Signature-256.
+		key = "X-Hub-Signature-256"
+		hash := hmac.New(sha256.New, []byte(secret))
+		hash.Write(payload)
+		wantVal := hex.EncodeToString(hash.Sum(nil))
+		if req.Header[key][0] != "sha256="+wantVal {
+			t.Fatalf("%s - Wanted %s, got %s", key, regex, req.Header[key][0])
+		}
+		// X-Hub-Signature.
+		key = "X-Hub-Signature"
+		hash = hmac.New(sha1.New, []byte(secret))
+		hash.Write(payload)
+		wantVal = hex.EncodeToString(hash.Sum(nil))
+		if req.Header[key][0] != "sha1="+wantVal {
+			t.Fatalf("%s - Wanted %s, got %s", key, regex, req.Header[key][0])
+		}
+	}
+}

--- a/webhook/gitlab_test.go
+++ b/webhook/gitlab_test.go
@@ -1,0 +1,54 @@
+// Copyright [2022] [Argus]
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webhook
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestSetGitLabParameter(t *testing.T) {
+	{ // GIVEN a URL without query params
+		req, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
+		if err != nil {
+			t.Fatalf("http.NewRequest failed - %s", err.Error())
+		}
+		whSecret := "secret"
+		// WHEN SetGitLabParameter is called
+		SetGitLabParameter(req, whSecret)
+		// THEN the function correctly encodes URL.RawQuery
+		want := "ref=master&token=secret"
+		got := req.URL.RawQuery
+		if got != want {
+			t.Fatalf("SetGitLabParameter failed. Want %s, got %s", want, got)
+		}
+	}
+
+	{ // GIVEN a URL with query params
+		req, err := http.NewRequest(http.MethodGet, "https://example.com?test=123", nil)
+		if err != nil {
+			t.Fatalf("http.NewRequest failed - %s", err.Error())
+		}
+		whSecret := "secret"
+		// WHEN SetGitLabParameter is called
+		SetGitLabParameter(req, whSecret)
+		// THEN the function correctly encodes URL.RawQuery
+		want := "ref=master&test=123&token=secret"
+		got := req.URL.RawQuery
+		if got != want {
+			t.Fatalf("SetGitLabParameter failed. Want %s, got %s", want, got)
+		}
+	}
+}

--- a/webhook/init_test.go
+++ b/webhook/init_test.go
@@ -1,0 +1,370 @@
+// Copyright [2022] [Argus]
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webhook
+
+import (
+
+	//#nosec G505 -- GitHub's X-Hub-Signature uses SHA-1
+
+	"testing"
+	"time"
+
+	service_status "github.com/release-argus/Argus/service/status"
+)
+
+func TestInit(t *testing.T) {
+	{ // GIVEN a nil Slice
+		var slice Slice
+		// WHEN Init is called
+		slice.Init(nil, nil, nil, nil, nil, nil, nil)
+		// THEN the function exits without defining any of the vars
+		got := len(slice)
+		want := 0
+		if got != want {
+			t.Fatalf("Got len %d, when expecting %d", got, want)
+		}
+	}
+	{ // GIVEN a non-nil Slice with everything else nil
+		id0 := "0"
+		slice := Slice{
+			"0": &WebHook{
+				ID: &id0,
+			},
+		}
+		// Won't ever be nil, so don't make it nil in tests
+		serviceID := ""
+		// WHEN Init is called
+		slice.Init(nil, &serviceID, nil, nil, nil, nil, nil)
+		// THEN the function exits without defining any of the vars
+		got := len(slice)
+		want := 1
+		if got != want {
+			t.Fatalf("Got len %d, when expecting %d", got, want)
+		}
+	}
+
+	{ // GIVEN a non-nil Slice, matching mains, defaults and hardDefaults
+		id0 := "0"
+		id1 := "1"
+		slice := Slice{
+			"0": &WebHook{
+				ID: &id0,
+			},
+			"1": &WebHook{
+				ID: &id1,
+			},
+		}
+		serviceID := "id_test"
+		serviceStatus := service_status.Status{LatestVersion: "status test"}
+		mainSecret0 := "main0"
+		mainSecret1 := "main1"
+		mains := Slice{
+			"0": &WebHook{
+				ID:     &id0,
+				Secret: &mainSecret0,
+			},
+			"1": &WebHook{
+				ID:     &id1,
+				Secret: &mainSecret1,
+			},
+		}
+		defaultURL := "default"
+		defaults := WebHook{
+			ID:     &id0,
+			Secret: &defaultURL,
+		}
+		hardDefaultDelay := "1s"
+		HardDefaults := WebHook{
+			Delay: &hardDefaultDelay,
+		}
+		// WHEN Init is called
+		slice.Init(nil, &serviceID, &serviceStatus, &mains, &defaults, &HardDefaults, nil)
+		{ // THEN the vars are handed out correctly
+			for key := range slice {
+				if slice[key].Main != mains[key] {
+					t.Fatalf("Main not handed to %s", key)
+				}
+				if *slice[key].Defaults != defaults {
+					t.Fatalf("Defaults not handed to %s", key)
+				}
+				if *slice[key].HardDefaults != HardDefaults {
+					t.Fatalf("HardDefaults not handed to %s", key)
+				}
+				if slice[key].Notifiers.Shoutrrr != nil {
+					t.Fatalf("Notifiers handed to %s (when non should have been)", key)
+				}
+			}
+		}
+		{ // WHEN initMetrics is called
+			slice["0"].initMetrics("foo")
+			// THEN the function runs without error
+		}
+		{
+			// WHEN AllowInvalidCerts is true and GetAllowInvalidCerts is called
+			wanted := true
+			slice["0"].AllowInvalidCerts = &wanted
+			got := slice["0"].GetAllowInvalidCerts()
+			// THEN the function returns true
+			if got != wanted {
+				t.Fatalf("GetAllowInvalidCerts - wanted %t, got %t", wanted, got)
+			}
+			// WHEN AllowInvalidCerts is false and GetAllowInvalidCerts is called
+			wanted = false
+			slice["0"].AllowInvalidCerts = &wanted
+			got = slice["0"].GetAllowInvalidCerts()
+			// THEN the function returns false
+			if got != wanted {
+				t.Fatalf("GetAllowInvalidCerts - wanted %t, got %t", wanted, got)
+			}
+		}
+		{ // WHEN Delay is "X" and GetDelayDuration is called
+			duration := "1s"
+			slice["0"].Delay = &duration
+			wanted, _ := time.ParseDuration(duration)
+			got := slice["0"].GetDelayDuration()
+			// THEN the function returns the X as a time.Duration
+			if got != wanted {
+				t.Fatalf("GetDelayDuration - wanted %s, got %s", wanted, got)
+			}
+		}
+		{ // WHEN DesiredStatusCode is 1 and GetDesiredStatusCode is called
+			wanted := 1
+			HardDefaults.DesiredStatusCode = &wanted
+			got := slice["0"].GetDesiredStatusCode()
+			// THEN the function returns the hardDefault
+			if got != wanted {
+				t.Fatalf("GetDesiredStatusCode - wanted %d, got %d", wanted, got)
+			}
+		}
+		{ // WHEN MaxTries is X and GetMaxTries is called
+			wanted := uint(4)
+			slice["0"].MaxTries = &wanted
+			got := slice["0"].GetMaxTries()
+			// THEN the function returns X
+			if got != wanted {
+				t.Fatalf("GetMaxTries - wanted %d, got %d", wanted, got)
+			}
+		}
+		{ // WHEN Type is "X" and GetType is called
+			wanted := "gitlab"
+			slice["0"].Type = &wanted
+			got := slice["0"].GetType()
+			// THEN the function returns "X"
+			if got != wanted {
+				t.Fatalf("GetType - wanted %s, got %s", wanted, got)
+			}
+		}
+		{ // WHEN Secret is "X" and GetSecret is called
+			wanted := "secret"
+			slice["0"].Secret = &wanted
+			got := slice["0"].GetSecret()
+			// THEN the function returns "X"
+			if *got != wanted {
+				t.Fatalf("GetSecret - wanted %s, got %s", wanted, *got)
+			}
+		}
+		{
+			// WHEN SilentFails is true and GetSilentFails is called
+			wanted := true
+			slice["0"].SilentFails = &wanted
+			got := slice["0"].GetSilentFails()
+			// THEN the function returns true
+			if got != wanted {
+				t.Fatalf("GetSilentFails - wanted %t, got %t", wanted, got)
+			}
+			// WHEN SilentFails is false and GetSilentFails is called
+			wanted = false
+			slice["0"].SilentFails = &wanted
+			got = slice["0"].GetSilentFails()
+			// THEN the function returns false
+			if got != wanted {
+				t.Fatalf("GetSilentFails - wanted %t, got %t", wanted, got)
+			}
+		}
+		{
+			// WHEN URL requires no Jinja templating and GetURL is called
+			wanted := "https://example.com"
+			slice["0"].URL = &wanted
+			got := slice["0"].GetURL()
+			// THEN the function returns the hardDefault
+			if *got != wanted {
+				t.Fatalf("GetURL - wanted %s, got %s", wanted, *got)
+			}
+			// WHEN URL requires Jinja templating and GetURL is called
+			template := "https://example.com{% if 'a' == 'a' %}/{{ version }}{% endif %}{% if 'a' == 'b' %}foo{% endif %}"
+			slice["0"].URL = &template
+			got = slice["0"].GetURL()
+			wanted = "https://example.com/status test"
+			// THEN the function returns the default
+			if *got != wanted {
+				t.Fatalf("GetURL - wanted %s, got %s", wanted, *got)
+			}
+			// AND the template stays intact
+			got = slice["0"].URL
+			if *got != wanted {
+				t.Fatalf("GetURL modified the template - wanted %s, got %s", wanted, *got)
+			}
+		}
+	}
+}
+
+func TestGetRequest(t *testing.T) {
+	{ // GIVEN type github and an invalid URL
+		whType := "github"
+		whURL := "invalid://	test"
+		whSecret := "secret"
+		webhook := WebHook{
+			Type:         &whType,
+			URL:          &whURL,
+			Secret:       &whSecret,
+			Main:         &WebHook{},
+			Defaults:     &WebHook{},
+			HardDefaults: &WebHook{},
+		}
+		// WHEN GetRequest is called
+		req := webhook.GetRequest()
+		// THEN req is nil
+		if req != nil {
+			t.Fatal("Invalid URL produced a non-nil http.Request")
+		}
+	}
+	{ // GIVEN type github and a valid URL
+		whType := "github"
+		whURL := "https://test"
+		whSecret := "secret"
+		webhook := WebHook{
+			Type:         &whType,
+			URL:          &whURL,
+			Secret:       &whSecret,
+			Main:         &WebHook{},
+			Defaults:     &WebHook{},
+			HardDefaults: &WebHook{},
+			CustomHeaders: &map[string]string{
+				"foo": "bar",
+			},
+			ServiceStatus: &service_status.Status{},
+		}
+		// WHEN GetRequest is called
+		req := webhook.GetRequest()
+		// THEN req is valid
+		if req == nil {
+			t.Fatal("Invalid URL produced a non-nil http.Request")
+		}
+		key := "Content-Type"
+		want := "application/json"
+		if req.Header[key][0] != want {
+			t.Fatalf("%s should have been %s, got %s", key, want, req.Header[key][0])
+		}
+		key = "foo"
+		want = "bar"
+		if req.Header[key][0] != want {
+			t.Fatalf("%s should have been %s, got %s", key, want, req.Header[key][0])
+		}
+		key = "X-Github-Event"
+		want = "push"
+		if req.Header[key][0] != want {
+			t.Fatalf("%s should have been %s, got %s", key, want, req.Header[key][0])
+		}
+	}
+
+	{ // GIVEN type gitlab and an invalid URL
+		whType := "gitlab"
+		whURL := "invalid://	test"
+		whSecret := "secret"
+		webhook := WebHook{
+			Type:         &whType,
+			URL:          &whURL,
+			Secret:       &whSecret,
+			Main:         &WebHook{},
+			Defaults:     &WebHook{},
+			HardDefaults: &WebHook{},
+		}
+		// WHEN GetRequest is called
+		req := webhook.GetRequest()
+		// THEN req is nil
+		if req != nil {
+			t.Fatal("Invalid URL produced a non-nil http.Request")
+		}
+	}
+	{ // GIVEN type gitlab and a valid URL
+		whType := "gitlab"
+		whURL := "https://test"
+		whSecret := "secret"
+		webhook := WebHook{
+			Type:         &whType,
+			URL:          &whURL,
+			Secret:       &whSecret,
+			Main:         &WebHook{},
+			Defaults:     &WebHook{},
+			HardDefaults: &WebHook{},
+			CustomHeaders: &map[string]string{
+				"foo": "bar",
+			},
+			ServiceStatus: &service_status.Status{},
+		}
+		// WHEN GetRequest is called
+		req := webhook.GetRequest()
+		// THEN req is valid
+		if req == nil {
+			t.Fatal("Invalid URL produced a non-nil http.Request")
+		}
+		key := "Content-Type"
+		want := "application/x-www-form-urlencoded"
+		if req.Header[key][0] != want {
+			t.Fatalf("%s should have been %s, got %s", key, want, req.Header[key][0])
+		}
+		if req.URL.RawQuery == "" {
+			t.Fatal("RawQuery was empty when it should have been encoded data")
+		}
+	}
+}
+
+func TestResetFails(t *testing.T) {
+	{ // GIVEN a nil Slice
+		var slice Slice
+		// WHEN ResetFails is run
+		// THEN it exits successfully
+		slice.ResetFails()
+	}
+
+	{ // GIVEN a Slice with WebHooks that have failed
+		slice := Slice{
+			"0": &WebHook{},
+			"1": &WebHook{},
+			"2": &WebHook{},
+			"3": &WebHook{},
+			"4": &WebHook{},
+		}
+		failed0 := true
+		(*slice["0"]).Failed = &failed0
+		failed1 := true
+		(*slice["1"]).Failed = &failed1
+		failed2 := true
+		(*slice["2"]).Failed = &failed2
+		failed3 := true
+		(*slice["3"]).Failed = &failed3
+		failed4 := true
+		(*slice["4"]).Failed = &failed4
+
+		// WHEN ResetFails is called
+		slice.ResetFails()
+		// THEN all the fails become nil and the count stays the same
+		for i := range slice {
+			if (*slice[i]).Failed != nil {
+				t.Fatalf("Reset failed, got %t", *(*slice[i]).Failed)
+			}
+		}
+	}
+}

--- a/webhook/types.go
+++ b/webhook/types.go
@@ -16,6 +16,7 @@ package webhook
 
 import (
 	"github.com/release-argus/Argus/notifiers/shoutrrr"
+	service_status "github.com/release-argus/Argus/service/status"
 	"github.com/release-argus/Argus/utils"
 )
 
@@ -28,23 +29,24 @@ type Slice map[string]*WebHook
 
 // WebHook to send.
 type WebHook struct {
-	ID                *string            `yaml:"-"`                             // Unique across the Slice
-	ServiceID         *string            `yaml:"-"`                             // ID of the service this WebHook is attached to
-	Type              *string            `yaml:"type,omitempty"`                // "github"/"url"
-	URL               *string            `yaml:"url,omitempty"`                 // "https://example.com"
-	AllowInvalidCerts *bool              `yaml:"allow_invalid_certs,omitempty"` // default - false = Disallows invalid HTTPS certificates.
-	CustomHeaders     *map[string]string `yaml:"custom_headers,omitempty"`      // Custom Headers for the WebHook
-	Secret            *string            `yaml:"secret,omitempty"`              // "SECRET"
-	DesiredStatusCode *int               `yaml:"desired_status_code,omitempty"` // e.g. 202
-	Delay             *string            `yaml:"delay,omitempty"`               // The delay before sending the WebHook.
-	MaxTries          *uint              `yaml:"max_tries,omitempty"`           // Number of times to attempt sending the WebHook if the desired status code is not received.
-	SilentFails       *bool              `yaml:"silent_fails,omitempty"`        // Whether to notify if this WebHook fails MaxTries times.
-	Failed            *bool              `yaml:"-"`                             // Whether the last send attempt failed
-	HardDefaults      *WebHook           `yaml:"-"`                             // Hardcoded default values
-	Defaults          *WebHook           `yaml:"-"`                             // Default values
-	Main              *WebHook           `yaml:"-"`                             // The Webhook that this Webhook is calling (and may override parts of)
-	Notifiers         *Notifiers         `yaml:"-"`                             // The Notify's to notify on failures
-	Announce          *chan []byte       `yaml:"-"`                             // Announce to the WebSocket
+	ID                *string                `yaml:"-"`                             // Unique across the Slice
+	ServiceID         *string                `yaml:"-"`                             // ID of the service this WebHook is attached to
+	Type              *string                `yaml:"type,omitempty"`                // "github"/"url"
+	URL               *string                `yaml:"url,omitempty"`                 // "https://example.com"
+	AllowInvalidCerts *bool                  `yaml:"allow_invalid_certs,omitempty"` // default - false = Disallows invalid HTTPS certificates.
+	CustomHeaders     *map[string]string     `yaml:"custom_headers,omitempty"`      // Custom Headers for the WebHook
+	Secret            *string                `yaml:"secret,omitempty"`              // "SECRET"
+	DesiredStatusCode *int                   `yaml:"desired_status_code,omitempty"` // e.g. 202
+	Delay             *string                `yaml:"delay,omitempty"`               // The delay before sending the WebHook.
+	MaxTries          *uint                  `yaml:"max_tries,omitempty"`           // Number of times to attempt sending the WebHook if the desired status code is not received.
+	SilentFails       *bool                  `yaml:"silent_fails,omitempty"`        // Whether to notify if this WebHook fails MaxTries times.
+	Failed            *bool                  `yaml:"-"`                             // Whether the last send attempt failed
+	HardDefaults      *WebHook               `yaml:"-"`                             // Hardcoded default values
+	Defaults          *WebHook               `yaml:"-"`                             // Default values
+	Main              *WebHook               `yaml:"-"`                             // The Webhook that this Webhook is calling (and may override parts of)
+	Notifiers         *Notifiers             `yaml:"-"`                             // The Notify's to notify on failures
+	Announce          *chan []byte           `yaml:"-"`                             // Announce to the WebSocket
+	ServiceStatus     *service_status.Status `yaml:"-"`                             // Status of the Service (used for templating vars)
 }
 
 // Notifiers to use when their WebHook fails.


### PR DESCRIPTION
version = 1.2.3

```yaml
webhook:
  name:
    url: https://example.com/{{ version }}
```
to use `https://example.com/1.2.3`

```yaml
webhook:
  name:
    type: github
    custom_headers:
      version: '{{ version }}'
```
to give the webhook a header of `version: 1.2.3`

```yaml
command:
  - ["something.sh", "{{ version }}"]
```
should do `something.sh 1.2.3`