### PR TITLE
refactor: standardise prints

### DIFF
--- a/commands/announce_test.go
+++ b/commands/announce_test.go
@@ -75,7 +75,8 @@ func TestAnnounceCommandWhenNotRun(t *testing.T) {
 
 	// THEN it broadcasts nil to the Announce channel
 	if parsedResult.CommandData["ls -lah"].Failed != nil {
-		t.Errorf("got %t. expected %s", *parsedResult.CommandData["ls -lah"].Failed, "false")
+		t.Errorf("got %t. expected %s",
+ *parsedResult.CommandData["ls -lah"].Failed, "false")
 	}
 }
 
@@ -171,7 +172,8 @@ func TestFindUnknown(t *testing.T) {
 
 	// THEN nil is returned
 	if index != nil {
-		t.Errorf("Command %q was found at index %d instead of nil", function, *index)
+		t.Errorf("Command %q was found at index %d instead of nil",
+ function, *index)
 	}
 }
 
@@ -190,7 +192,8 @@ func TestFindKnown(t *testing.T) {
 		if index != nil {
 			got = fmt.Sprint(index)
 		}
-		t.Errorf("Command %q was found at index %s instead of 1", function, got)
+		t.Errorf("Command %q was found at index %s instead of 1",
+ function, got)
 	}
 }
 
@@ -234,7 +237,8 @@ func TestResetFailsNonNilController(t *testing.T) {
 	// THEN all the fails become nil
 	for _, failed := range controller.Failed {
 		if failed != nil {
-			t.Errorf("Reset failed, got %v", controller.Failed)
+			t.Errorf("Reset failed, got %v",
+ controller.Failed)
 		}
 
 	}

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -48,7 +48,8 @@ func (c *Controller) Exec(logFrom *utils.LogFrom) (errs error) {
 	for range *c.Command {
 		err := <-errChan
 		if err != nil {
-			errs = fmt.Errorf("%s\n%w", utils.ErrorToString(errs), err)
+			errs = fmt.Errorf("%s\n%w",
+				utils.ErrorToString(errs), err)
 		}
 	}
 

--- a/commands/init_test.go
+++ b/commands/init_test.go
@@ -64,7 +64,8 @@ func TestInitNonNil(t *testing.T) {
 
 	// THEN Failed is initialised with length 2
 	if len(*controller.Command) != len(controller.Failed) {
-		t.Errorf("Failed should have been of length %d, but is length %d", len(*controller.Command), len(controller.Failed))
+		t.Errorf("Failed should have been of length %d, but is length %d",
+			len(*controller.Command), len(controller.Failed))
 	}
 }
 
@@ -96,7 +97,8 @@ func TestFormattedStringMultiArg(t *testing.T) {
 
 	// THEN it is returned in this format
 	if got != want {
-		t.Errorf("FormattedString, got %q, wanted %q", got, want)
+		t.Errorf("FormattedString, got %q, wanted %q",
+			got, want)
 	}
 }
 
@@ -110,7 +112,8 @@ func TestFormattedStringSingleArg(t *testing.T) {
 
 	// THEN it is returned in this format
 	if got != want {
-		t.Errorf("FormattedString, got %q, wanted %q", got, want)
+		t.Errorf("FormattedString, got %q, wanted %q",
+			got, want)
 	}
 }
 
@@ -124,7 +127,8 @@ func TestStringMultiArg(t *testing.T) {
 
 	// THEN it is returned in this format
 	if got != want {
-		t.Errorf("String, got %q, wanted %q", got, want)
+		t.Errorf("String, got %q, wanted %q",
+			got, want)
 	}
 }
 
@@ -138,7 +142,8 @@ func TestStringSingleArg(t *testing.T) {
 
 	// THEN it is returned in this format
 	if got != want {
-		t.Errorf("String, got %q, wanted %q", got, want)
+		t.Errorf("String, got %q, wanted %q",
+			got, want)
 	}
 }
 

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -184,7 +184,8 @@ func (d *Defaults) CheckValues() (errs error) {
 	// Service
 	serviceErrs := false
 	if err := d.Service.CheckValues(prefix); err != nil {
-		errs = fmt.Errorf("%s%sservice:\\%w", utils.ErrorToString(errs), prefix, err)
+		errs = fmt.Errorf("%s%sservice:\\%w",
+			utils.ErrorToString(errs), prefix, err)
 		serviceErrs = true
 	}
 	if err := d.Service.DeployedVersionLookup.CheckValues(prefix); err != nil {
@@ -192,7 +193,8 @@ func (d *Defaults) CheckValues() (errs error) {
 		if !serviceErrs {
 			customPrefix = fmt.Sprintf("%s%sservice:\\", utils.ErrorToString(errs), prefix)
 		}
-		errs = fmt.Errorf("%s%s%s  deployed_version:\\%w", utils.ErrorToString(errs), customPrefix, prefix, err)
+		errs = fmt.Errorf("%s%s%s  deployed_version:\\%w",
+			utils.ErrorToString(errs), customPrefix, prefix, err)
 	}
 
 	// Notify
@@ -201,12 +203,14 @@ func (d *Defaults) CheckValues() (errs error) {
 		d.Notify[i].Type = ""
 	}
 	if err := d.Notify.CheckValues(prefix); err != nil {
-		errs = fmt.Errorf("%s%w", utils.ErrorToString(errs), err)
+		errs = fmt.Errorf("%s%w",
+			utils.ErrorToString(errs), err)
 	}
 
 	// WebHook
 	if err := d.WebHook.CheckValues(prefix); err != nil {
-		errs = fmt.Errorf("%s%w", utils.ErrorToString(errs), err)
+		errs = fmt.Errorf("%s%w",
+			utils.ErrorToString(errs), err)
 	}
 
 	return errs

--- a/config/defaults_test.go
+++ b/config/defaults_test.go
@@ -34,7 +34,8 @@ func TehstSetDefaultsService(t *testing.T) {
 	want := "10m"
 	got := *defaults.Service.Interval
 	if got != want {
-		t.Errorf("defaults.Service.Interval should have been %s, but got %s", want, got)
+		t.Errorf("defaults.Service.Interval should have been %s, but got %s",
+			want, got)
 	}
 }
 
@@ -49,7 +50,8 @@ func TestDefaultsSetDefaultsNotify(t *testing.T) {
 	want := "Argus"
 	got := defaults.Notify["discord"].GetSelfParam("username")
 	if got != want {
-		t.Errorf("defaults.Notify.discord.Params.username should have been %s, but got %s", want, got)
+		t.Errorf("defaults.Notify.discord.Params.username should have been %s, but got %s",
+			want, got)
 	}
 }
 
@@ -64,7 +66,8 @@ func TestDefaultsSetDefaultsWebHook(t *testing.T) {
 	want := "github"
 	got := *defaults.WebHook.Type
 	if got != want {
-		t.Errorf("defaults.WebHook.Type should have been %s, but got %s", want, got)
+		t.Errorf("defaults.WebHook.Type should have been %s, but got %s",
+			want, got)
 	}
 }
 
@@ -79,7 +82,8 @@ func TestDefaultsCheckValuesWithInvalidService(t *testing.T) {
 
 	// THEN err is non-nil
 	if err == nil {
-		t.Errorf("err shouldn't be %v, Service.Interval was invalid with %q", err, *defaults.Service.Interval)
+		t.Errorf("err shouldn't be %v, Service.Interval was invalid with %q",
+			err, *defaults.Service.Interval)
 	}
 }
 
@@ -94,7 +98,8 @@ func TestDefaultsCheckValuesWithInvalidServiceDeployedVersionLookup(t *testing.T
 
 	// THEN err is non-nil
 	if err == nil {
-		t.Errorf("err shouldn't be %v, Service.DeployedVersionLookup.Regex was invalid with %q", err, defaults.Service.DeployedVersionLookup.Regex)
+		t.Errorf("err shouldn't be %v, Service.DeployedVersionLookup.Regex was invalid with %q",
+			err, defaults.Service.DeployedVersionLookup.Regex)
 	}
 }
 
@@ -109,7 +114,8 @@ func TestDefaultsCheckValuesWithInvalidNotify(t *testing.T) {
 
 	// THEN err is non-nil
 	if err == nil {
-		t.Errorf("err shouldn't be %v, Notify.slack.Delay was invalid with %q", err, defaults.Notify["slack"].GetSelfOption("delay"))
+		t.Errorf("err shouldn't be %v, Notify.slack.Delay was invalid with %q",
+			err, defaults.Notify["slack"].GetSelfOption("delay"))
 	}
 }
 
@@ -124,7 +130,8 @@ func TestDefaultsCheckValuesWithInvalidWebHook(t *testing.T) {
 
 	// THEN err is non-nil
 	if err == nil {
-		t.Errorf("err shouldn't be %v, WebHook.Delay was invalid with %q", err, *defaults.WebHook.Delay)
+		t.Errorf("err shouldn't be %v, WebHook.Delay was invalid with %q",
+			err, *defaults.WebHook.Delay)
 	}
 }
 
@@ -146,6 +153,7 @@ func TestDefaultsPrint(t *testing.T) {
 	want := 142
 	got := strings.Count(string(out), "\n")
 	if got != want {
-		t.Errorf("Print should have given %d lines, but gave %d\n%s", want, got, out)
+		t.Errorf("Print should have given %d lines, but gave %d\n%s",
+			want, got, out)
 	}
 }

--- a/config/save_test.go
+++ b/config/save_test.go
@@ -58,7 +58,8 @@ func TestSaveHandler(t *testing.T) {
 
 	// THEN it should have panic'd after TIMEOUT and not reach this
 	time.Sleep(TIMEOUT * time.Second)
-	t.Errorf("Save should panic'd on inaccessible file location %q", config.File)
+	t.Errorf("Save should panic'd on inaccessible file location %q",
+		config.File)
 }
 
 func TestWaitChannelTimeout(t *testing.T) {
@@ -76,7 +77,8 @@ func TestWaitChannelTimeout(t *testing.T) {
 	// THEN after `TIMEOUT`, it would have tried to Save (and failed)
 	elapsed := time.Since(start)
 	if elapsed < TIMEOUT {
-		t.Errorf("waitChannelTimeout should have waited atleast %v, but only waited %v", TIMEOUT, elapsed)
+		t.Errorf("waitChannelTimeout should have waited atleast %v, but only waited %v",
+			TIMEOUT, elapsed)
 	}
 }
 

--- a/config/settings_test.go
+++ b/config/settings_test.go
@@ -45,7 +45,8 @@ func TestNilUndefinedFlagsDoesntResetDefined(t *testing.T) {
 	// THEN LogLevel is not nil
 	if LogLevel == nil || *LogLevel != newLevel {
 		got := utils.DefaultIfNil(LogLevel)
-		t.Errorf("LogLevel shouldn't have been reset to %s. Want %s", got, *LogLevel)
+		t.Errorf("LogLevel shouldn't have been reset to %s. Want %s",
+			got, *LogLevel)
 	}
 }
 
@@ -69,7 +70,8 @@ func TestNilUndefinedFlagsDoesResetUndefined(t *testing.T) {
 
 	// THEN LogLevel is not nil
 	if LogLevel != nil {
-		t.Errorf("LogLevel should have been reset to nil, not %s", *LogLevel)
+		t.Errorf("LogLevel should have been reset to nil, not %s",
+			*LogLevel)
 	}
 }
 
@@ -85,7 +87,8 @@ func TestSettingsSetDefaultsWebFromFlags(t *testing.T) {
 	// THEN the Service part is initialised to the defined defaults
 	got := settings.GetWebListenPort()
 	if got != want {
-		t.Errorf("settings.Web.CertFile should have been %s, but got %s", want, got)
+		t.Errorf("settings.Web.CertFile should have been %s, but got %s",
+			want, got)
 	}
 }
 
@@ -103,7 +106,8 @@ func TestSettingsSetDefaultsLogsFromFlags(t *testing.T) {
 	// THEN the Service part is initialised to the defined defaults
 	got := settings.GetLogLevel()
 	if got != want {
-		t.Errorf("settings.Log.Level should have been %s, but got %s", want, got)
+		t.Errorf("settings.Log.Level should have been %s, but got %s",
+			want, got)
 	}
 }
 
@@ -140,7 +144,8 @@ func TestGetLogLevel(t *testing.T) {
 	// THEN it'll return the value from Settings.Log.Level
 	want := settings.Log.Level
 	if want != got {
-		t.Errorf("Settings.Log.Level should have been returned (%s), not %s", *want, *got)
+		t.Errorf("Settings.Log.Level should have been returned (%s), not %s",
+			*want, *got)
 	}
 }
 
@@ -154,7 +159,8 @@ func TestGetLogTimestamps(t *testing.T) {
 	// THEN it'll return the value from Settings.Log.Timestamps
 	want := settings.Log.Timestamps
 	if want != got {
-		t.Errorf("Settings.Log.Timestamps should have been returned (%t), not %t", *want, *got)
+		t.Errorf("Settings.Log.Timestamps should have been returned (%t), not %t",
+			*want, *got)
 	}
 }
 
@@ -168,7 +174,8 @@ func TestGetWebListenHost(t *testing.T) {
 	// THEN it'll return the value from Settings.Web.ListenHost
 	want := settings.Web.ListenHost
 	if *want != got {
-		t.Errorf("Settings.Web.ListenHost should have been returned (%s), not %s", *want, got)
+		t.Errorf("Settings.Web.ListenHost should have been returned (%s), not %s",
+			*want, got)
 	}
 }
 
@@ -182,7 +189,8 @@ func TestGetWebListenPort(t *testing.T) {
 	// THEN it'll return the value from Settings.Web.ListenPort
 	want := settings.Web.ListenPort
 	if *want != got {
-		t.Errorf("Settings.Web.ListenPort should have been returned (%s), not %s", *want, got)
+		t.Errorf("Settings.Web.ListenPort should have been returned (%s), not %s",
+			*want, got)
 	}
 }
 
@@ -196,7 +204,8 @@ func TestGetWebRoutePrefix(t *testing.T) {
 	// THEN it'll return the value from Settings.Web.RoutePrefix
 	want := settings.Web.RoutePrefix
 	if *want != got {
-		t.Errorf("Settings.Web.RoutePrefix should have been returned (%s), not %s", *want, got)
+		t.Errorf("Settings.Web.RoutePrefix should have been returned (%s), not %s",
+			*want, got)
 	}
 }
 
@@ -210,7 +219,8 @@ func TestGetWebCertFile(t *testing.T) {
 	// THEN it'll return the value from Settings.Web.CertFile
 	want := settings.Web.CertFile
 	if want != got {
-		t.Errorf("Settings.Web.CertFile should have been returned (%s), not %s", *want, *got)
+		t.Errorf("Settings.Web.CertFile should have been returned (%s), not %s",
+			*want, *got)
 	}
 }
 
@@ -225,7 +235,8 @@ func TestGetWebCertFileUndefined(t *testing.T) {
 	// THEN it'll return the value from Settings.Web.CertFile
 	var want *string
 	if want != got {
-		t.Errorf("Settings.Web.CertFile should have been returned %v, not %s", want, *got)
+		t.Errorf("Settings.Web.CertFile should have been returned %v, not %s",
+			want, *got)
 	}
 }
 
@@ -242,7 +253,8 @@ func TestGetWebCertFileNotExist(t *testing.T) {
 	settings.GetWebCertFile()
 
 	// THEN this call will crash the program
-	t.Errorf("%s doesn't exist, so this call should have been Fatal", *settings.Web.CertFile)
+	t.Errorf("%s doesn't exist, so this call should have been Fatal",
+		*settings.Web.CertFile)
 }
 
 func TestGetWebKeyFile(t *testing.T) {
@@ -255,7 +267,8 @@ func TestGetWebKeyFile(t *testing.T) {
 	// THEN it'll return the value from Settings.Web.KeyFile
 	want := settings.Web.KeyFile
 	if want != got {
-		t.Errorf("Settings.Web.KeyFile should have been returned (%s), not %s", *want, *got)
+		t.Errorf("Settings.Web.KeyFile should have been returned (%s), not %s",
+			*want, *got)
 	}
 }
 
@@ -270,7 +283,8 @@ func TestGetWebKeyFileUndefined(t *testing.T) {
 	// THEN it'll return the value from Settings.Web.KeyFile
 	var want *string
 	if want != got {
-		t.Errorf("Settings.Web.KeyFile should have been returned %v, not %s", want, *got)
+		t.Errorf("Settings.Web.KeyFile should have been returned %v, not %s",
+			want, *got)
 	}
 }
 
@@ -287,5 +301,6 @@ func TestGetWebKeyFileNotExist(t *testing.T) {
 	settings.GetWebKeyFile()
 
 	// THEN this call will crash the program
-	t.Errorf("%s doesn't exist, so this call should have been Fatal", *settings.Web.KeyFile)
+	t.Errorf("%s doesn't exist, so this call should have been Fatal",
+		*settings.Web.KeyFile)
 }

--- a/config/verify.go
+++ b/config/verify.go
@@ -26,19 +26,23 @@ import (
 func (c *Config) CheckValues() {
 	var errs error
 	if err := c.Defaults.CheckValues(); err != nil {
-		errs = fmt.Errorf("defaults:\\%w", err)
+		errs = fmt.Errorf("defaults:\\%w",
+			err)
 	}
 
 	if err := c.Notify.CheckValues("  "); err != nil {
-		errs = fmt.Errorf("%s%w", utils.ErrorToString(errs), err)
+		errs = fmt.Errorf("%s%w",
+			utils.ErrorToString(errs), err)
 	}
 
 	if err := c.WebHook.CheckValues("  "); err != nil {
-		errs = fmt.Errorf("%s%w", utils.ErrorToString(errs), err)
+		errs = fmt.Errorf("%s%w",
+			utils.ErrorToString(errs), err)
 	}
 
 	if err := c.Service.CheckValues("  "); err != nil {
-		errs = fmt.Errorf("%sservice:\\%w", utils.ErrorToString(errs), err)
+		errs = fmt.Errorf("%sservice:\\%w",
+			utils.ErrorToString(errs), err)
 	}
 
 	if errs != nil {

--- a/config/verify_test.go
+++ b/config/verify_test.go
@@ -79,7 +79,8 @@ func TestConfigCheckValuesWithInvalidDefaults(t *testing.T) {
 	config.CheckValues()
 
 	// THEN this call will crash the program
-	t.Errorf("Should have panic'd because of Defaults.Service.Interval being invalid (%q)", invalid)
+	t.Errorf("Should have panic'd because of Defaults.Service.Interval being invalid (%q)",
+		invalid)
 }
 
 func TestConfigCheckValuesWithInvalidNotify(t *testing.T) {
@@ -96,7 +97,8 @@ func TestConfigCheckValuesWithInvalidNotify(t *testing.T) {
 	config.CheckValues()
 
 	// THEN this call will crash the program
-	t.Errorf("Should have panic'd because of Notify.discord.options.delay being invalid (%q)", invalid)
+	t.Errorf("Should have panic'd because of Notify.discord.options.delay being invalid (%q)",
+		invalid)
 }
 
 func TestConfigCheckValuesWithInvalidWebHook(t *testing.T) {
@@ -113,7 +115,8 @@ func TestConfigCheckValuesWithInvalidWebHook(t *testing.T) {
 	config.CheckValues()
 
 	// THEN this call will crash the program
-	t.Errorf("Should have panic'd because of WebHook.test.Delay being invalid (%q)", invalid)
+	t.Errorf("Should have panic'd because of WebHook.test.Delay being invalid (%q)",
+		invalid)
 }
 
 func TestConfigCheckValuesWithInvalidService(t *testing.T) {
@@ -130,7 +133,8 @@ func TestConfigCheckValuesWithInvalidService(t *testing.T) {
 	config.CheckValues()
 
 	// THEN this call will crash the program
-	t.Errorf("Should have panic'd because of Service.test.Interval being invalid (%q)", invalid)
+	t.Errorf("Should have panic'd because of Service.test.Interval being invalid (%q)",
+		invalid)
 }
 
 func TestConfigPrintWithFalseFlag(t *testing.T) {
@@ -151,7 +155,8 @@ func TestConfigPrintWithFalseFlag(t *testing.T) {
 	want := 0
 	got := len(string(out))
 	if got != want {
-		t.Errorf("Print with no flag set printed %d lines. Wanted %d", got, want)
+		t.Errorf("Print with no flag set printed %d lines. Wanted %d",
+			got, want)
 	}
 }
 
@@ -175,6 +180,7 @@ func TestConfigPrint(t *testing.T) {
 	want := 165
 	got := strings.Count(string(out), "\n")
 	if got != want {
-		t.Errorf("Print with no flag set printed %d lines. Wanted %d\n%s", got, want, string(out))
+		t.Errorf("Print with no flag set printed %d lines. Wanted %d\n%s",
+			got, want, string(out))
 	}
 }

--- a/notifiers/shoutrrr/gets_test.go
+++ b/notifiers/shoutrrr/gets_test.go
@@ -99,7 +99,8 @@ func TestGetOption(t *testing.T) {
 	// THEN we get the delay of the master Shoutrrr
 	want := shoutrrr.Main.Options["delay"]
 	if got != want {
-		t.Errorf("Should have got %q delay from the main, not %s", want, got)
+		t.Errorf("Should have got %q delay from the main, not %s",
+			want, got)
 	}
 }
 
@@ -113,7 +114,8 @@ func TestGetSelfOption(t *testing.T) {
 	// THEN we get the delay of the master Shoutrrr
 	want := shoutrrr.Options["delay"]
 	if got != want {
-		t.Errorf("Should have got %q delay from the master, not %s", want, got)
+		t.Errorf("Should have got %q delay from the master, not %s",
+			want, got)
 	}
 }
 
@@ -128,7 +130,8 @@ func TestSetOption(t *testing.T) {
 	// THEN we get this value with we GetSelfOption
 	got := shoutrrr.GetSelfOption("delay")
 	if got != want {
-		t.Errorf("Should have got %q delay from the main, not %s", want, got)
+		t.Errorf("Should have got %q delay from the main, not %s",
+			want, got)
 	}
 }
 
@@ -143,7 +146,8 @@ func TestGetURLField(t *testing.T) {
 	// THEN we get the token of the master Shoutrrr
 	want := shoutrrr.Main.URLFields["token"]
 	if got != want {
-		t.Errorf("Should have got %q token from the main, not %s", want, got)
+		t.Errorf("Should have got %q token from the main, not %s",
+			want, got)
 	}
 }
 
@@ -157,7 +161,8 @@ func TestGetSelfURLField(t *testing.T) {
 	// THEN we get the token of the master Shoutrrr
 	want := shoutrrr.URLFields["token"]
 	if got != want {
-		t.Errorf("Should have got %q token from the master, not %s", want, got)
+		t.Errorf("Should have got %q token from the master, not %s",
+			want, got)
 	}
 }
 
@@ -172,7 +177,8 @@ func TestSetURLField(t *testing.T) {
 	// THEN we get this value with we GetSelfURLField
 	got := shoutrrr.GetSelfURLField("token")
 	if got != want {
-		t.Errorf("Should have got %q token from the main, not %s", want, got)
+		t.Errorf("Should have got %q token from the main, not %s",
+			want, got)
 	}
 }
 
@@ -187,7 +193,8 @@ func TestGetParam(t *testing.T) {
 	// THEN we get the avatar of the master Shoutrrr
 	want := shoutrrr.Main.Params["avatar"]
 	if got != want {
-		t.Errorf("Should have got %q avatar from the main, not %s", want, got)
+		t.Errorf("Should have got %q avatar from the main, not %s",
+			want, got)
 	}
 }
 
@@ -201,7 +208,8 @@ func TestGetSelfParam(t *testing.T) {
 	// THEN we get the avatar of the master Shoutrrr
 	want := shoutrrr.Params["avatar"]
 	if got != want {
-		t.Errorf("Should have got %q avatar from the master, not %s", want, got)
+		t.Errorf("Should have got %q avatar from the master, not %s",
+			want, got)
 	}
 }
 
@@ -216,7 +224,8 @@ func TestSetParam(t *testing.T) {
 	// THEN we get this value with we GetSelfParam
 	got := shoutrrr.GetSelfParam("avatar")
 	if got != want {
-		t.Errorf("Should have got %q avatar from the main, not %s", want, got)
+		t.Errorf("Should have got %q avatar from the main, not %s",
+			want, got)
 	}
 }
 func TestGetDelay(t *testing.T) {
@@ -229,7 +238,8 @@ func TestGetDelay(t *testing.T) {
 	// THEN the function returns the closest Options.delay as a time.Duration
 	want := shoutrrr.GetSelfOption("delay")
 	if got != want {
-		t.Errorf("Want %s, got %s", want, got)
+		t.Errorf("Want %s, got %s",
+			want, got)
 	}
 }
 
@@ -247,7 +257,8 @@ func TestGetDelayWithNoDelaySet(t *testing.T) {
 	// THEN the function returns the closest Options.delay as a time.Duration
 	want := "0s"
 	if got != want {
-		t.Errorf("Want %s, got %s", want, got)
+		t.Errorf("Want %s, got %s",
+			want, got)
 	}
 }
 
@@ -261,7 +272,8 @@ func TestGetDelayDuration(t *testing.T) {
 	// THEN the function returns the closest Options.delay as a time.Duration
 	want, _ := time.ParseDuration(shoutrrr.GetOption("delay"))
 	if got != want {
-		t.Errorf("Want %s, got %s", want, got)
+		t.Errorf("Want %s, got %s",
+			want, got)
 	}
 }
 
@@ -275,7 +287,8 @@ func TestGetMaxTries(t *testing.T) {
 	// THEN the function returns the closest Options.delay as a time.Duration
 	want, _ := strconv.ParseUint(shoutrrr.GetSelfOption("max_tries"), 10, 32)
 	if got != uint(want) {
-		t.Errorf("Want %d, got %d", want, got)
+		t.Errorf("Want %d, got %d",
+			want, got)
 	}
 }
 
@@ -290,7 +303,8 @@ func TestGetMessage(t *testing.T) {
 	// THEN the message is formatted with that context
 	want := "1.2.3-foo"
 	if got != want {
-		t.Errorf("Not templated correctly. Want %q, got %q", want, got)
+		t.Errorf("Not templated correctly. Want %q, got %q",
+			want, got)
 	}
 }
 
@@ -305,7 +319,8 @@ func TestGetTitle(t *testing.T) {
 	// THEN the Title is formatted with that context
 	want := "1.2.3-master"
 	if got != want {
-		t.Errorf("Not templated correctly. Want %q, got %q", want, got)
+		t.Errorf("Not templated correctly. Want %q, got %q",
+			want, got)
 	}
 }
 
@@ -319,6 +334,7 @@ func TestGetType(t *testing.T) {
 	// THEN the Type is formatted with that context
 	want := shoutrrr.Type
 	if got != want {
-		t.Errorf("Want %q, got %q", want, got)
+		t.Errorf("Want %q, got %q",
+			want, got)
 	}
 }

--- a/notifiers/shoutrrr/init.go
+++ b/notifiers/shoutrrr/init.go
@@ -42,6 +42,9 @@ func (s *Slice) Init(
 		}
 		(*s)[key].ID = &id
 
+		if len(*mains) == 0 {
+			mains = &Slice{}
+		}
 		if (*mains)[key] == nil {
 			(*mains)[key] = &Shoutrrr{}
 		}

--- a/notifiers/shoutrrr/init_test.go
+++ b/notifiers/shoutrrr/init_test.go
@@ -33,7 +33,8 @@ func TestSetLog(t *testing.T) {
 
 	// THEN jLog is set to this new one
 	if jLog != new {
-		t.Errorf("jLog should be %v but is %v", new, jLog)
+		t.Errorf("jLog should be %v but is %v",
+			new, jLog)
 	}
 }
 
@@ -67,7 +68,8 @@ func TestInitMapsWithNil(t *testing.T) {
 
 	// THEN the maps will stay nil
 	if shoutrrr != nil {
-		t.Errorf("The Shoutrrr was nil, but is now %v", *shoutrrr)
+		t.Errorf("The Shoutrrr was nil, but is now %v",
+			*shoutrrr)
 	}
 }
 
@@ -87,7 +89,8 @@ func TestInitOptions(t *testing.T) {
 	for key := range shoutrrr.Options {
 		want := strings.ToLower(key)
 		if key != want {
-			t.Errorf("Keys were not lowercased, got %s, want %s", key, want)
+			t.Errorf("Keys were not lowercased, got %s, want %s",
+				key, want)
 		}
 	}
 }
@@ -108,7 +111,8 @@ func TestInitURLFields(t *testing.T) {
 	for key := range shoutrrr.URLFields {
 		want := strings.ToLower(key)
 		if key != want {
-			t.Errorf("Keys were not lowercased, got %s, want %s", key, want)
+			t.Errorf("Keys were not lowercased, got %s, want %s",
+				key, want)
 		}
 	}
 }
@@ -129,7 +133,8 @@ func TestInitParams(t *testing.T) {
 	for key := range shoutrrr.Params {
 		want := strings.ToLower(key)
 		if key != want {
-			t.Errorf("Keys were not lowercased, got %s, want %s", key, want)
+			t.Errorf("Keys were not lowercased, got %s, want %s",
+				key, want)
 		}
 	}
 }
@@ -158,7 +163,8 @@ func TestInitMapsUppercasesOptions(t *testing.T) {
 	for key := range shoutrrr.Options {
 		want := strings.ToLower(key)
 		if key != want {
-			t.Errorf("Keys were not lowercased, got %s, want %s", key, want)
+			t.Errorf("Keys were not lowercased, got %s, want %s",
+				key, want)
 		}
 	}
 }
@@ -187,7 +193,8 @@ func TestInitMapsUppercasesURLFields(t *testing.T) {
 	for key := range shoutrrr.URLFields {
 		want := strings.ToLower(key)
 		if key != want {
-			t.Errorf("Keys were not lowercased, got %s, want %s", key, want)
+			t.Errorf("Keys were not lowercased, got %s, want %s",
+				key, want)
 		}
 	}
 }
@@ -216,7 +223,8 @@ func TestInitMapsUppercasesParams(t *testing.T) {
 	for key := range shoutrrr.Params {
 		want := strings.ToLower(key)
 		if key != want {
-			t.Errorf("Keys were not lowercased, got %s, want %s", key, want)
+			t.Errorf("Keys were not lowercased, got %s, want %s",
+				key, want)
 		}
 	}
 }
@@ -231,7 +239,8 @@ func TestShoutrrrInitWithNilShoutrrr(t *testing.T) {
 
 	// THEN it is still nil
 	if shoutrrr != nil {
-		t.Errorf("Shoutrrr should still be nil, not %v after Init", shoutrrr)
+		t.Errorf("Shoutrrr should still be nil, not %v after Init",
+			shoutrrr)
 	}
 }
 
@@ -246,7 +255,8 @@ func TestShoutrrrInitWithNilMain(t *testing.T) {
 
 	// THEN it is no longer nil
 	if shoutrrr.Main == nil {
-		t.Errorf("Shoutrrr.Main shouldn't still be %v after Init", shoutrrr)
+		t.Errorf("Shoutrrr.Main shouldn't still be %v after Init",
+			shoutrrr)
 	}
 }
 
@@ -261,7 +271,8 @@ func TestShoutrrrInitGivesMain(t *testing.T) {
 
 	// THEN it is given vars.Main
 	if shoutrrr.Main != vars.Main {
-		t.Errorf("Shoutrrr.Main shouldn't be %v after Init", shoutrrr)
+		t.Errorf("Shoutrrr.Main shouldn't be %v after Init",
+			shoutrrr)
 	}
 }
 
@@ -276,7 +287,8 @@ func TestShoutrrrInitGivesDefaults(t *testing.T) {
 
 	// THEN it is given vars.Defaults
 	if shoutrrr.Defaults != vars.Defaults {
-		t.Errorf("Shoutrrr.Defaults shouldn't be %v after Init", shoutrrr)
+		t.Errorf("Shoutrrr.Defaults shouldn't be %v after Init",
+			shoutrrr)
 	}
 }
 
@@ -291,7 +303,8 @@ func TestShoutrrrInitGivesHardDefaults(t *testing.T) {
 
 	// THEN it is given vars.HardDefaults
 	if shoutrrr.HardDefaults != vars.HardDefaults {
-		t.Errorf("Shoutrrr.HardDefaults shouldn't be %v after Init", shoutrrr)
+		t.Errorf("Shoutrrr.HardDefaults shouldn't be %v after Init",
+			shoutrrr)
 	}
 }
 
@@ -324,7 +337,8 @@ func TestSliceInitWithNil(t *testing.T) {
 
 	// THEN it is still nil
 	if slice != nil {
-		t.Errorf("Slice should still be nil, not %v", slice)
+		t.Errorf("Slice should still be nil, not %v",
+			slice)
 	}
 }
 
@@ -344,7 +358,8 @@ func TestSliceInitWithMatchingMain(t *testing.T) {
 
 	// THEN "1" has that main
 	if slice["1"].Main != mains["1"] {
-		t.Errorf("Slice['1'] was given %v, not the matching Main (%v)", slice["1"].Main, mains["1"])
+		t.Errorf("Slice['1'] was given %v, not the matching Main (%v)",
+			slice["1"].Main, mains["1"])
 	}
 }
 
@@ -364,7 +379,8 @@ func TestSliceInitWithNonMatchingMain(t *testing.T) {
 
 	// THEN "1" has that main
 	if slice["0"].Main.ID != nil {
-		t.Errorf("Slice['0'] was given id=%q, not a fresh Main (id=%v)", *slice["0"].Main.ID, Shoutrrr{}.ID)
+		t.Errorf("Slice['0'] was given id=%q, not a fresh Main (id=%v)",
+			*slice["0"].Main.ID, Shoutrrr{}.ID)
 	}
 }
 
@@ -379,7 +395,8 @@ func TestSliceInitWithNilElement(t *testing.T) {
 
 	// THEN that element is no longer nil
 	if slice["1"] == nil {
-		t.Errorf("Slice['1'] should have been created from the Init. Shouldn't be %v", slice["1"])
+		t.Errorf("Slice['1'] should have been created from the Init. Shouldn't be %v",
+			slice["1"])
 	}
 }
 
@@ -396,7 +413,8 @@ func TestSliceInitWithDefaultMain(t *testing.T) {
 		len(slice["1"].Main.Options) != 0 ||
 		len(slice["1"].Main.URLFields) != 0 ||
 		len(slice["1"].Main.Params) != 0 {
-		t.Errorf("Slice['1'] was given %v, not an empty Main (%v)", slice["1"].Main, Shoutrrr{})
+		t.Errorf("Slice['1'] was given %v, not an empty Main (%v)",
+			slice["1"].Main, Shoutrrr{})
 	}
 }
 
@@ -411,7 +429,8 @@ func TestSliceInitWithNilMains(t *testing.T) {
 
 	// THEN the elements get non-nil mains
 	if slice["1"].Main == nil {
-		t.Errorf("Mains were nil in the Init, but non-nil's should. Shouldn't be %v", slice["1"])
+		t.Errorf("Mains were nil in the Init, but non-nil's should. Shouldn't be %v",
+			slice["1"])
 	}
 }
 
@@ -434,7 +453,8 @@ func TestSliceInitWithDefaults(t *testing.T) {
 	// THEN all "discord" types have the default
 	for i := range slice {
 		if slice[i].Type == "discord" && slice[i].Defaults != defaults["discord"] {
-			t.Errorf("Slice['%s'] should have been given the %s defaults, %v", i, slice[i].Type, defaults["discord"])
+			t.Errorf("Slice['%s'] should have been given the %s defaults, %v",
+				i, slice[i].Type, defaults["discord"])
 		}
 	}
 }
@@ -458,7 +478,8 @@ func TestSliceInitWithNoDefaults(t *testing.T) {
 	// THEN no non "discord" types are given this default
 	for i := range slice {
 		if slice[i].Type != "discord" && slice[i].Defaults == defaults["discord"] {
-			t.Errorf("Slice['%s'] shouldn't have been given the discord defaults, %v", i, defaults["discord"])
+			t.Errorf("Slice['%s'] shouldn't have been given the discord defaults, %v",
+				i, defaults["discord"])
 		}
 	}
 }
@@ -482,7 +503,8 @@ func TestSliceInitWithHardDefaults(t *testing.T) {
 	// THEN all "discord" types have the default
 	for i := range slice {
 		if slice[i].Type == "discord" && slice[i].HardDefaults != hardDefaults["discord"] {
-			t.Errorf("Slice['%s'] should have been given the %s hardDefaults, %v", i, slice[i].Type, hardDefaults["discord"])
+			t.Errorf("Slice['%s'] should have been given the %s hardDefaults, %v",
+				i, slice[i].Type, hardDefaults["discord"])
 		}
 	}
 }
@@ -506,7 +528,8 @@ func TestSliceInitWithNoHardDefaults(t *testing.T) {
 	// THEN no non "discord" types are given this default
 	for i := range slice {
 		if slice[i].Type != "discord" && slice[i].HardDefaults == hardDefaults["discord"] {
-			t.Errorf("Slice['%s'] shouldn't have been given the discord hardDefaults, %v", i, hardDefaults["discord"])
+			t.Errorf("Slice['%s'] shouldn't have been given the discord hardDefaults, %v",
+				i, hardDefaults["discord"])
 		}
 	}
 }

--- a/notifiers/shoutrrr/init_test.go
+++ b/notifiers/shoutrrr/init_test.go
@@ -383,6 +383,23 @@ func TestSliceInitWithNilElement(t *testing.T) {
 	}
 }
 
+func TestSliceInitWithDefaultMain(t *testing.T) {
+	// GIVEN a Slice and a Slice with a Main for "1"
+	slice := testSlice()
+	serviceID := "test"
+
+	// WHEN Init is called on it with a main for "1"
+	slice.Init(nil, &serviceID, &Slice{}, &Slice{}, &Slice{})
+
+	// THEN "1" has an empty main
+	if slice["1"].Main.Type != "" ||
+		len(slice["1"].Main.Options) != 0 ||
+		len(slice["1"].Main.URLFields) != 0 ||
+		len(slice["1"].Main.Params) != 0 {
+		t.Errorf("Slice['1'] was given %v, not an empty Main (%v)", slice["1"].Main, Shoutrrr{})
+	}
+}
+
 func TestSliceInitWithNilMains(t *testing.T) {
 	// GIVEN a Slice with nil Shoutrrr mains
 	slice := testSlice()

--- a/notifiers/shoutrrr/shoutrrr_test.go
+++ b/notifiers/shoutrrr/shoutrrr_test.go
@@ -212,7 +212,8 @@ func TestGetParamsMaster(t *testing.T) {
 	got := (*params)[key]
 	want := key + "-val"
 	if got != want {
-		t.Errorf("%s key not looked up correctly from master. Got %s, want %s", key, got, want)
+		t.Errorf("%s key not looked up correctly from master. Got %s, want %s",
+			key, got, want)
 	}
 }
 
@@ -228,7 +229,8 @@ func TestGetParamsMain(t *testing.T) {
 	got := (*params)[key]
 	want := key + "-val"
 	if got != want {
-		t.Errorf("%s key not looked up correctly from main. Got %s, want %s", key, got, want)
+		t.Errorf("%s key not looked up correctly from main. Got %s, want %s",
+			key, got, want)
 	}
 }
 
@@ -244,7 +246,8 @@ func TestGetParamsDefault(t *testing.T) {
 	got := (*params)[key]
 	want := key + "-val"
 	if got != want {
-		t.Errorf("%s key not looked up correctly from default. Got %s, want %s", key, got, want)
+		t.Errorf("%s key not looked up correctly from default. Got %s, want %s",
+			key, got, want)
 	}
 }
 
@@ -260,7 +263,8 @@ func TestGetParamsHardDefault(t *testing.T) {
 	got := (*params)[key]
 	want := key + "-val"
 	if got != want {
-		t.Errorf("%s key not looked up correctly from harddefault. Got %s, want %s", key, got, want)
+		t.Errorf("%s key not looked up correctly from harddefault. Got %s, want %s",
+			key, got, want)
 	}
 }
 
@@ -276,7 +280,8 @@ func TestGetParamsTemplating(t *testing.T) {
 	got := (*params)["template"]
 	want := "1.2.3-yes"
 	if got != want {
-		t.Errorf("Param templating not applied as expected. Got %s, want %s", got, want)
+		t.Errorf("Param templating not applied as expected. Got %s, want %s",
+			got, want)
 	}
 }
 
@@ -299,7 +304,8 @@ func TestGetURLForDiscord(t *testing.T) {
 	// THEN the Shoutrrr URL is correctly formatted
 	want := "discord://foo@bar"
 	if got != want {
-		t.Errorf("Unexpected URL returned. Got %q, want %q", got, want)
+		t.Errorf("Unexpected URL returned. Got %q, want %q",
+			got, want)
 	}
 }
 
@@ -328,7 +334,8 @@ func TestGetURLForSMTP(t *testing.T) {
 	// THEN the Shoutrrr URL is correctly formatted
 	want := "smtp://bar:foo@example.com:123/?fromaddress=me@me.com&toaddresses=you@you.com"
 	if got != want {
-		t.Errorf("Unexpected URL returned. Got %q, want %q", got, want)
+		t.Errorf("Unexpected URL returned. Got %q, want %q",
+			got, want)
 	}
 }
 
@@ -353,7 +360,8 @@ func TestGetURLForGotify(t *testing.T) {
 	// THEN the Shoutrrr URL is correctly formatted
 	want := "gotify://example.com:123/test/foo"
 	if got != want {
-		t.Errorf("Unexpected URL returned. Got %q, want %q", got, want)
+		t.Errorf("Unexpected URL returned. Got %q, want %q",
+			got, want)
 	}
 }
 
@@ -375,7 +383,8 @@ func TestGetURLForGoogleChat(t *testing.T) {
 	// THEN the Shoutrrr URL is correctly formatted
 	want := "googlechat://chat.googleapis.com/v1/spaces/FOO/messages?key=bar&token=baz"
 	if got != want {
-		t.Errorf("Unexpected URL returned. Got %q, want %q", got, want)
+		t.Errorf("Unexpected URL returned. Got %q, want %q",
+			got, want)
 	}
 }
 
@@ -400,7 +409,8 @@ func TestGetURLForIFTTT(t *testing.T) {
 	// THEN the Shoutrrr URL is correctly formatted
 	want := "ifttt://foo/?events=event1,event2"
 	if got != want {
-		t.Errorf("Unexpected URL returned. Got %q, want %q", got, want)
+		t.Errorf("Unexpected URL returned. Got %q, want %q",
+			got, want)
 	}
 }
 
@@ -425,7 +435,8 @@ func TestGetURLForJoin(t *testing.T) {
 	// THEN the Shoutrrr URL is correctly formatted
 	want := "join://shoutrrr:foo@join/?devices=device1,device2"
 	if got != want {
-		t.Errorf("Unexpected URL returned. Got %q, want %q", got, want)
+		t.Errorf("Unexpected URL returned. Got %q, want %q",
+			got, want)
 	}
 }
 
@@ -452,7 +463,8 @@ func TestGetURLForMattermost(t *testing.T) {
 	// THEN the Shoutrrr URL is correctly formatted
 	want := "mattermost://bar@example.com:123/test/bish/bash"
 	if got != want {
-		t.Errorf("Unexpected URL returned. Got %q, want %q", got, want)
+		t.Errorf("Unexpected URL returned. Got %q, want %q",
+			got, want)
 	}
 }
 
@@ -482,7 +494,8 @@ func TestGetURLForMatrix(t *testing.T) {
 	// THEN the Shoutrrr URL is correctly formatted
 	want := "matrix://foo:bar@example.com:123/test/?rooms=!roomID1,roomAlias2&disableTLS=yes"
 	if got != want {
-		t.Errorf("Unexpected URL returned. Got %q, want %q", got, want)
+		t.Errorf("Unexpected URL returned. Got %q, want %q",
+			got, want)
 	}
 }
 
@@ -511,7 +524,8 @@ func TestGetURLForMatrixNoRooms(t *testing.T) {
 	// THEN the Shoutrrr URL is correctly formatted
 	want := "matrix://foo:bar@example.com:123/test/?disableTLS=yes"
 	if got != want {
-		t.Errorf("Unexpected URL returned. Got %q, want %q", got, want)
+		t.Errorf("Unexpected URL returned. Got %q, want %q",
+			got, want)
 	}
 }
 
@@ -535,7 +549,8 @@ func TestGetURLForOpsGenie(t *testing.T) {
 	// THEN the Shoutrrr URL is correctly formatted
 	want := "opsgenie://example.com:123/foo"
 	if got != want {
-		t.Errorf("Unexpected URL returned. Got %q, want %q", got, want)
+		t.Errorf("Unexpected URL returned. Got %q, want %q",
+			got, want)
 	}
 }
 
@@ -558,7 +573,8 @@ func TestGetURLForPushbullet(t *testing.T) {
 	// THEN the Shoutrrr URL is correctly formatted
 	want := "pushbullet://foo/bar"
 	if got != want {
-		t.Errorf("Unexpected URL returned. Got %q, want %q", got, want)
+		t.Errorf("Unexpected URL returned. Got %q, want %q",
+			got, want)
 	}
 }
 
@@ -584,7 +600,8 @@ func TestGetURLForPushover(t *testing.T) {
 	// THEN the Shoutrrr URL is correctly formatted
 	want := "pushover://shoutrrr:foo@bar/?devices=device1"
 	if got != want {
-		t.Errorf("Unexpected URL returned. Got %q, want %q", got, want)
+		t.Errorf("Unexpected URL returned. Got %q, want %q",
+			got, want)
 	}
 }
 
@@ -611,7 +628,8 @@ func TestGetURLForRocketChat(t *testing.T) {
 	// THEN the Shoutrrr URL is correctly formatted
 	want := "rocketchat://foo@example.com:123/bish/bish/bosh"
 	if got != want {
-		t.Errorf("Unexpected URL returned. Got %q, want %q", got, want)
+		t.Errorf("Unexpected URL returned. Got %q, want %q",
+			got, want)
 	}
 }
 
@@ -634,7 +652,8 @@ func TestGetURLForSlack(t *testing.T) {
 	// THEN the Shoutrrr URL is correctly formatted
 	want := "slack://hook-foo@bar"
 	if got != want {
-		t.Errorf("Unexpected URL returned. Got %q, want %q", got, want)
+		t.Errorf("Unexpected URL returned. Got %q, want %q",
+			got, want)
 	}
 }
 
@@ -662,7 +681,8 @@ func TestGetURLForTeams(t *testing.T) {
 	// THEN the Shoutrrr URL is correctly formatted
 	want := "teams://foo@bish/bash/bosh?host=example.webhook.office.com"
 	if got != want {
-		t.Errorf("Unexpected URL returned. Got %q, want %q", got, want)
+		t.Errorf("Unexpected URL returned. Got %q, want %q",
+			got, want)
 	}
 }
 
@@ -687,7 +707,8 @@ func TestGetURLForTelegram(t *testing.T) {
 	// THEN the Shoutrrr URL is correctly formatted
 	want := "telegram://foo@telegram?chats=channel1,channel2"
 	if got != want {
-		t.Errorf("Unexpected URL returned. Got %q, want %q", got, want)
+		t.Errorf("Unexpected URL returned. Got %q, want %q",
+			got, want)
 	}
 }
 
@@ -713,7 +734,8 @@ func TestGetURLForZulipChat(t *testing.T) {
 	// THEN the Shoutrrr URL is correctly formatted
 	want := "zulip://bish:bash@bosh:123/test"
 	if got != want {
-		t.Errorf("Unexpected URL returned. Got %q, want %q", got, want)
+		t.Errorf("Unexpected URL returned. Got %q, want %q",
+			got, want)
 	}
 }
 
@@ -735,7 +757,8 @@ func TestGetURLForShoutrrr(t *testing.T) {
 	// THEN the Shoutrrr URL is correctly formatted
 	want := "something://bish:bash:bosh"
 	if got != want {
-		t.Errorf("Unexpected URL returned. Got %q, want %q", got, want)
+		t.Errorf("Unexpected URL returned. Got %q, want %q",
+			got, want)
 	}
 }
 
@@ -749,7 +772,8 @@ func TestSendWithNil(t *testing.T) {
 	// THEN err is nil
 	var want error
 	if err != want {
-		t.Errorf("Send on %v should have produced %v err, not\n%v", slice, want, err)
+		t.Errorf("Send on %v should have produced %v err, not\n%v",
+			slice, want, err)
 	}
 }
 
@@ -780,7 +804,8 @@ func TestSendWithNilServiceInfo(t *testing.T) {
 	contain := " invalid port "
 	e := utils.ErrorToString(err)
 	if !strings.Contains(e, contain) {
-		t.Errorf("Send should err about the %q, not\n%v", contain, e)
+		t.Errorf("Send should err about the %q, not\n%v",
+			contain, e)
 	}
 }
 
@@ -812,6 +837,42 @@ func TestSendWithFail(t *testing.T) {
 	contain := "failed to send slack notification:"
 	e := utils.ErrorToString(err)
 	if !strings.Contains(e, contain) {
-		t.Errorf("Send should err about %q, not\n%v", contain, e)
+		t.Errorf("Send should err about %q, not\n%v",
+			contain, e)
+	}
+}
+
+func TestSendWithMultipleFails(t *testing.T) {
+	// GIVEN a Slice with an invalid Shoutrrr
+	jLog = utils.NewJLog("WARN", false)
+	id := "test"
+	failingShoutrrr := &Shoutrrr{
+		ID:   &id,
+		Type: "slack",
+		Options: map[string]string{
+			"max_tries": "2",
+			"delay":     "1s",
+		},
+		URLFields: map[string]string{
+			"token":   "hook:WNA3PBYV6-F20DUQND3RQ-Webc4MAvoacrpPakR8phF0zi",
+			"channel": "bar",
+		},
+		Main:         &Shoutrrr{},
+		Defaults:     &Shoutrrr{},
+		HardDefaults: &Shoutrrr{},
+	}
+	slice := Slice{
+		"test":  failingShoutrrr,
+		"other": failingShoutrrr,
+	}
+	// WHEN Send is called on this Shoutrrr with a nil serviceInfo
+	err := slice.Send("title", "message", nil)
+
+	// THEN the Send errors related to the Shoutrrr being invalid
+	contain := "failed to send slack notification:"
+	e := utils.ErrorToString(err)
+	if strings.Count(e, contain) != len(slice) {
+		t.Errorf("Send should err about %q %d times, not\n%v",
+			contain, len(slice), e)
 	}
 }

--- a/notifiers/shoutrrr/verify.go
+++ b/notifiers/shoutrrr/verify.go
@@ -32,12 +32,14 @@ func (s *Slice) CheckValues(prefix string) (errs error) {
 
 	for key := range *s {
 		if err := (*s)[key].CheckValues(prefix + "    "); err != nil {
-			errs = fmt.Errorf("%s%s  %s:\\%w", utils.ErrorToString(errs), prefix, key, err)
+			errs = fmt.Errorf("%s%s  %s:\\%w",
+				utils.ErrorToString(errs), prefix, key, err)
 		}
 	}
 
 	if errs != nil {
-		errs = fmt.Errorf("%snotify:\\%w", prefix, errs)
+		errs = fmt.Errorf("%snotify:\\%w",
+			prefix, errs)
 	}
 	return
 }
@@ -63,7 +65,8 @@ func (s *Shoutrrr) CheckValues(prefix string) (errs error) {
 			s.Options["delay"] += "s"
 		}
 		if _, err := time.ParseDuration(s.Options["delay"]); err != nil {
-			errsOptions = fmt.Errorf("%s%s  delay: %q <invalid> (Use 'AhBmCs' duration format)\\", utils.ErrorToString(errsOptions), prefix, delay)
+			errsOptions = fmt.Errorf("%s%s  delay: %q <invalid> (Use 'AhBmCs' duration format)\\",
+				utils.ErrorToString(errsOptions), prefix, delay)
 		}
 	}
 
@@ -76,21 +79,26 @@ func (s *Shoutrrr) CheckValues(prefix string) (errs error) {
 		//nolint:errcheck // ^
 		sender, _ := shoutrrr_lib.CreateSender()
 		if _, err := sender.Locate(s.GetURL()); err != nil {
-			errsLocate = fmt.Errorf("%s%s^ %s\\", utils.ErrorToString(errsLocate), prefix, err.Error())
+			errsLocate = fmt.Errorf("%s%s^ %s\\",
+				utils.ErrorToString(errsLocate), prefix, err.Error())
 		}
 	}
 
 	if errsOptions != nil {
-		errs = fmt.Errorf("%s%soptions:\\%w", utils.ErrorToString(errs), prefix, errsOptions)
+		errs = fmt.Errorf("%s%soptions:\\%w",
+			utils.ErrorToString(errs), prefix, errsOptions)
 	}
 	if errsURLFields != nil {
-		errs = fmt.Errorf("%s%surl_fields:\\%w", utils.ErrorToString(errs), prefix, errsURLFields)
+		errs = fmt.Errorf("%s%surl_fields:\\%w",
+			utils.ErrorToString(errs), prefix, errsURLFields)
 	}
 	if errsParams != nil {
-		errs = fmt.Errorf("%s%sparams:\\%w", utils.ErrorToString(errs), prefix, errsParams)
+		errs = fmt.Errorf("%s%sparams:\\%w",
+			utils.ErrorToString(errs), prefix, errsParams)
 	}
 	if errsLocate != nil {
-		errs = fmt.Errorf("%s%w", utils.ErrorToString(errs), errsLocate)
+		errs = fmt.Errorf("%s%w",
+			utils.ErrorToString(errs), errsLocate)
 	}
 	return
 }
@@ -144,162 +152,202 @@ func (s *Shoutrrr) correctSelf() {
 // for its Type
 func (s *Shoutrrr) checkValuesMaster(prefix string, errs *error, errsOptions *error, errsURLFields *error, errsParams *error) {
 	if utils.GetFirstNonDefault(s.Type, s.Main.Type) == "" {
-		*errs = fmt.Errorf("%s%stype: <required> e.g. 'slack', see the docs for possible types - https://release-argus.io/docs/config/notify\\", utils.ErrorToString(*errs), prefix)
+		*errs = fmt.Errorf("%s%stype: <required> e.g. 'slack', see the docs for possible types - https://release-argus.io/docs/config/notify\\",
+			utils.ErrorToString(*errs), prefix)
 	}
 
 	switch s.GetType() {
 	case "discord":
 		// discord://token@webhookid
 		if s.GetURLField("token") == "" {
-			*errsURLFields = fmt.Errorf("%s%s  token: <required> e.g. 'https://discord.com/api/webhooks/[ 975870285909737583 <- webhookid ]/[ QEdyk-Qi5AiMXoZdxQFpWNcwEfmz5oOm_1Rni9DnjQAUap4zWcurM4IquamVrDIyNgBG <- TOKEN ]'\\", utils.ErrorToString(*errsURLFields), prefix)
+			*errsURLFields = fmt.Errorf("%s%s  token: <required> e.g. 'https://discord.com/api/webhooks/[ 975870285909737583 <- webhookid ]/[ QEdyk-Qi5AiMXoZdxQFpWNcwEfmz5oOm_1Rni9DnjQAUap4zWcurM4IquamVrDIyNgBG <- TOKEN ]'\\",
+				utils.ErrorToString(*errsURLFields), prefix)
 		}
 		if s.GetURLField("webhookid") == "" {
-			*errsURLFields = fmt.Errorf("%s%s  webhookid: <required> e.g. 'https://discord.com/api/webhooks/[ 975870285909737583 <- WEBHOOKID ]/[ QEdyk-Qi5AiMXoZdxQFpWNcwEfmz5oOm_1Rni9DnjQAUap4zWcurM4IquamVrDIyNgBG <- token ]'\\", utils.ErrorToString(*errsURLFields), prefix)
+			*errsURLFields = fmt.Errorf("%s%s  webhookid: <required> e.g. 'https://discord.com/api/webhooks/[ 975870285909737583 <- WEBHOOKID ]/[ QEdyk-Qi5AiMXoZdxQFpWNcwEfmz5oOm_1Rni9DnjQAUap4zWcurM4IquamVrDIyNgBG <- token ]'\\",
+				utils.ErrorToString(*errsURLFields), prefix)
 		}
 	case "smtp":
 		// smtp://username:password@host:port[/path]
 		if s.GetURLField("host") == "" {
-			*errsURLFields = fmt.Errorf("%s%s  host: <required> e.g. 'smtp.example.io'\\", utils.ErrorToString(*errsURLFields), prefix)
+			*errsURLFields = fmt.Errorf("%s%s  host: <required> e.g. 'smtp.example.io'\\",
+				utils.ErrorToString(*errsURLFields), prefix)
 		}
 		if s.GetParam("fromaddress") == "" {
-			*errsParams = fmt.Errorf("%s%s  fromaddress: <required> e.g. 'service@gmail.com'\\", utils.ErrorToString(*errsParams), prefix)
+			*errsParams = fmt.Errorf("%s%s  fromaddress: <required> e.g. 'service@gmail.com'\\",
+				utils.ErrorToString(*errsParams), prefix)
 		}
 		if s.GetParam("toaddresses") == "" {
-			*errsParams = fmt.Errorf("%s%s  toaddresses: <required> e.g. 'name@gmail.com'\\", utils.ErrorToString(*errsParams), prefix)
+			*errsParams = fmt.Errorf("%s%s  toaddresses: <required> e.g. 'name@gmail.com'\\",
+				utils.ErrorToString(*errsParams), prefix)
 		}
 	case "gotify":
 		// gotify://host:port/path/token
 		if s.GetURLField("host") == "" {
-			*errsURLFields = fmt.Errorf("%s%s  host: <required> e.g. 'gotify.example.io'\\", utils.ErrorToString(*errsURLFields), prefix)
+			*errsURLFields = fmt.Errorf("%s%s  host: <required> e.g. 'gotify.example.io'\\",
+				utils.ErrorToString(*errsURLFields), prefix)
 		}
 		if s.GetURLField("token") == "" {
-			*errsURLFields = fmt.Errorf("%s%s  token: <required> e.g. 'Aod9Cb0zXCeOrnD'\\", utils.ErrorToString(*errsURLFields), prefix)
+			*errsURLFields = fmt.Errorf("%s%s  token: <required> e.g. 'Aod9Cb0zXCeOrnD'\\",
+				utils.ErrorToString(*errsURLFields), prefix)
 		}
 	case "googlechat":
 		// googlechat://url
 		if s.GetURLField("raw") == "" {
-			*errsURLFields = fmt.Errorf("%s%s  raw: <required> e.g. 'https://chat.googleapis.com/v1/spaces/FOO/messages?key=bar&token=baz'\\", utils.ErrorToString(*errsURLFields), prefix)
+			*errsURLFields = fmt.Errorf("%s%s  raw: <required> e.g. 'https://chat.googleapis.com/v1/spaces/FOO/messages?key=bar&token=baz'\\",
+				utils.ErrorToString(*errsURLFields), prefix)
 		}
 	case "ifttt":
 		// ifttt://webhookid
 		if s.GetURLField("webhookid") == "" {
-			*errsURLFields = fmt.Errorf("%s%s  webhookid: <required> e.g. 'h1fyLh42h7lDI2L11T-bv'\\", utils.ErrorToString(*errsURLFields), prefix)
+			*errsURLFields = fmt.Errorf("%s%s  webhookid: <required> e.g. 'h1fyLh42h7lDI2L11T-bv'\\",
+				utils.ErrorToString(*errsURLFields), prefix)
 		}
 		if s.GetParam("events") == "" {
-			*errsParams = fmt.Errorf("%s%s  ebets: <required> e.g. 'event1,event2'\\", utils.ErrorToString(*errsParams), prefix)
+			*errsParams = fmt.Errorf("%s%s  ebets: <required> e.g. 'event1,event2'\\",
+				utils.ErrorToString(*errsParams), prefix)
 		}
 	case "join":
 		// join://apiKey@join
 		if s.GetURLField("apikey") == "" {
-			*errsURLFields = fmt.Errorf("%s%s  apikey: <required> e.g. 'f8eae56127864015b0d2f4d8db6ff53f'\\", utils.ErrorToString(*errsURLFields), prefix)
+			*errsURLFields = fmt.Errorf("%s%s  apikey: <required> e.g. 'f8eae56127864015b0d2f4d8db6ff53f'\\",
+				utils.ErrorToString(*errsURLFields), prefix)
 		}
 		if s.GetParam("devices") == "" {
-			*errsParams = fmt.Errorf("%s%s  devices: <required> e.g. '550ddc132c2b4fd28b8b89f735860db1,7294feb73974e5c99d7479ab7b73ba39,d2d775a2f453237d733aa2b7ea2c3ecd'\\", utils.ErrorToString(*errsParams), prefix)
+			*errsParams = fmt.Errorf("%s%s  devices: <required> e.g. '550ddc132c2b4fd28b8b89f735860db1,7294feb73974e5c99d7479ab7b73ba39,d2d775a2f453237d733aa2b7ea2c3ecd'\\",
+				utils.ErrorToString(*errsParams), prefix)
 		}
 	case "mattermost":
 		// mattermost://[username@]host[:port][/path]/token[/channel]
 		if s.GetURLField("host") == "" {
-			*errsURLFields = fmt.Errorf("%s%s  host: <required> e.g. 'mattermost.example.io'\\", utils.ErrorToString(*errsURLFields), prefix)
+			*errsURLFields = fmt.Errorf("%s%s  host: <required> e.g. 'mattermost.example.io'\\",
+				utils.ErrorToString(*errsURLFields), prefix)
 		}
 		if s.GetURLField("token") == "" {
-			*errsURLFields = fmt.Errorf("%s%s  token: <required> e.g. 'Aod9Cb0zXCeOrnD'\\", utils.ErrorToString(*errsURLFields), prefix)
+			*errsURLFields = fmt.Errorf("%s%s  token: <required> e.g. 'Aod9Cb0zXCeOrnD'\\",
+				utils.ErrorToString(*errsURLFields), prefix)
 		}
 	case "matrix":
 		// matrix://user:password@host
 		if s.GetURLField("host") == "" {
-			*errsURLFields = fmt.Errorf("%s%s  host: <required> e.g. 'matrix.example.io'\\", utils.ErrorToString(*errsURLFields), prefix)
+			*errsURLFields = fmt.Errorf("%s%s  host: <required> e.g. 'matrix.example.io'\\",
+				utils.ErrorToString(*errsURLFields), prefix)
 		}
 		if s.GetURLField("password") == "" {
-			*errsURLFields = fmt.Errorf("%s%s  password: <required> e.g. 'pass123' OR 'access_token'\\", utils.ErrorToString(*errsURLFields), prefix)
+			*errsURLFields = fmt.Errorf("%s%s  password: <required> e.g. 'pass123' OR 'access_token'\\",
+				utils.ErrorToString(*errsURLFields), prefix)
 		}
 	case "opsgenie":
 		// opsgenie://host[:port][/path]/apiKey
 		if s.GetURLField("apikey") == "" {
-			*errsURLFields = fmt.Errorf("%s%s  apikey: <required> e.g. 'xxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx'\\", utils.ErrorToString(*errsURLFields), prefix)
+			*errsURLFields = fmt.Errorf("%s%s  apikey: <required> e.g. 'xxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx'\\",
+				utils.ErrorToString(*errsURLFields), prefix)
 		}
 	case "pushbullet":
 		// pushbullet://token/targets
 		if s.GetURLField("token") == "" {
-			*errsURLFields = fmt.Errorf("%s%s  token: <required> e.g. 'o.5NfxzU9yH4xBZlEXZArRtyUB4S4Ua8Hd'\\", utils.ErrorToString(*errsURLFields), prefix)
+			*errsURLFields = fmt.Errorf("%s%s  token: <required> e.g. 'o.5NfxzU9yH4xBZlEXZArRtyUB4S4Ua8Hd'\\",
+				utils.ErrorToString(*errsURLFields), prefix)
 		}
 		if s.GetURLField("targets") == "" {
-			*errsURLFields = fmt.Errorf("%s%s  targets: <required> e.g. 'fpwfXzDCYsTxw4VfAAoHiR,5eAzVLKp5VRUMJeYehwbzv,XR7VKoK5b2MYWDpstD3Hfq'\\", utils.ErrorToString(*errsURLFields), prefix)
+			*errsURLFields = fmt.Errorf("%s%s  targets: <required> e.g. 'fpwfXzDCYsTxw4VfAAoHiR,5eAzVLKp5VRUMJeYehwbzv,XR7VKoK5b2MYWDpstD3Hfq'\\",
+				utils.ErrorToString(*errsURLFields), prefix)
 		}
 	case "pushover":
 		// pushover://token@user
 		if s.GetURLField("token") == "" {
-			*errsURLFields = fmt.Errorf("%s%s  token: <required> e.g. 'aayohdg8gqjj3ssszuqwwmuipt5gcd'\\", utils.ErrorToString(*errsURLFields), prefix)
+			*errsURLFields = fmt.Errorf("%s%s  token: <required> e.g. 'aayohdg8gqjj3ssszuqwwmuipt5gcd'\\",
+				utils.ErrorToString(*errsURLFields), prefix)
 		}
 		if s.GetURLField("user") == "" {
-			*errsURLFields = fmt.Errorf("%s%s  user: <required> e.g. '2QypyiVSnURsw72cpnXCuVAQMJpKKY'\\", utils.ErrorToString(*errsURLFields), prefix)
+			*errsURLFields = fmt.Errorf("%s%s  user: <required> e.g. '2QypyiVSnURsw72cpnXCuVAQMJpKKY'\\",
+				utils.ErrorToString(*errsURLFields), prefix)
 		}
 	case "rocketchat":
 		// rocketchat://[username@]host:port[/port]/tokenA/tokenB/channel
 		if s.GetURLField("host") == "" {
-			*errsURLFields = fmt.Errorf("%s%s  host: <required> e.g. 'rocket-chat.example.io'\\", utils.ErrorToString(*errsURLFields), prefix)
+			*errsURLFields = fmt.Errorf("%s%s  host: <required> e.g. 'rocket-chat.example.io'\\",
+				utils.ErrorToString(*errsURLFields), prefix)
 		}
 		if s.GetURLField("tokena") == "" {
-			*errsURLFields = fmt.Errorf("%s%s  tokena: <required> e.g. '8eGdRzc9r4YYNyvge'\\", utils.ErrorToString(*errsURLFields), prefix)
+			*errsURLFields = fmt.Errorf("%s%s  tokena: <required> e.g. '8eGdRzc9r4YYNyvge'\\",
+				utils.ErrorToString(*errsURLFields), prefix)
 		}
 		if s.GetURLField("tokenb") == "" {
-			*errsURLFields = fmt.Errorf("%s%s  tokenb: <required> e.g. '2XYQcX9NBwJBKfQnphpebPcnXZcPEi32Nt4NKJfrnbhsbRfX'\\", utils.ErrorToString(*errsURLFields), prefix)
+			*errsURLFields = fmt.Errorf("%s%s  tokenb: <required> e.g. '2XYQcX9NBwJBKfQnphpebPcnXZcPEi32Nt4NKJfrnbhsbRfX'\\",
+				utils.ErrorToString(*errsURLFields), prefix)
 		}
 		if s.GetURLField("channel") == "" {
-			*errsURLFields = fmt.Errorf("%s%s  channel: <required> e.g. 'argusChannel' or '@user'\\", utils.ErrorToString(*errsURLFields), prefix)
+			*errsURLFields = fmt.Errorf("%s%s  channel: <required> e.g. 'argusChannel' or '@user'\\",
+				utils.ErrorToString(*errsURLFields), prefix)
 		}
 	case "slack":
 		// slack://token:token@channel
 		if s.GetURLField("token") == "" {
-			*errsURLFields = fmt.Errorf("%s%s  token: <required> e.g. '123456789012-1234567890123-4mt0t4l1YL3g1T5L4cK70k3N'\\", utils.ErrorToString(*errsURLFields), prefix)
+			*errsURLFields = fmt.Errorf("%s%s  token: <required> e.g. '123456789012-1234567890123-4mt0t4l1YL3g1T5L4cK70k3N'\\",
+				utils.ErrorToString(*errsURLFields), prefix)
 		}
 		if s.GetURLField("channel") == "" {
-			*errsURLFields = fmt.Errorf("%s%s  channel: <required> e.g. 'C001CH4NN3L' or 'webhook'\\", utils.ErrorToString(*errsURLFields), prefix)
+			*errsURLFields = fmt.Errorf("%s%s  channel: <required> e.g. 'C001CH4NN3L' or 'webhook'\\",
+				utils.ErrorToString(*errsURLFields), prefix)
 		}
 	case "teams":
 		// teams://[group@][tenant][/altid][/groupowner]
 		if s.GetURLField("group") == "" {
-			*errsURLFields = fmt.Errorf("%s%s  group: <required> e.g. '<host>/webhookb2/<GROUP>@<tenant>/IncomingWebhook/<altId>/<groupOwner>'\\", utils.ErrorToString(*errsURLFields), prefix)
+			*errsURLFields = fmt.Errorf("%s%s  group: <required> e.g. '<host>/webhookb2/<GROUP>@<tenant>/IncomingWebhook/<altId>/<groupOwner>'\\",
+				utils.ErrorToString(*errsURLFields), prefix)
 		}
 		if s.GetURLField("tenant") == "" {
-			*errsURLFields = fmt.Errorf("%s%s  tenant: <required> e.g. '<host>/webhookb2/<group>@<TENANT>/IncomingWebhook/<altId>/<groupOwner>'\\", utils.ErrorToString(*errsURLFields), prefix)
+			*errsURLFields = fmt.Errorf("%s%s  tenant: <required> e.g. '<host>/webhookb2/<group>@<TENANT>/IncomingWebhook/<altId>/<groupOwner>'\\",
+				utils.ErrorToString(*errsURLFields), prefix)
 		}
 		if s.GetURLField("altid") == "" {
-			*errsURLFields = fmt.Errorf("%s%s  altid: <required> e.g. '<host>/webhookb2/<group>@<tenant>/IncomingWebhook/<ALT-ID>/<groupOwner>'\\", utils.ErrorToString(*errsURLFields), prefix)
+			*errsURLFields = fmt.Errorf("%s%s  altid: <required> e.g. '<host>/webhookb2/<group>@<tenant>/IncomingWebhook/<ALT-ID>/<groupOwner>'\\",
+				utils.ErrorToString(*errsURLFields), prefix)
 		}
 		if s.GetURLField("groupowner") == "" {
-			*errsURLFields = fmt.Errorf("%s%s  groupowner: <required> e.g. '<host>/webhookb2/<group>@<tenant>/IncomingWebhook/<altId>/<GROUP-OWNER>'\\", utils.ErrorToString(*errsURLFields), prefix)
+			*errsURLFields = fmt.Errorf("%s%s  groupowner: <required> e.g. '<host>/webhookb2/<group>@<tenant>/IncomingWebhook/<altId>/<GROUP-OWNER>'\\",
+				utils.ErrorToString(*errsURLFields), prefix)
 		}
 		if s.GetParam("host") == "" {
-			*errsParams = fmt.Errorf("%s%s  host: <required> e.g. 'example.webhook.office.com'\\", utils.ErrorToString(*errsParams), prefix)
+			*errsParams = fmt.Errorf("%s%s  host: <required> e.g. 'example.webhook.office.com'\\",
+				utils.ErrorToString(*errsParams), prefix)
 		}
 	case "telegram":
 		// telegram://token@telegram
 		if s.GetURLField("token") == "" {
-			*errsURLFields = fmt.Errorf("%s%s  token: <required> e.g. '110201543:AAHdqTcvCH1vGWJxfSeofSAs0K5PALDsaw'\\", utils.ErrorToString(*errsURLFields), prefix)
+			*errsURLFields = fmt.Errorf("%s%s  token: <required> e.g. '110201543:AAHdqTcvCH1vGWJxfSeofSAs0K5PALDsaw'\\",
+				utils.ErrorToString(*errsURLFields), prefix)
 		}
 		if s.GetParam("chats") == "" {
-			*errsParams = fmt.Errorf("%s%s  chats: <required> e.g. '@channelName' or 'chatID'\\", utils.ErrorToString(*errsParams), prefix)
+			*errsParams = fmt.Errorf("%s%s  chats: <required> e.g. '@channelName' or 'chatID'\\",
+				utils.ErrorToString(*errsParams), prefix)
 		}
 	case "zulip_chat":
 		// zulip://botMail:botKey@host:port
 		if s.GetURLField("host") == "" {
-			*errsURLFields = fmt.Errorf("%s%s  host: <required> e.g. 'example.zulipchat.com'\\", utils.ErrorToString(*errsURLFields), prefix)
+			*errsURLFields = fmt.Errorf("%s%s  host: <required> e.g. 'example.zulipchat.com'\\",
+				utils.ErrorToString(*errsURLFields), prefix)
 		}
 		if s.GetURLField("botmail") == "" {
-			*errsURLFields = fmt.Errorf("%s%s  botmail: <required> e.g. 'my-bot@zulipchat.com'\\", utils.ErrorToString(*errsURLFields), prefix)
+			*errsURLFields = fmt.Errorf("%s%s  botmail: <required> e.g. 'my-bot@zulipchat.com'\\",
+				utils.ErrorToString(*errsURLFields), prefix)
 		}
 		if s.GetURLField("botkey") == "" {
-			*errsURLFields = fmt.Errorf("%s%s  botkey: <required> e.g. 'correcthorsebatterystable'\\", utils.ErrorToString(*errsURLFields), prefix)
+			*errsURLFields = fmt.Errorf("%s%s  botkey: <required> e.g. 'correcthorsebatterystable'\\",
+				utils.ErrorToString(*errsURLFields), prefix)
 		}
 	case "shoutrrr":
 		// Raw
 		if s.GetURLField("raw") == "" {
-			*errsURLFields = fmt.Errorf("%s%s  raw: <required> e.g. 'service://foo:bar@something'\\", utils.ErrorToString(*errsURLFields), prefix)
+			*errsURLFields = fmt.Errorf("%s%s  raw: <required> e.g. 'service://foo:bar@something'\\",
+				utils.ErrorToString(*errsURLFields), prefix)
 		}
 	default:
 		// Invalid/Unknown type
 		if s.Type != "" {
-			*errs = fmt.Errorf("%s%stype: %q <invalid> e.g. 'slack', see the docs for possible types - https://release-argus.io/docs/config/notify\\", utils.ErrorToString(*errs), prefix, s.GetType())
+			*errs = fmt.Errorf("%s%stype: %q <invalid> e.g. 'slack', see the docs for possible types - https://release-argus.io/docs/config/notify\\",
+				utils.ErrorToString(*errs), prefix, s.GetType())
 		}
 	}
 }

--- a/notifiers/shoutrrr/verify_test.go
+++ b/notifiers/shoutrrr/verify_test.go
@@ -183,7 +183,8 @@ func TestCorrectSelfTeamsAltID(t *testing.T) {
 	got := shoutrrr.GetSelfURLField("altid")
 	want := "foo"
 	if got != want {
-		t.Errorf("Got %s, want %s", got, want)
+		t.Errorf("Got %s, want %s",
+			got, want)
 	}
 }
 
@@ -203,7 +204,8 @@ func TestCorrectSelfTeamsGroupOwner(t *testing.T) {
 	got := shoutrrr.GetSelfURLField("groupowner")
 	want := "bar"
 	if got != want {
-		t.Errorf("Got %s, want %s", got, want)
+		t.Errorf("Got %s, want %s",
+			got, want)
 	}
 }
 
@@ -1169,7 +1171,8 @@ func TestCheckValuesWithValid(t *testing.T) {
 
 	// THEN no error was produced
 	if err != nil {
-		t.Errorf("Err should not have been found on %v.\nGot %s", shoutrrr, err.Error())
+		t.Errorf("Err should not have been found on %v.\nGot %s",
+			shoutrrr, err.Error())
 	}
 }
 
@@ -1384,7 +1387,8 @@ func TestSlicePrint(t *testing.T) {
 	want := 17
 	got := strings.Count(string(out), "\n")
 	if got != want {
-		t.Errorf("Print should have given %d lines, but gave %d\n%s", want, got, out)
+		t.Errorf("Print should have given %d lines, but gave %d\n%s",
+			want, got, out)
 	}
 }
 
@@ -1405,6 +1409,7 @@ func TestShoutrrrPrint(t *testing.T) {
 	want := 7
 	got := strings.Count(string(out), "\n")
 	if got != want {
-		t.Errorf("Print should have given %d lines, but gave %d\n%s", want, got, out)
+		t.Errorf("Print should have given %d lines, but gave %d\n%s",
+			want, got, out)
 	}
 }

--- a/service/deployed_version.go
+++ b/service/deployed_version.go
@@ -141,7 +141,8 @@ func (d *DeployedVersionLookup) Query(logFrom utils.LogFrom, semanticVersioning 
 	if semanticVersioning {
 		_, err = semver.NewVersion(version)
 		if err != nil {
-			err = fmt.Errorf("failed converting %q to a semantic version. If all versions are in this style, consider adding json/regex to get the version into the style of 'MAJOR.MINOR.PATCH' (https://semver.org/), or disabling semantic versioning (globally with defaults.service.semantic_versioning or just for this service with the semantic_versioning var)", version)
+			err = fmt.Errorf("failed converting %q to a semantic version. If all versions are in this style, consider adding json/regex to get the version into the style of 'MAJOR.MINOR.PATCH' (https://semver.org/), or disabling semantic versioning (globally with defaults.service.semantic_versioning or just for this service with the semantic_versioning var)",
+				version)
 			jLog.Error(err, logFrom, true)
 			return "", err
 		}
@@ -228,17 +229,20 @@ func (d *DeployedVersionLookup) CheckValues(prefix string) (errs error) {
 
 	// URL
 	if d.URL == "" && d.Defaults != nil {
-		errs = fmt.Errorf("%s%s  url: <missing> (URL to get the deployed_version is required)\\", utils.ErrorToString(errs), prefix)
+		errs = fmt.Errorf("%s%s  url: <missing> (URL to get the deployed_version is required)\\",
+			utils.ErrorToString(errs), prefix)
 	}
 
 	// RegEx
 	_, err := regexp.Compile(d.Regex)
 	if err != nil {
-		errs = fmt.Errorf("%s%s  regex: %q <invalid> (Invalid RegEx)\\", utils.ErrorToString(errs), prefix, d.Regex)
+		errs = fmt.Errorf("%s%s  regex: %q <invalid> (Invalid RegEx)\\",
+			utils.ErrorToString(errs), prefix, d.Regex)
 	}
 
 	if errs != nil {
-		errs = fmt.Errorf("%sdeployed_version:\\%w", prefix, errs)
+		errs = fmt.Errorf("%sdeployed_version:\\%w",
+			prefix, errs)
 	}
 	return
 }

--- a/service/deployed_version_test.go
+++ b/service/deployed_version_test.go
@@ -321,7 +321,8 @@ func TestDeployedVersionLookupPrintWithNil(t *testing.T) {
 	want := 0
 	got := strings.Count(string(out), "\n")
 	if got != want {
-		t.Errorf("Print should have given %d lines, but gave %d\n%s", want, got, out)
+		t.Errorf("Print should have given %d lines, but gave %d\n%s",
+			want, got, out)
 	}
 }
 
@@ -354,7 +355,8 @@ func TestDeployedVersionLookupPrint(t *testing.T) {
 	want := 11
 	got := strings.Count(string(out), "\n")
 	if got != want {
-		t.Errorf("Print should have given %d lines, but gave %d\n%s", want, got, out)
+		t.Errorf("Print should have given %d lines, but gave %d\n%s",
+			want, got, out)
 	}
 }
 

--- a/service/github.go
+++ b/service/github.go
@@ -99,7 +99,8 @@ func (s *Service) checkGitHubReleasesBody(body *[]byte, logFrom utils.LogFrom) (
 			err = errors.New("github access token is invalid")
 			jLog.Fatal(err, logFrom, strings.Contains(string(*body), "Bad credentials"))
 
-			err = fmt.Errorf("tag_name not found at %s\n%s", *s.URL, string(*body))
+			err = fmt.Errorf("tag_name not found at %s\n%s",
+				*s.URL, string(*body))
 			jLog.Error(err, logFrom, true)
 			return
 		}
@@ -107,7 +108,8 @@ func (s *Service) checkGitHubReleasesBody(body *[]byte, logFrom utils.LogFrom) (
 
 	if err = json.Unmarshal(*body, &releases); err != nil {
 		jLog.Error(err, logFrom, true)
-		err = fmt.Errorf("unmarshal of GitHub API data failed\n%s", err)
+		err = fmt.Errorf("unmarshal of GitHub API data failed\n%s",
+			err)
 		jLog.Error(err, logFrom, true)
 	}
 	return

--- a/service/init_test.go
+++ b/service/init_test.go
@@ -218,7 +218,8 @@ func TestServiceGetIntervalDuration(t *testing.T) {
 	// THEN the function returns Interval as a time.Duration
 	want, _ := time.ParseDuration(service.GetInterval())
 	if got != want {
-		t.Errorf("Want %s, got %s", want, got)
+		t.Errorf("Want %s, got %s",
+			want, got)
 	}
 }
 

--- a/service/query.go
+++ b/service/query.go
@@ -49,7 +49,8 @@ func (s *Service) Query() (bool, error) {
 			// Check it's a valid smenatic version
 			newVersion, err := semver.NewVersion(version)
 			if err != nil {
-				err = fmt.Errorf("failed converting %q to a semantic version. If all versions are in this style, consider adding url_commands to get the version into the style of 'MAJOR.MINOR.PATCH' (https://semver.org/), or disabling semantic versioning (globally with defaults.service.semantic_versioning or just for this service with the semantic_versioning var)", version)
+				err = fmt.Errorf("failed converting %q to a semantic version. If all versions are in this style, consider adding url_commands to get the version into the style of 'MAJOR.MINOR.PATCH' (https://semver.org/), or disabling semantic versioning (globally with defaults.service.semantic_versioning or just for this service with the semantic_versioning var)",
+					version)
 				jLog.Error(err, logFrom, true)
 				return false, err
 			}
@@ -58,7 +59,8 @@ func (s *Service) Query() (bool, error) {
 			if s.Status.LatestVersion != "" {
 				oldVersion, err := semver.NewVersion(s.Status.LatestVersion)
 				if err != nil {
-					err := fmt.Errorf("failed converting %q to a semantic version (This is the old version, so you've probably just enabled `semantic_versioning`. Update/remove this latest_version from the config)", s.Status.LatestVersion)
+					err := fmt.Errorf("failed converting %q to a semantic version (This is the old version, so you've probably just enabled `semantic_versioning`. Update/remove this latest_version from the config)",
+						s.Status.LatestVersion)
 					jLog.Error(err, logFrom, true)
 					return false, err
 				}
@@ -68,7 +70,8 @@ func (s *Service) Query() (bool, error) {
 				// oldVersion = 1.2.10
 				// return false (don't notify anything. Stay on oldVersion)
 				if newVersion.LessThan(*oldVersion) {
-					err := fmt.Errorf("queried version %q is less than the deployed version %q", version, s.Status.LatestVersion)
+					err := fmt.Errorf("queried version %q is less than the deployed version %q",
+						version, s.Status.LatestVersion)
 					jLog.Warn(err, logFrom, true)
 					return false, err
 				}

--- a/service/regex.go
+++ b/service/regex.go
@@ -29,7 +29,8 @@ func (s *Service) regexCheckVersion(
 	if s.RegexVersion != nil {
 		regexMatch := utils.RegexCheck(*wantedRegexVersion, version)
 		if !regexMatch {
-			err := fmt.Errorf("regex not matched on version %q", version)
+			err := fmt.Errorf("regex not matched on version %q",
+				version)
 			s.Status.RegexMissesVersion++
 			jLog.Info(err, logFrom, s.Status.RegexMissesVersion == 1)
 			return err
@@ -61,7 +62,8 @@ func (s *Service) regexCheckContent(
 				)
 			}
 		default:
-			return fmt.Errorf("invalid body type %T", v)
+			return fmt.Errorf("invalid body type %T",
+				v)
 		}
 
 		for i := range searchArea {

--- a/service/status/status_test.go
+++ b/service/status/status_test.go
@@ -113,7 +113,8 @@ func TestPrintFull(t *testing.T) {
 	want := 5
 	got := strings.Count(string(out), "\n")
 	if got != want {
-		t.Errorf("Print should have given %d lines, but gave %d\n%s", want, got, out)
+		t.Errorf("Print should have given %d lines, but gave %d\n%s",
+			want, got, out)
 	}
 }
 
@@ -134,6 +135,7 @@ func TestPrintEmpty(t *testing.T) {
 	want := 0
 	got := strings.Count(string(out), "\n")
 	if got != want {
-		t.Errorf("Print should have given %d lines, but gave %d\n%s", want, got, out)
+		t.Errorf("Print should have given %d lines, but gave %d\n%s",
+			want, got, out)
 	}
 }

--- a/service/urlcommand.go
+++ b/service/urlcommand.go
@@ -159,7 +159,8 @@ func (c *URLCommand) regex(text string, logFrom utils.LogFrom) (string, error) {
 	}
 
 	if len(texts) == 0 {
-		err := fmt.Errorf("%s (%s) didn't return any matches", c.Type, *c.Regex)
+		err := fmt.Errorf("%s (%s) didn't return any matches",
+			c.Type, *c.Regex)
 		jLog.Warn(err, logFrom, !utils.EvalNilPtr(c.GetIgnoreMisses(), false))
 
 		return text, err
@@ -180,7 +181,8 @@ func (c *URLCommand) split(text string, logFrom utils.LogFrom) (string, error) {
 	texts := strings.Split(text, *c.Text)
 
 	if len(texts) == 1 {
-		err := fmt.Errorf("%s didn't find any %q to split on", c.Type, *c.Text)
+		err := fmt.Errorf("%s didn't find any %q to split on",
+			c.Type, *c.Text)
 		jLog.Warn(err, logFrom, !utils.EvalNilPtr(c.GetIgnoreMisses(), false))
 
 		return text, err
@@ -193,7 +195,8 @@ func (c *URLCommand) split(text string, logFrom utils.LogFrom) (string, error) {
 	}
 
 	if (len(texts) - index) < 1 {
-		err := fmt.Errorf("%s (%s) returned %d elements but the index wants element number %d", c.Type, *c.Text, len(texts), (index + 1))
+		err := fmt.Errorf("%s (%s) returned %d elements but the index wants element number %d",
+			c.Type, *c.Text, len(texts), (index + 1))
 		jLog.Warn(err, logFrom, !utils.EvalNilPtr(c.GetIgnoreMisses(), false))
 
 		return text, err
@@ -211,12 +214,14 @@ func (c *URLCommandSlice) CheckValues(prefix string) error {
 	var errs error
 	for index := range *c {
 		if err := (*c)[index].CheckValues(prefix + "    "); err != nil {
-			errs = fmt.Errorf("%s%s  item_%d:\\%w", utils.ErrorToString(errs), prefix, index, err)
+			errs = fmt.Errorf("%s%s  item_%d:\\%w",
+				utils.ErrorToString(errs), prefix, index, err)
 		}
 	}
 
 	if errs != nil {
-		errs = fmt.Errorf("%surl_commands:\\%s", prefix, utils.ErrorToString(errs))
+		errs = fmt.Errorf("%surl_commands:\\%s",
+			prefix, utils.ErrorToString(errs))
 	}
 	return errs
 }
@@ -228,26 +233,32 @@ func (c *URLCommand) CheckValues(prefix string) (errs error) {
 	switch c.Type {
 	case "split":
 		if c.Text == nil {
-			errs = fmt.Errorf("%s%stext: <required> (text to split on)\\", utils.ErrorToString(errs), prefix)
+			errs = fmt.Errorf("%s%stext: <required> (text to split on)\\",
+				utils.ErrorToString(errs), prefix)
 		}
 	case "replace":
 		if c.New == nil {
-			errs = fmt.Errorf("%s%snew: <required> (text you want to replace with)\\", utils.ErrorToString(errs), prefix)
+			errs = fmt.Errorf("%s%snew: <required> (text you want to replace with)\\",
+				utils.ErrorToString(errs), prefix)
 		}
 		if c.Old == nil {
-			errs = fmt.Errorf("%s%sold: <required> (text you want replaced)\\", utils.ErrorToString(errs), prefix)
+			errs = fmt.Errorf("%s%sold: <required> (text you want replaced)\\",
+				utils.ErrorToString(errs), prefix)
 		}
 	case "regex":
 		if c.Regex == nil {
-			errs = fmt.Errorf("%s%sregex: <required> (regex to use)\\", utils.ErrorToString(errs), prefix)
+			errs = fmt.Errorf("%s%sregex: <required> (regex to use)\\",
+				utils.ErrorToString(errs), prefix)
 		}
 	default:
 		validType = false
-		errs = fmt.Errorf("%s%stype: %q <invalid> is not a valid url_command (regex/replace/split)\\", utils.ErrorToString(errs), prefix, c.Type)
+		errs = fmt.Errorf("%s%stype: %q <invalid> is not a valid url_command (regex/replace/split)\\",
+			utils.ErrorToString(errs), prefix, c.Type)
 	}
 
 	if errs != nil && validType {
-		errs = fmt.Errorf("%stype: %s\\%s", prefix, c.Type, errs)
+		errs = fmt.Errorf("%stype: %s\\%s",
+			prefix, c.Type, errs)
 	}
 	return
 }

--- a/service/urlcommand_test.go
+++ b/service/urlcommand_test.go
@@ -43,7 +43,8 @@ func TestURLCommandPrintRegex(t *testing.T) {
 	want := 4
 	got := strings.Count(string(out), "\n")
 	if got != want {
-		t.Errorf("Print should have given %d lines, but gave %d\n%s", want, got, out)
+		t.Errorf("Print should have given %d lines, but gave %d\n%s",
+			want, got, out)
 	}
 }
 
@@ -64,7 +65,8 @@ func TestURLCommandPrintReplace(t *testing.T) {
 	want := 3
 	got := strings.Count(string(out), "\n")
 	if got != want {
-		t.Errorf("Print should have given %d lines, but gave %d\n%s", want, got, out)
+		t.Errorf("Print should have given %d lines, but gave %d\n%s",
+			want, got, out)
 	}
 }
 
@@ -85,7 +87,8 @@ func TestURLCommandPrintSplit(t *testing.T) {
 	want := 4
 	got := strings.Count(string(out), "\n")
 	if got != want {
-		t.Errorf("Print should have given %d lines, but gave %d\n%s", want, got, out)
+		t.Errorf("Print should have given %d lines, but gave %d\n%s",
+			want, got, out)
 	}
 }
 
@@ -106,7 +109,8 @@ func TestURLCommandSlicePrintNil(t *testing.T) {
 	want := 1
 	got := strings.Count(string(out), "\n")
 	if got != want {
-		t.Errorf("Print should have given %d lines, but gave %d\n%s", want, got, out)
+		t.Errorf("Print should have given %d lines, but gave %d\n%s",
+			want, got, out)
 	}
 }
 
@@ -131,7 +135,8 @@ func TestURLCommandSlicePrintAllTypes(t *testing.T) {
 	want := 11
 	got := strings.Count(string(out), "\n")
 	if got != want {
-		t.Errorf("Print should have given %d lines, but gave %d\n%s", want, got, out)
+		t.Errorf("Print should have given %d lines, but gave %d\n%s",
+			want, got, out)
 	}
 }
 
@@ -260,7 +265,8 @@ func TestURLCommandRunSplit(t *testing.T) {
 	// THEN the text is split correctly and returned
 	want := "secondpart"
 	if err != nil {
-		t.Errorf("err should be nil, got %s", err.Error())
+		t.Errorf("err should be nil, got %s",
+			err.Error())
 	}
 	if want != text {
 		t.Errorf("Want %q, got %q",
@@ -279,7 +285,8 @@ func TestURLCommandRunReplace(t *testing.T) {
 	// THEN the text is replaced correctly and returned
 	want := "iwantbar"
 	if err != nil {
-		t.Errorf("err should be nil, got %s", err.Error())
+		t.Errorf("err should be nil, got %s",
+			err.Error())
 	}
 	if want != text {
 		t.Errorf("Want %q, got %q",
@@ -299,7 +306,8 @@ func TestURLCommandRunRegex(t *testing.T) {
 	// THEN the correct RegEx submatch is returned
 	want := "1.2.3"
 	if err != nil {
-		t.Errorf("err should be nil, got %s", err.Error())
+		t.Errorf("err should be nil, got %s",
+			err.Error())
 	}
 	if want != text {
 		t.Errorf("Want %q, got %q",
@@ -319,7 +327,8 @@ func TestURLCommandRunRegexNegativeIndex(t *testing.T) {
 	// THEN the correct RegEx submatch is returned
 	want := "4"
 	if err != nil {
-		t.Errorf("err should be nil, got %q", err.Error())
+		t.Errorf("err should be nil, got %q",
+			err.Error())
 	}
 	if want != text {
 		t.Errorf("Want %q, got %q",
@@ -375,7 +384,8 @@ func TestURLCommandRunSplitNegativeIndex(t *testing.T) {
 	// THEN the text is split correctly and returned
 	want := "thirdpart"
 	if err != nil {
-		t.Errorf("err should be nil, got %q", err.Error())
+		t.Errorf("err should be nil, got %q",
+			err.Error())
 	}
 	if want != text {
 		t.Errorf("Want %q, got %q",
@@ -543,7 +553,8 @@ func TestCheckValuesWithNil(t *testing.T) {
 
 	// THEN err is nil
 	if err != nil {
-		t.Errorf("err should be nil, not %q", err.Error())
+		t.Errorf("err should be nil, not %q",
+			err.Error())
 	}
 }
 
@@ -560,7 +571,8 @@ func TestCheckValuesPass(t *testing.T) {
 
 	// THEN err is nil
 	if err != nil {
-		t.Errorf("err should be nil, not %q", err.Error())
+		t.Errorf("err should be nil, not %q",
+			err.Error())
 	}
 }
 

--- a/service/verify.go
+++ b/service/verify.go
@@ -34,31 +34,37 @@ func (s *Slice) CheckValues(prefix string) error {
 
 		// Check Service
 		if err := service.CheckValues(prefix); err != nil {
-			serviceErrors = fmt.Errorf("%s%w", utils.ErrorToString(serviceErrors), err)
+			serviceErrors = fmt.Errorf("%s%w",
+				utils.ErrorToString(serviceErrors), err)
 		}
 
 		// URL Commands
 		if err := service.URLCommands.CheckValues(prefix + "  "); err != nil {
-			errs = fmt.Errorf("%s%w", utils.ErrorToString(errs), err)
+			errs = fmt.Errorf("%s%w",
+				utils.ErrorToString(errs), err)
 		}
 
 		// Check DeployedVersionLookup
 		if err := service.DeployedVersionLookup.CheckValues(prefix + "  "); err != nil {
-			serviceErrors = fmt.Errorf("%s%w", utils.ErrorToString(serviceErrors), err)
+			serviceErrors = fmt.Errorf("%s%w",
+				utils.ErrorToString(serviceErrors), err)
 		}
 
 		// Check Notify(s)
 		if err := service.Notify.CheckValues(prefix + "  "); err != nil {
-			serviceErrors = fmt.Errorf("%s%w", utils.ErrorToString(serviceErrors), err)
+			serviceErrors = fmt.Errorf("%s%w",
+				utils.ErrorToString(serviceErrors), err)
 		}
 
 		// Check WebHook(s)
 		if err := service.WebHook.CheckValues(prefix + "  "); err != nil {
-			serviceErrors = fmt.Errorf("%s%w", utils.ErrorToString(serviceErrors), err)
+			serviceErrors = fmt.Errorf("%s%w",
+				utils.ErrorToString(serviceErrors), err)
 		}
 
 		if serviceErrors != nil {
-			errs = fmt.Errorf("%s  %s:\\%w", utils.ErrorToString(errs), key, serviceErrors)
+			errs = fmt.Errorf("%s  %s:\\%w",
+				utils.ErrorToString(errs), key, serviceErrors)
 		}
 	}
 	return errs
@@ -73,16 +79,19 @@ func (s *Service) CheckValues(prefix string) (errs error) {
 			*s.Interval += "s"
 		}
 		if _, err := time.ParseDuration(*s.Interval); err != nil {
-			errs = fmt.Errorf("%s%s  interval: %q <invalid> (Use 'AhBmCs' duration format)\\", utils.ErrorToString(errs), prefix, *s.Interval)
+			errs = fmt.Errorf("%s%s  interval: %q <invalid> (Use 'AhBmCs' duration format)\\",
+				utils.ErrorToString(errs), prefix, *s.Interval)
 		}
 	}
 
 	// Type
 	if s.Defaults != nil {
 		if s.Type == nil {
-			errs = fmt.Errorf("%s%s  type: <missing> (Services require a type)\\", utils.ErrorToString(errs), prefix)
+			errs = fmt.Errorf("%s%s  type: <missing> (Services require a type)\\",
+				utils.ErrorToString(errs), prefix)
 		} else if *s.Type != "github" && *s.Type != "url" {
-			errs = fmt.Errorf("%s%s  type: %q <invalid> (Should be either 'github' or 'url')\\", utils.ErrorToString(errs), prefix, *s.Type)
+			errs = fmt.Errorf("%s%s  type: %q <invalid> (Should be either 'github' or 'url')\\",
+				utils.ErrorToString(errs), prefix, *s.Type)
 		}
 	}
 
@@ -90,13 +99,15 @@ func (s *Service) CheckValues(prefix string) (errs error) {
 	if s.RegexContent != nil {
 		_, err := regexp.Compile(*s.RegexContent)
 		if err != nil {
-			errs = fmt.Errorf("%s%s  regex_content: %q <invalid> (Invalid RegEx)\\", utils.ErrorToString(errs), prefix, *s.RegexContent)
+			errs = fmt.Errorf("%s%s  regex_content: %q <invalid> (Invalid RegEx)\\",
+				utils.ErrorToString(errs), prefix, *s.RegexContent)
 		}
 	}
 	if s.RegexVersion != nil {
 		_, err := regexp.Compile(*s.RegexVersion)
 		if err != nil {
-			errs = fmt.Errorf("%s%s  regex_version: %q <invalid> (Invalid RegEx)\\", utils.ErrorToString(errs), prefix, *s.RegexVersion)
+			errs = fmt.Errorf("%s%s  regex_version: %q <invalid> (Invalid RegEx)\\",
+				utils.ErrorToString(errs), prefix, *s.RegexVersion)
 		}
 	}
 
@@ -106,17 +117,20 @@ func (s *Service) CheckValues(prefix string) (errs error) {
 		if s.Status.DeployedVersionTimestamp != "" {
 			_, err := time.Parse(time.RFC3339, s.Status.DeployedVersionTimestamp)
 			if err != nil {
-				statusErrs = fmt.Errorf("%s%s    deployed_version_timestamp: %q <invalid> (Failed to convert to RFC3339 format)\\", utils.ErrorToString(errs), prefix, s.Status.DeployedVersionTimestamp)
+				statusErrs = fmt.Errorf("%s%s    deployed_version_timestamp: %q <invalid> (Failed to convert to RFC3339 format)\\",
+					utils.ErrorToString(errs), prefix, s.Status.DeployedVersionTimestamp)
 			}
 		}
 		if s.Status.LatestVersionTimestamp != "" {
 			_, err := time.Parse(time.RFC3339, s.Status.LatestVersionTimestamp)
 			if err != nil {
-				statusErrs = fmt.Errorf("%s%s    latest_version_timestamp: %q <invalid> (Failed to convert to RFC3339 format)\\", utils.ErrorToString(errs), prefix, s.Status.LatestVersionTimestamp)
+				statusErrs = fmt.Errorf("%s%s    latest_version_timestamp: %q <invalid> (Failed to convert to RFC3339 format)\\",
+					utils.ErrorToString(errs), prefix, s.Status.LatestVersionTimestamp)
 			}
 		}
 		if statusErrs != nil {
-			errs = fmt.Errorf("%s%s  status:\\%s", utils.ErrorToString(errs), prefix, statusErrs)
+			errs = fmt.Errorf("%s%s  status:\\%s",
+				utils.ErrorToString(errs), prefix, statusErrs)
 		}
 	}
 

--- a/service/verify_test.go
+++ b/service/verify_test.go
@@ -67,7 +67,8 @@ func TestServiceCheckValuesWithIntInterval(t *testing.T) {
 	// THEN err is nil
 	got := service.GetInterval()
 	if got != want {
-		t.Errorf("Want %s, got %s", want, got)
+		t.Errorf("Want %s, got %s",
+			want, got)
 	}
 	if err != nil {
 		t.Errorf("Expecting %q interval err to be nil, not\n%s",
@@ -315,7 +316,8 @@ func TestServicePrintWithService(t *testing.T) {
 	want := 13
 	got := strings.Count(string(out), "\n")
 	if got != want {
-		t.Errorf("Print should have given %d lines, but gave %d\n%s", want, got, out)
+		t.Errorf("Print should have given %d lines, but gave %d\n%s",
+			want, got, out)
 	}
 }
 
@@ -357,7 +359,8 @@ func TestServicePrintWithFullService(t *testing.T) {
 	want := 37
 	got := strings.Count(string(out), "\n")
 	if got != want {
-		t.Errorf("Print should have given %d lines, but gave %d\n%s", want, got, out)
+		t.Errorf("Print should have given %d lines, but gave %d\n%s",
+			want, got, out)
 	}
 }
 
@@ -383,7 +386,8 @@ func TestSlicePrintWithTwoServices(t *testing.T) {
 	want := 29
 	got := strings.Count(string(out), "\n")
 	if got != want {
-		t.Errorf("Print should have given %d lines, but gave %d\n%s", want, got, out)
+		t.Errorf("Print should have given %d lines, but gave %d\n%s",
+			want, got, out)
 	}
 }
 
@@ -404,7 +408,8 @@ func TestSlicePrintWithNil(t *testing.T) {
 	want := 0
 	got := strings.Count(string(out), "\n")
 	if got != want {
-		t.Errorf("Print with nil should have given %d lines, but gave %d\n%s", want, got, out)
+		t.Errorf("Print with nil should have given %d lines, but gave %d\n%s",
+			want, got, out)
 	}
 }
 
@@ -439,6 +444,7 @@ func TestSlicePrintWithTwoServicesOrdered(t *testing.T) {
 
 	// THEN the Services are printed in two different orderings
 	if string(gotOne) == string(gotTwo) {
-		t.Errorf("Print should have used ordering\n%s", gotOne)
+		t.Errorf("Print should have used ordering\n%s",
+			gotOne)
 	}
 }

--- a/utils/log_test.go
+++ b/utils/log_test.go
@@ -36,7 +36,8 @@ func TestNewJLogGivesJLog(t *testing.T) {
 	// THEN a JLog pointer is created
 	switch v := jLog.(type) {
 	default:
-		t.Errorf("unexpected type %T, jLog should be of type JLog!", v)
+		t.Errorf("unexpected type %T, jLog should be of type JLog!",
+			v)
 	case *JLog:
 	}
 }
@@ -52,7 +53,8 @@ func TestNewJLogWithLogLevelParam(t *testing.T) {
 	// THEN a JLog pointer is created with this Log Level
 	got := (*jLog).Level
 	if got != wantedLogLevelUInt {
-		t.Errorf("NewJLog didn't use level param. Wanted %q (%d) but got %d", logLevel, wantedLogLevelUInt, got)
+		t.Errorf("NewJLog didn't use level param. Wanted %q (%d) but got %d",
+			logLevel, wantedLogLevelUInt, got)
 	}
 }
 
@@ -66,7 +68,8 @@ func TestNewJLogWithTimestampParam(t *testing.T) {
 	// THEN a JLog pointer is created with this Log Level
 	got := (*jLog).Timestamps
 	if got != timestamps {
-		t.Errorf("NewJLog didn't use level param. Wanted %t but got %t", timestamps, got)
+		t.Errorf("NewJLog didn't use level param. Wanted %t but got %t",
+			timestamps, got)
 	}
 }
 
@@ -82,7 +85,8 @@ func TestSetLevelWithUppercaseValidLevel(t *testing.T) {
 	// THEN a JLog pointer is created with this Log Level
 	got := (*jLog).Level
 	if got != want {
-		t.Errorf("SetLevel set the level correctly. Wanted %q (%d) but got %d", level, want, got)
+		t.Errorf("SetLevel set the level correctly. Wanted %q (%d) but got %d",
+			level, want, got)
 	}
 }
 
@@ -98,7 +102,8 @@ func TestSetLevelWithLowercaseValidLevel(t *testing.T) {
 	// THEN a JLog pointer is created with this Log Level
 	got := (*jLog).Level
 	if got != want {
-		t.Errorf("SetLevel set the level correctly. Wanted %q (%d) but got %d", level, want, got)
+		t.Errorf("SetLevel set the level correctly. Wanted %q (%d) but got %d",
+			level, want, got)
 	}
 }
 
@@ -114,7 +119,8 @@ func TestSetLevelWithInvalidLevel(t *testing.T) {
 	jLog.SetLevel(level)
 
 	// THEN this call will crash the program
-	t.Errorf("%s is an unknown log level and should have been Fatal", level)
+	t.Errorf("%s is an unknown log level and should have been Fatal",
+		level)
 }
 
 func TestSetTimestamps(t *testing.T) {
@@ -128,7 +134,8 @@ func TestSetTimestamps(t *testing.T) {
 	// THEN the Timetamps var is flipped
 	got := (*jLog).Timestamps
 	if got != timestamps {
-		t.Errorf("SetTimestamps didn't set Timestamps correctly. Wanted %t but got %t", timestamps, got)
+		t.Errorf("SetTimestamps didn't set Timestamps correctly. Wanted %t but got %t",
+			timestamps, got)
 	}
 }
 
@@ -142,7 +149,8 @@ func TestFormatMessageSourceWithDefaultLogFrom(t *testing.T) {
 
 	// THEN an empty string is returned
 	if got != want {
-		t.Errorf("FormatMessageSource should have returned %q with an empty LogFrom, not %q", want, got)
+		t.Errorf("FormatMessageSource should have returned %q with an empty LogFrom, not %q",
+			want, got)
 	}
 }
 
@@ -156,7 +164,8 @@ func TestFormatMessageSourceWithLogFromPrimaryOnly(t *testing.T) {
 
 	// THEN an the string returned is this primary followed by ', '
 	if got != want {
-		t.Errorf("FormatMessageSource should have returned %q with only a Primary, not %q", want, got)
+		t.Errorf("FormatMessageSource should have returned %q with only a Primary, not %q",
+			want, got)
 	}
 }
 
@@ -170,7 +179,8 @@ func TestFormatMessageSourceWithLogFromSecondaryOnly(t *testing.T) {
 
 	// THEN an the string returned is this primary followed by ', '
 	if got != want {
-		t.Errorf("FormatMessageSource should have returned %q with only a Secondary, not %q", want, got)
+		t.Errorf("FormatMessageSource should have returned %q with only a Secondary, not %q",
+			want, got)
 	}
 }
 
@@ -184,7 +194,8 @@ func TestFormatMessageSourceWithLogFromPrimaryAndSecondary(t *testing.T) {
 
 	// THEN an the string returned is this primary followed by ', '
 	if got != want {
-		t.Errorf("FormatMessageSource should have returned %q with a Primary and Secondary, not %q", want, got)
+		t.Errorf("FormatMessageSource should have returned %q with a Primary and Secondary, not %q",
+			want, got)
 	}
 }
 
@@ -198,7 +209,8 @@ func TestIsLevelPass(t *testing.T) {
 
 	// THEN a JLog pointer is created with this Log Level
 	if !check {
-		t.Errorf("IsLevel should have got a match on %s and %d, but returned %t", level, jLog.Level, check)
+		t.Errorf("IsLevel should have got a match on %s and %d, but returned %t",
+			level, jLog.Level, check)
 	}
 }
 
@@ -213,7 +225,8 @@ func TestIsLevelFail(t *testing.T) {
 
 	// THEN a JLog pointer is created with this Log Level
 	if check {
-		t.Errorf("IsLevel shouldn't have got a match on %s and %d, but returned %t", guess, jLog.Level, check)
+		t.Errorf("IsLevel shouldn't have got a match on %s and %d, but returned %t",
+			guess, jLog.Level, check)
 	}
 }
 
@@ -233,7 +246,8 @@ func TestErrorFalse(t *testing.T) {
 	out, _ := ioutil.ReadAll(r)
 	os.Stdout = stdout
 	if string(out) != "" {
-		t.Errorf("Error printed when otherCondition was false. (%q)", string(out))
+		t.Errorf("Error printed when otherCondition was false. (%q)",
+			string(out))
 	}
 }
 
@@ -253,7 +267,8 @@ func TestErrorTrueTimestamps(t *testing.T) {
 	got := out.String()
 	match := reg.MatchString(got)
 	if !match {
-		t.Errorf("Error printed didn't match %q. Got %q, want %q", regex, got, msg)
+		t.Errorf("Error printed didn't match %q. Got %q, want %q",
+			regex, got, msg)
 	}
 }
 
@@ -274,7 +289,8 @@ func TestErrorTrueNoTimestamps(t *testing.T) {
 	out, _ := ioutil.ReadAll(r)
 	os.Stdout = stdout
 	if string(out) != want {
-		t.Errorf("Error printed didn't match desired. Got %q, want %q", string(out), msg)
+		t.Errorf("Error printed didn't match desired. Got %q, want %q",
+			string(out), msg)
 	}
 }
 
@@ -294,7 +310,8 @@ func TestWarnFalse(t *testing.T) {
 	out, _ := ioutil.ReadAll(r)
 	os.Stdout = stdout
 	if string(out) != "" {
-		t.Errorf("Warn printed when otherCondition was false. (%q)", string(out))
+		t.Errorf("Warn printed when otherCondition was false. (%q)",
+			string(out))
 	}
 }
 
@@ -314,7 +331,8 @@ func TestWarnTrueTimestamps(t *testing.T) {
 	got := out.String()
 	match := reg.MatchString(got)
 	if !match {
-		t.Errorf("Warn printed didn't match %q. Got %q, want %q", regex, got, msg)
+		t.Errorf("Warn printed didn't match %q. Got %q, want %q",
+			regex, got, msg)
 	}
 }
 
@@ -335,7 +353,8 @@ func TestWarnTrueNoTimestamps(t *testing.T) {
 	out, _ := ioutil.ReadAll(r)
 	os.Stdout = stdout
 	if string(out) != want {
-		t.Errorf("Warn printed didn't match desired. Got %q, want %q", string(out), msg)
+		t.Errorf("Warn printed didn't match desired. Got %q, want %q",
+			string(out), msg)
 	}
 }
 
@@ -355,7 +374,8 @@ func TestInfoFalse(t *testing.T) {
 	out, _ := ioutil.ReadAll(r)
 	os.Stdout = stdout
 	if string(out) != "" {
-		t.Errorf("Info printed when otherCondition was false. (%q)", string(out))
+		t.Errorf("Info printed when otherCondition was false. (%q)",
+			string(out))
 	}
 }
 
@@ -375,7 +395,8 @@ func TestInfoTrueTimestamps(t *testing.T) {
 	got := out.String()
 	match := reg.MatchString(got)
 	if !match {
-		t.Errorf("Info printed didn't match %q. Got %q, want %q", regex, got, msg)
+		t.Errorf("Info printed didn't match %q. Got %q, want %q",
+			regex, got, msg)
 	}
 }
 
@@ -396,7 +417,8 @@ func TestInfoTrueNoTimestamps(t *testing.T) {
 	out, _ := ioutil.ReadAll(r)
 	os.Stdout = stdout
 	if string(out) != want {
-		t.Errorf("Info printed didn't match desired. Got %q, want %q", string(out), msg)
+		t.Errorf("Info printed didn't match desired. Got %q, want %q",
+			string(out), msg)
 	}
 }
 
@@ -416,7 +438,8 @@ func TestVerboseFalse(t *testing.T) {
 	out, _ := ioutil.ReadAll(r)
 	os.Stdout = stdout
 	if string(out) != "" {
-		t.Errorf("Verbose printed when otherCondition was false. (%q)", string(out))
+		t.Errorf("Verbose printed when otherCondition was false. (%q)",
+			string(out))
 	}
 }
 
@@ -436,7 +459,8 @@ func TestVerboseTrueTimestamps(t *testing.T) {
 	got := out.String()
 	match := reg.MatchString(got)
 	if !match {
-		t.Errorf("Verbose printed didn't match %q. Got %q, want %q", regex, got, msg)
+		t.Errorf("Verbose printed didn't match %q. Got %q, want %q",
+			regex, got, msg)
 	}
 }
 
@@ -457,7 +481,8 @@ func TestVerboseTrueNoTimestamps(t *testing.T) {
 	out, _ := ioutil.ReadAll(r)
 	os.Stdout = stdout
 	if string(out) != want {
-		t.Errorf("Verbose printed didn't match desired. Got %q, want %q", string(out), msg)
+		t.Errorf("Verbose printed didn't match desired. Got %q, want %q",
+			string(out), msg)
 	}
 }
 
@@ -477,7 +502,8 @@ func TestDebugFalse(t *testing.T) {
 	out, _ := ioutil.ReadAll(r)
 	os.Stdout = stdout
 	if string(out) != "" {
-		t.Errorf("Debug printed when otherCondition was false. (%q)", string(out))
+		t.Errorf("Debug printed when otherCondition was false. (%q)",
+			string(out))
 	}
 }
 
@@ -497,7 +523,8 @@ func TestDebugTrueTimestamps(t *testing.T) {
 	got := out.String()
 	match := reg.MatchString(got)
 	if !match {
-		t.Errorf("Debug printed didn't match %q. Got %q, want %q", regex, got, msg)
+		t.Errorf("Debug printed didn't match %q. Got %q, want %q",
+			regex, got, msg)
 	}
 }
 
@@ -518,7 +545,8 @@ func TestDebugTrueNoTimestamps(t *testing.T) {
 	out, _ := ioutil.ReadAll(r)
 	os.Stdout = stdout
 	if string(out) != want {
-		t.Errorf("Debug printed didn't match desired. Got %q, want %q", string(out), msg)
+		t.Errorf("Debug printed didn't match desired. Got %q, want %q",
+			string(out), msg)
 	}
 }
 
@@ -538,7 +566,8 @@ func TestFatalFalse(t *testing.T) {
 	out, _ := ioutil.ReadAll(r)
 	os.Stdout = stdout
 	if string(out) != "" {
-		t.Errorf("Fatal printed when otherCondition was false. (%q)", string(out))
+		t.Errorf("Fatal printed when otherCondition was false. (%q)",
+			string(out))
 	}
 }
 
@@ -563,5 +592,6 @@ func TestFatalTrue(t *testing.T) {
 		return
 	}
 	got := out.String()
-	t.Errorf("Fatal print didn't os.Exit. Got %q", got)
+	t.Errorf("Fatal print didn't os.Exit. Got %q",
+		got)
 }

--- a/utils/regex_test.go
+++ b/utils/regex_test.go
@@ -30,7 +30,8 @@ func TestRegexCheckPass(t *testing.T) {
 
 	// THEN a match is found
 	if !match {
-		t.Errorf("%q should have matched the %q RegEx", str, regex)
+		t.Errorf("%q should have matched the %q RegEx",
+			str, regex)
 	}
 }
 
@@ -44,7 +45,8 @@ func TestRegexCheckFail(t *testing.T) {
 
 	// THEN a match is not found
 	if match {
-		t.Errorf("%q shouldn't have matched the %q RegEx", str, regex)
+		t.Errorf("%q shouldn't have matched the %q RegEx",
+			str, regex)
 	}
 }
 
@@ -59,7 +61,8 @@ func TestRegexCheckWithParamsRunsOnTemplatedStringPass(t *testing.T) {
 
 	// THEN a match is found
 	if !match {
-		t.Errorf("%q (version=%s) should have matched the %q RegEx", str, version, regex)
+		t.Errorf("%q (version=%s) should have matched the %q RegEx",
+			str, version, regex)
 	}
 }
 
@@ -74,6 +77,7 @@ func TestRegexCheckWithParamsRunsOnTemplatedStringFail(t *testing.T) {
 
 	// THEN a match is found
 	if match {
-		t.Errorf("%q (version=%s) should not have matched the %q RegEx", str, version, regex)
+		t.Errorf("%q (version=%s) should not have matched the %q RegEx",
+			str, version, regex)
 	}
 }

--- a/utils/template_test.go
+++ b/utils/template_test.go
@@ -39,7 +39,8 @@ func TestTemplateStringNoJinja(t *testing.T) {
 
 	// THEN the string stays the same
 	if got != want {
-		t.Errorf("TemplateString didn't stay the same! Got %q, want %q", got, want)
+		t.Errorf("TemplateString didn't stay the same! Got %q, want %q",
+			got, want)
 	}
 }
 
@@ -53,7 +54,8 @@ func TestTemplateStringCompilePanic(t *testing.T) {
 	got := TemplateString(str, testTemplateStringContext())
 
 	// THEN it should have panic'd at the compile and not reach this
-	t.Errorf("TemplateString didn't panic on invalid Jinja %q. Got %s", str, got)
+	t.Errorf("TemplateString didn't panic on invalid Jinja %q. Got %s",
+		str, got)
 }
 
 func TestTemplateStringJinjaVars(t *testing.T) {
@@ -66,7 +68,8 @@ func TestTemplateStringJinjaVars(t *testing.T) {
 
 	// THEN the string stays the same
 	if got != want {
-		t.Errorf("TemplateString didn't expand %q correctly! Got %q, want %q", str, got, want)
+		t.Errorf("TemplateString didn't expand %q correctly! Got %q, want %q",
+			str, got, want)
 	}
 }
 
@@ -80,7 +83,8 @@ func TestTemplateStringJinjaExpressions(t *testing.T) {
 
 	// THEN the string stays the same
 	if got != want {
-		t.Errorf("TemplateString didn't eval %q correctly! Got %q, want %q", str, got, want)
+		t.Errorf("TemplateString didn't eval %q correctly! Got %q, want %q",
+			str, got, want)
 	}
 }
 
@@ -94,20 +98,7 @@ func TestTemplateStringJinjaExpressionsAndVars(t *testing.T) {
 
 	// THEN the string stays the same
 	if got != want {
-		t.Errorf("TemplateString didn't eval %q correctly! Got %q, want %q", str, got, want)
+		t.Errorf("TemplateString didn't eval %q correctly! Got %q, want %q",
+			str, got, want)
 	}
 }
-
-// func TestTemplateStringExecutePanic(t *testing.T) {
-// 	// GIVEN a string with a jinja expression that will be much larger than the template
-// 	str := "a{% for i in range(10) %}hello123{% endfor %}"
-// 	str = "{% for i in 'abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz' %}abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz{% endfor %}"
-// 	// Turn off the panic.
-// 	defer func() { _ = recover() }()
-
-// 	// WHEN TemplateString is called
-// 	got := TemplateString(str, testTemplateStringContext())
-
-// 	// THEN it should have panic'd at the render and not reach this
-// 	t.Errorf("TemplateString didn't panic on template rendering too large %q. Got %s", str, got)
-// }

--- a/utils/util_test.go
+++ b/utils/util_test.go
@@ -35,7 +35,8 @@ func TestContainsTrue(t *testing.T) {
 
 	// THEN true is returned
 	if !found {
-		t.Errorf("%q couldn't be found in %v. But it is there!", want, lst)
+		t.Errorf("%q couldn't be found in %v. But it is there!",
+			want, lst)
 	}
 }
 
@@ -49,7 +50,8 @@ func TestContainsFalse(t *testing.T) {
 
 	// THEN true is returned
 	if found {
-		t.Errorf("%q shouldn't have been found in %v!", want, lst)
+		t.Errorf("%q shouldn't have been found in %v!",
+			want, lst)
 	}
 }
 
@@ -188,7 +190,8 @@ func TestDefaultIfNilWithNil(t *testing.T) {
 
 	// THEN the default of int (0) would be returned
 	if got != want {
-		t.Errorf("DefaultIfNil should have given %d but gave %d with a nil int pointer", want, got)
+		t.Errorf("DefaultIfNil should have given %d but gave %d with a nil int pointer",
+			want, got)
 	}
 }
 
@@ -201,7 +204,8 @@ func TestDefaultIfNilWithNonNil(t *testing.T) {
 
 	// THEN the default of int (0) would be returned
 	if got != value {
-		t.Errorf("DefaultIfNil should have given %d but gave %d with a nil int pointer", value, got)
+		t.Errorf("DefaultIfNil should have given %d but gave %d with a nil int pointer",
+			value, got)
 	}
 }
 
@@ -220,7 +224,8 @@ func TestGetFirstNonNilPtrWithAllNil(t *testing.T) {
 
 	// THEN nil should be returned
 	if got != want {
-		t.Errorf("GetFirstNonNilPtr was given a list of nil's which should have returned nil, but returned %v", *got)
+		t.Errorf("GetFirstNonNilPtr was given a list of nil's which should have returned nil, but returned %v",
+			*got)
 	}
 }
 
@@ -240,7 +245,8 @@ func TestGetFirstNonNilPtrWithNonANil(t *testing.T) {
 
 	// THEN nil should be returned
 	if *got != want {
-		t.Errorf("GetFirstNonNilPtr was given a list of string pointers and should have returned the first non-nil, %s", want)
+		t.Errorf("GetFirstNonNilPtr was given a list of string pointers and should have returned the first non-nil, %s",
+			want)
 	}
 }
 
@@ -259,7 +265,8 @@ func TestGetFirstNonDefaultWithAllDefault(t *testing.T) {
 
 	// THEN the default string should be returned
 	if got != want {
-		t.Errorf("GetFirstNonDefault should have returned the empty string when given a list of empty strings. Got %s", got)
+		t.Errorf("GetFirstNonDefault should have returned the empty string when given a list of empty strings. Got %s",
+			got)
 	}
 }
 
@@ -278,7 +285,8 @@ func TestGetFirstNonDefaultWithNonDefault(t *testing.T) {
 
 	// THEN the default string should be returned
 	if got != want {
-		t.Errorf("GetFirstNonDefault should have returned the first non-default (%s). Got %s", want, got)
+		t.Errorf("GetFirstNonDefault should have returned the first non-default (%s). Got %s",
+			want, got)
 	}
 }
 
@@ -425,7 +433,8 @@ func TestDefaultOrValueWithNil(t *testing.T) {
 
 	// THEN the default string is returned
 	if got != want {
-		t.Errorf("DefaultOrValue should have returned %q when used with a nil, not %q", want, got)
+		t.Errorf("DefaultOrValue should have returned %q when used with a nil, not %q",
+			want, got)
 	}
 }
 
@@ -439,7 +448,8 @@ func TestDefaultOrValueWithNonNil(t *testing.T) {
 
 	// THEN value is returned
 	if got != value {
-		t.Errorf("DefaultOrValue should have returned %q when used with a nil, not %q", value, got)
+		t.Errorf("DefaultOrValue should have returned %q when used with a nil, not %q",
+			value, got)
 	}
 }
 
@@ -453,7 +463,8 @@ func TestErrorToStringWithNil(t *testing.T) {
 
 	// THEN an empty string is returned
 	if got != want {
-		t.Errorf("ErrorToString should have returned %q, but got %q", want, got)
+		t.Errorf("ErrorToString should have returned %q, but got %q",
+			want, got)
 	}
 }
 
@@ -467,7 +478,8 @@ func TestErrorToStringWithErr(t *testing.T) {
 
 	// THEN an empty string is returned
 	if got != want {
-		t.Errorf("ErrorToString should have returned %q, but got %q", want, got)
+		t.Errorf("ErrorToString should have returned %q, but got %q",
+			want, got)
 	}
 }
 
@@ -483,7 +495,8 @@ func TestRandAlphaNumericLower(t *testing.T) {
 	regex := regexp.MustCompile(re)
 	match := regex.MatchString(got)
 	if !match {
-		t.Errorf("%q RegEx didn't match an alphanumeric produced from RandAlphaNumericLower. Got %q", re, got)
+		t.Errorf("%q RegEx didn't match an alphanumeric produced from RandAlphaNumericLower. Got %q",
+			re, got)
 	}
 }
 
@@ -499,7 +512,8 @@ func TestRandNumeric(t *testing.T) {
 	regex := regexp.MustCompile(re)
 	match := regex.MatchString(got)
 	if !match {
-		t.Errorf("%q RegEx didn't match a numeric produced from RandNumeric. Got %q", re, got)
+		t.Errorf("%q RegEx didn't match a numeric produced from RandNumeric. Got %q",
+			re, got)
 	}
 }
 
@@ -516,7 +530,8 @@ func TestRandString(t *testing.T) {
 	regex := regexp.MustCompile(re)
 	match := regex.MatchString(got)
 	if !match {
-		t.Errorf("%q RegEx didn't match a string produced from RandString. Got %q", re, got)
+		t.Errorf("%q RegEx didn't match a string produced from RandString. Got %q",
+			re, got)
 	}
 }
 
@@ -530,7 +545,8 @@ func TestNormaliseNewlinesMac(t *testing.T) {
 
 	// THEN the Mac newlines are normalised to \n
 	if string(got) != want {
-		t.Errorf("Mac newlines were not normalised from %q to %q. Got %q", str, want, string(got))
+		t.Errorf("Mac newlines were not normalised from %q to %q. Got %q",
+			str, want, string(got))
 	}
 }
 
@@ -544,7 +560,8 @@ func TestNormaliseNewlinesWindows(t *testing.T) {
 
 	// THEN the Windows newlines are normalised to \n
 	if string(got) != want {
-		t.Errorf("Windows newlines were not normalised from %q to %q. Got %q", str, want, string(got))
+		t.Errorf("Windows newlines were not normalised from %q to %q. Got %q",
+			str, want, string(got))
 	}
 }
 
@@ -561,11 +578,13 @@ func TestCopyMap(t *testing.T) {
 
 	// THEN the map is a copy of the original one
 	if len(copy) != len(original) {
-		t.Errorf("CopyMap did not return an identical copy, length differed. Got %v from %v", copy, original)
+		t.Errorf("CopyMap did not return an identical copy, length differed. Got %v from %v",
+			copy, original)
 	}
 	for key := range copy {
 		if original[key] != copy[key] {
-			t.Errorf("CopyMap did not return an identical copy, map differed. Got %v from %v", copy, original)
+			t.Errorf("CopyMap did not return an identical copy, map differed. Got %v from %v",
+				copy, original)
 		}
 	}
 	if &original == &copy {
@@ -583,7 +602,8 @@ func TestGetPortFromURLWithNoPortOrProto(t *testing.T) {
 
 	// THEN defaultPort is retunred
 	if got != defaultPort {
-		t.Errorf("GetPortFromURL shouldn't have found a port in %q. Got %q, want %q (defaultPort)", url, got, defaultPort)
+		t.Errorf("GetPortFromURL shouldn't have found a port in %q. Got %q, want %q (defaultPort)",
+			url, got, defaultPort)
 	}
 }
 
@@ -597,7 +617,8 @@ func TestGetPortFromURLWithPort(t *testing.T) {
 
 	// THEN defaultPort is retunred
 	if got != port {
-		t.Errorf("GetPortFromURL should have got the port from %q. Got %q, want %q", url, got, port)
+		t.Errorf("GetPortFromURL should have got the port from %q. Got %q, want %q",
+			url, got, port)
 	}
 }
 
@@ -612,7 +633,8 @@ func TestGetPortFromURLWithProtoAndPort(t *testing.T) {
 
 	// THEN the specified port is retunred
 	if got != port {
-		t.Errorf("GetPortFromURL should have got the port from %q. Got %q, want %q", url, got, port)
+		t.Errorf("GetPortFromURL should have got the port from %q. Got %q, want %q",
+			url, got, port)
 	}
 }
 
@@ -627,7 +649,8 @@ func TestGetPortFromURLWithProtoHTTP(t *testing.T) {
 
 	// THEN default protocol port is retunred
 	if got != want {
-		t.Errorf("GetPortFromURL should have got the port from the 'http://' in %q. Got %q, want %q", url, got, want)
+		t.Errorf("GetPortFromURL should have got the port from the 'http://' in %q. Got %q, want %q",
+			url, got, want)
 	}
 }
 
@@ -641,7 +664,8 @@ func TestGetPortFromURLWithProtoHTTPS(t *testing.T) {
 
 	// THEN defaultPort is retunred
 	if got != want {
-		t.Errorf("GetPortFromURL should have got the port from the 'https://' in %q. Got %q, want %q", url, got, want)
+		t.Errorf("GetPortFromURL should have got the port from the 'https://' in %q. Got %q, want %q",
+			url, got, want)
 	}
 }
 
@@ -659,7 +683,8 @@ func TestLowercaseStringStringMap(t *testing.T) {
 	for key := range got {
 		want := strings.ToLower(key)
 		if key != want {
-			t.Errorf("Keys were not lowercased, got %s, want %s", key, want)
+			t.Errorf("Keys were not lowercased, got %s, want %s",
+				key, want)
 		}
 	}
 }

--- a/web/api/v1/http_test.go
+++ b/web/api/v1/http_test.go
@@ -44,7 +44,8 @@ func TestHTTPVersion(t *testing.T) {
 	// THEN the version is returned in JSON format
 	data, err := ioutil.ReadAll(res.Body)
 	if err != nil {
-		t.Errorf("expected error to be nil got %v", err)
+		t.Errorf("expected error to be nil got %v",
+			err)
 	}
 	var got api_types.VersionAPI
 	json.Unmarshal(data, &got)

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -149,7 +149,8 @@ func connectToWebSocket(t *testing.T) *websocket.Conn {
 	// Connect to the server
 	ws, _, err := dialer.Dial(url, nil)
 	if err != nil {
-		t.Errorf("%v", err)
+		t.Errorf("%v",
+			err)
 	}
 	time.Sleep(time.Second)
 	return ws
@@ -167,7 +168,8 @@ func TestWebSocketInvalidJSON(t *testing.T) {
 	msg := `"version": 1, "key": "value", "key": "value"`
 	data, _ := json.Marshal(msg)
 	if err := ws.WriteMessage(websocket.TextMessage, data); err != nil {
-		t.Errorf("%v", err)
+		t.Errorf("%v",
+			err)
 	}
 	time.Sleep(time.Second)
 
@@ -194,7 +196,8 @@ func TestWebSocketClientMessageWithNoVersionKey(t *testing.T) {
 	msg := `"key": "value"`
 	data, _ := json.Marshal(msg)
 	if err := ws.WriteMessage(websocket.TextMessage, data); err != nil {
-		t.Errorf("%v", err)
+		t.Errorf("%v",
+			err)
 	}
 	time.Sleep(time.Second)
 
@@ -229,12 +232,14 @@ func TestWebSocketApprovalsINIT(t *testing.T) {
 
 	// THEN we get the expected responses
 	if err := ws.WriteMessage(websocket.TextMessage, data); err != nil {
-		t.Errorf("%v", err)
+		t.Errorf("%v",
+			err)
 	}
 	// ORDERING
 	_, p, err := ws.ReadMessage()
 	if err != nil {
-		t.Errorf("%v", err)
+		t.Errorf("%v",
+			err)
 	}
 	var receivedMsg api_types.WebSocketMessage
 	json.Unmarshal(p, &receivedMsg)
@@ -249,7 +254,8 @@ func TestWebSocketApprovalsINIT(t *testing.T) {
 		}
 		_, p, err = ws.ReadMessage()
 		if err != nil {
-			t.Errorf("%v", err)
+			t.Errorf("%v",
+				err)
 		}
 		json.Unmarshal(p, &receivedMsg)
 		if receivedMsg.ServiceData == nil {
@@ -282,7 +288,8 @@ func TestWebSocketApprovalsWithNilService(t *testing.T) {
 	}
 	data, _ := json.Marshal(msg)
 	if err := ws.WriteMessage(websocket.TextMessage, data); err != nil {
-		t.Errorf("%v", err)
+		t.Errorf("%v",
+			err)
 	}
 	time.Sleep(time.Second)
 
@@ -292,7 +299,8 @@ func TestWebSocketApprovalsWithNilService(t *testing.T) {
 	var receivedMsg api_types.WebSocketMessage
 	json.Unmarshal(p, &receivedMsg)
 	if err != nil {
-		t.Errorf("%v", err)
+		t.Errorf("%v",
+			err)
 	} else if receivedMsg.Order == nil ||
 		len(*receivedMsg.Order) == 0 {
 		order := "[]"
@@ -336,19 +344,22 @@ func TestWebSocketApprovalsVersion(t *testing.T) {
 	}
 	data, _ := json.Marshal(msg)
 	if err := ws.WriteMessage(websocket.TextMessage, data); err != nil {
-		t.Errorf("%v", err)
+		t.Errorf("%v",
+			err)
 	}
 
 	// THEN we receive a response acknowledging it
 	_, p, err := ws.ReadMessage()
 	if err != nil {
-		t.Errorf("%v", err)
+		t.Errorf("%v",
+			err)
 	}
 	var receivedMsg api_types.WebSocketMessage
 	json.Unmarshal(p, &receivedMsg)
 	if !strings.HasPrefix(receivedMsg.ServiceData.Status.ApprovedVersion,
 		"SKIP_"+cfg.Service["test"].Status.LatestVersion) {
-		t.Errorf("LatestVersion wasn't skipped?\n%v", string(p))
+		t.Errorf("LatestVersion wasn't skipped?\n%v",
+			string(p))
 	}
 }
 
@@ -384,7 +395,8 @@ func TestWebSocketApprovalsVersionWithNoServiceID(t *testing.T) {
 	}
 	data, _ := json.Marshal(msg)
 	if err := ws.WriteMessage(websocket.TextMessage, data); err != nil {
-		t.Errorf("%v", err)
+		t.Errorf("%v",
+			err)
 	}
 	time.Sleep(time.Second)
 
@@ -431,7 +443,8 @@ func TestWebSocketApprovalsVersionWithNoTarget(t *testing.T) {
 	}
 	data, _ := json.Marshal(msg)
 	if err := ws.WriteMessage(websocket.TextMessage, data); err != nil {
-		t.Errorf("%v", err)
+		t.Errorf("%v",
+			err)
 	}
 	time.Sleep(time.Second)
 
@@ -480,7 +493,8 @@ func TestWebSocketApprovalsVersionWithInvalidServiceID(t *testing.T) {
 	}
 	data, _ := json.Marshal(msg)
 	if err := ws.WriteMessage(websocket.TextMessage, data); err != nil {
-		t.Errorf("%v", err)
+		t.Errorf("%v",
+			err)
 	}
 	time.Sleep(time.Second)
 
@@ -535,7 +549,8 @@ func TestWebSocketApprovalsVersionWithNoCommandsOrWebHooks(t *testing.T) {
 	}
 	data, _ := json.Marshal(msg)
 	if err := ws.WriteMessage(websocket.TextMessage, data); err != nil {
-		t.Errorf("%v", err)
+		t.Errorf("%v",
+			err)
 	}
 	time.Sleep(time.Second)
 
@@ -592,7 +607,8 @@ func TestWebSocketApprovalsVersionWithArgusFailedAndFailedCommandThatWillPass(t 
 	}
 	data, _ := json.Marshal(msg)
 	if err := ws.WriteMessage(websocket.TextMessage, data); err != nil {
-		t.Errorf("%v", err)
+		t.Errorf("%v",
+			err)
 	}
 	time.Sleep(2 * time.Second)
 
@@ -646,7 +662,8 @@ func TestWebSocketApprovalsVersionWithSpecificCommandThatIsOnlyFailedDidUpdateLa
 	}
 	data, _ := json.Marshal(msg)
 	if err := ws.WriteMessage(websocket.TextMessage, data); err != nil {
-		t.Errorf("%v", err)
+		t.Errorf("%v",
+			err)
 	}
 	time.Sleep(time.Second)
 
@@ -702,7 +719,8 @@ func TestWebSocketApprovalsVersionWithSpecificCommandThatIsOnlyFailedDidAnnounce
 	}
 	data, _ := json.Marshal(msg)
 	if err := ws.WriteMessage(websocket.TextMessage, data); err != nil {
-		t.Errorf("%v", err)
+		t.Errorf("%v",
+			err)
 	}
 	time.Sleep(time.Second)
 
@@ -710,7 +728,8 @@ func TestWebSocketApprovalsVersionWithSpecificCommandThatIsOnlyFailedDidAnnounce
 	// EVENT
 	_, p, err := ws.ReadMessage()
 	if err != nil {
-		t.Errorf("%v", err)
+		t.Errorf("%v",
+			err)
 	}
 	var receivedMsg api_types.WebSocketMessage
 	json.Unmarshal(p, &receivedMsg)
@@ -726,7 +745,8 @@ func TestWebSocketApprovalsVersionWithSpecificCommandThatIsOnlyFailedDidAnnounce
 	// VERSION
 	_, p, err = ws.ReadMessage()
 	if err != nil {
-		t.Errorf("%v", err)
+		t.Errorf("%v",
+			err)
 	}
 	receivedMsg = api_types.WebSocketMessage{}
 	json.Unmarshal(p, &receivedMsg)
@@ -785,14 +805,16 @@ func TestWebSocketApprovalsVersionWithSpecificCommandThatIsNotOnlyFailedDidntAnn
 	}
 	data, _ := json.Marshal(msg)
 	if err := ws.WriteMessage(websocket.TextMessage, data); err != nil {
-		t.Errorf("%v", err)
+		t.Errorf("%v",
+			err)
 	}
 	time.Sleep(time.Second)
 
 	// THEN it passes and we receive a response acknowledging it with no change in DeployedVersion
 	_, p, err := ws.ReadMessage()
 	if err != nil {
-		t.Errorf("%v", err)
+		t.Errorf("%v",
+			err)
 	}
 	var receivedMsg api_types.WebSocketMessage
 	json.Unmarshal(p, &receivedMsg)
@@ -852,7 +874,8 @@ func TestWebSocketApprovalsVersionWithSpecificCommandThatIsNotOnlyFailedDidntUpd
 	}
 	data, _ := json.Marshal(msg)
 	if err := ws.WriteMessage(websocket.TextMessage, data); err != nil {
-		t.Errorf("%v", err)
+		t.Errorf("%v",
+			err)
 	}
 	time.Sleep(time.Second)
 
@@ -913,7 +936,8 @@ func TestWebSocketApprovalsVersionWithSpecificWebHookThatIsOnlyFailedDidAnnounce
 	}
 	data, _ := json.Marshal(msg)
 	if err := ws.WriteMessage(websocket.TextMessage, data); err != nil {
-		t.Errorf("%v", err)
+		t.Errorf("%v",
+			err)
 	}
 	time.Sleep(time.Second)
 
@@ -921,7 +945,8 @@ func TestWebSocketApprovalsVersionWithSpecificWebHookThatIsOnlyFailedDidAnnounce
 	// EVENT
 	_, p, err := ws.ReadMessage()
 	if err != nil {
-		t.Errorf("%v", err)
+		t.Errorf("%v",
+			err)
 	}
 	var receivedMsg api_types.WebSocketMessage
 	json.Unmarshal(p, &receivedMsg)
@@ -937,7 +962,8 @@ func TestWebSocketApprovalsVersionWithSpecificWebHookThatIsOnlyFailedDidAnnounce
 	// VERSION
 	_, p, err = ws.ReadMessage()
 	if err != nil {
-		t.Errorf("%v", err)
+		t.Errorf("%v",
+			err)
 	}
 	receivedMsg = api_types.WebSocketMessage{}
 	json.Unmarshal(p, &receivedMsg)
@@ -1001,14 +1027,16 @@ func TestWebSocketApprovalsVersionWithSpecificWebHookThatIsNotOnlyFailedDidAnnou
 	}
 	data, _ := json.Marshal(msg)
 	if err := ws.WriteMessage(websocket.TextMessage, data); err != nil {
-		t.Errorf("%v", err)
+		t.Errorf("%v",
+			err)
 	}
 	time.Sleep(time.Second)
 
 	// THEN it passes and we receive a response acknowledging it with no change in DeployedVersion
 	_, p, err := ws.ReadMessage()
 	if err != nil {
-		t.Errorf("%v", err)
+		t.Errorf("%v",
+			err)
 	}
 	var receivedMsg api_types.WebSocketMessage
 	json.Unmarshal(p, &receivedMsg)
@@ -1073,7 +1101,8 @@ func TestWebSocketApprovalsVersionWithSpecificWebHookThatIsNotOnlyFailedDidntUpd
 	}
 	data, _ := json.Marshal(msg)
 	if err := ws.WriteMessage(websocket.TextMessage, data); err != nil {
-		t.Errorf("%v", err)
+		t.Errorf("%v",
+			err)
 	}
 	time.Sleep(time.Second)
 
@@ -1108,7 +1137,8 @@ func TestWebSocketApprovalsActionsWithNoServiceID(t *testing.T) {
 	}
 	data, _ := json.Marshal(msg)
 	if err := ws.WriteMessage(websocket.TextMessage, data); err != nil {
-		t.Errorf("%v", err)
+		t.Errorf("%v",
+			err)
 	}
 	time.Sleep(time.Second)
 
@@ -1149,7 +1179,8 @@ func TestWebSocketApprovalsActionsWithUnknownServiceID(t *testing.T) {
 	}
 	data, _ := json.Marshal(msg)
 	if err := ws.WriteMessage(websocket.TextMessage, data); err != nil {
-		t.Errorf("%v", err)
+		t.Errorf("%v",
+			err)
 	}
 	time.Sleep(time.Second)
 
@@ -1199,14 +1230,16 @@ func TestWebSocketApprovalsActionsWithNoWebHook(t *testing.T) {
 	}
 	data, _ := json.Marshal(msg)
 	if err := ws.WriteMessage(websocket.TextMessage, data); err != nil {
-		t.Errorf("%v", err)
+		t.Errorf("%v",
+			err)
 	}
 	time.Sleep(time.Second)
 
 	// THEN it passes and we only receive a response with the WebHooks
 	_, p, err := ws.ReadMessage()
 	if err != nil {
-		t.Errorf("%v", err)
+		t.Errorf("%v",
+			err)
 	}
 	var receivedMsg api_types.WebSocketMessage
 	json.Unmarshal(p, &receivedMsg)
@@ -1257,14 +1290,16 @@ func TestWebSocketApprovalsActionsWithNoCommandController(t *testing.T) {
 	}
 	data, _ := json.Marshal(msg)
 	if err := ws.WriteMessage(websocket.TextMessage, data); err != nil {
-		t.Errorf("%v", err)
+		t.Errorf("%v",
+			err)
 	}
 	time.Sleep(time.Second)
 
 	// THEN it passes and we only receive a response with the WebHooks
 	_, p, err := ws.ReadMessage()
 	if err != nil {
-		t.Errorf("%v", err)
+		t.Errorf("%v",
+			err)
 	}
 	var receivedMsg api_types.WebSocketMessage
 	json.Unmarshal(p, &receivedMsg)
@@ -1300,14 +1335,16 @@ func TestWebSocketApprovalsActions(t *testing.T) {
 	}
 	data, _ := json.Marshal(msg)
 	if err := ws.WriteMessage(websocket.TextMessage, data); err != nil {
-		t.Errorf("%v", err)
+		t.Errorf("%v",
+			err)
 	}
 
 	// THEN we receive a response acknowledging it
 	// WEBHOOK
 	_, p, err := ws.ReadMessage()
 	if err != nil {
-		t.Errorf("%v", err)
+		t.Errorf("%v",
+			err)
 	}
 	var receivedMsg api_types.WebSocketMessage
 	json.Unmarshal(p, &receivedMsg)
@@ -1322,7 +1359,8 @@ func TestWebSocketApprovalsActions(t *testing.T) {
 	// COMMAND
 	_, p, err = ws.ReadMessage()
 	if err != nil {
-		t.Errorf("%v", err)
+		t.Errorf("%v",
+			err)
 	}
 	receivedMsg = api_types.WebSocketMessage{}
 	json.Unmarshal(p, &receivedMsg)
@@ -1358,7 +1396,8 @@ func TestWebSocketApprovalsUnknownType(t *testing.T) {
 	}
 	data, _ := json.Marshal(msg)
 	if err := ws.WriteMessage(websocket.TextMessage, data); err != nil {
-		t.Errorf("%v", err)
+		t.Errorf("%v",
+			err)
 	}
 	time.Sleep(time.Second)
 
@@ -1391,14 +1430,16 @@ func TestWebSocketRuntimeBuildInit(t *testing.T) {
 	}
 	data, _ := json.Marshal(msg)
 	if err := ws.WriteMessage(websocket.TextMessage, data); err != nil {
-		t.Errorf("%v", err)
+		t.Errorf("%v",
+			err)
 	}
 	time.Sleep(time.Second)
 
 	// THEN it passes and we only receive a response with the WebHooks
 	_, p, err := ws.ReadMessage()
 	if err != nil {
-		t.Errorf("%v", err)
+		t.Errorf("%v",
+			err)
 	}
 	var receivedMsg api_types.WebSocketMessage
 	json.Unmarshal(p, &receivedMsg)
@@ -1437,7 +1478,8 @@ func TestWebSocketRuntimeBuildUnknownType(t *testing.T) {
 	}
 	data, _ := json.Marshal(msg)
 	if err := ws.WriteMessage(websocket.TextMessage, data); err != nil {
-		t.Errorf("%v", err)
+		t.Errorf("%v",
+			err)
 	}
 	time.Sleep(time.Second)
 
@@ -1470,14 +1512,16 @@ func TestWebSocketFlagsInit(t *testing.T) {
 	}
 	data, _ := json.Marshal(msg)
 	if err := ws.WriteMessage(websocket.TextMessage, data); err != nil {
-		t.Errorf("%v", err)
+		t.Errorf("%v",
+			err)
 	}
 	time.Sleep(time.Second)
 
 	// THEN it passes and we only receive a response with the WebHooks
 	_, p, err := ws.ReadMessage()
 	if err != nil {
-		t.Errorf("%v", err)
+		t.Errorf("%v",
+			err)
 	}
 	var receivedMsg api_types.WebSocketMessage
 	json.Unmarshal(p, &receivedMsg)
@@ -1516,7 +1560,8 @@ func TestWebSocketFlagsUnknownType(t *testing.T) {
 	}
 	data, _ := json.Marshal(msg)
 	if err := ws.WriteMessage(websocket.TextMessage, data); err != nil {
-		t.Errorf("%v", err)
+		t.Errorf("%v",
+			err)
 	}
 	time.Sleep(time.Second)
 
@@ -1549,7 +1594,8 @@ func TestWebSocketConfigInitSettings(t *testing.T) {
 	}
 	data, _ := json.Marshal(msg)
 	if err := ws.WriteMessage(websocket.TextMessage, data); err != nil {
-		t.Errorf("%v", err)
+		t.Errorf("%v",
+			err)
 	}
 	time.Sleep(time.Second)
 
@@ -1557,7 +1603,8 @@ func TestWebSocketConfigInitSettings(t *testing.T) {
 	{ // SETTINGS
 		_, p, err := ws.ReadMessage()
 		if err != nil {
-			t.Errorf("%v", err)
+			t.Errorf("%v",
+				err)
 		}
 		var receivedMsg api_types.WebSocketMessage
 		json.Unmarshal(p, &receivedMsg)
@@ -1606,7 +1653,8 @@ func TestWebSocketConfigUnknownType(t *testing.T) {
 	}
 	data, _ := json.Marshal(msg)
 	if err := ws.WriteMessage(websocket.TextMessage, data); err != nil {
-		t.Errorf("%v", err)
+		t.Errorf("%v",
+			err)
 	}
 	time.Sleep(time.Second)
 
@@ -1639,7 +1687,8 @@ func TestWebSocketConfigInitDefaults(t *testing.T) {
 	}
 	data, _ := json.Marshal(msg)
 	if err := ws.WriteMessage(websocket.TextMessage, data); err != nil {
-		t.Errorf("%v", err)
+		t.Errorf("%v",
+			err)
 	}
 	time.Sleep(time.Second)
 
@@ -1650,7 +1699,8 @@ func TestWebSocketConfigInitDefaults(t *testing.T) {
 	{ // DEFAULTS
 		_, p, err := ws.ReadMessage()
 		if err != nil {
-			t.Errorf("%v", err)
+			t.Errorf("%v",
+				err)
 		}
 		receivedMsg := api_types.WebSocketMessage{}
 		json.Unmarshal(p, &receivedMsg)
@@ -1691,7 +1741,8 @@ func TestWebSocketConfigInitNotify(t *testing.T) {
 	}
 	data, _ := json.Marshal(msg)
 	if err := ws.WriteMessage(websocket.TextMessage, data); err != nil {
-		t.Errorf("%v", err)
+		t.Errorf("%v",
+			err)
 	}
 	time.Sleep(time.Second)
 
@@ -1705,7 +1756,8 @@ func TestWebSocketConfigInitNotify(t *testing.T) {
 	{ // NOTIFY
 		_, p, err := ws.ReadMessage()
 		if err != nil {
-			t.Errorf("%v", err)
+			t.Errorf("%v",
+				err)
 		}
 		receivedMsg := api_types.WebSocketMessage{}
 		json.Unmarshal(p, &receivedMsg)
@@ -1746,7 +1798,8 @@ func TestWebSocketConfigInitWebHook(t *testing.T) {
 	}
 	data, _ := json.Marshal(msg)
 	if err := ws.WriteMessage(websocket.TextMessage, data); err != nil {
-		t.Errorf("%v", err)
+		t.Errorf("%v",
+			err)
 	}
 	time.Sleep(time.Second)
 
@@ -1763,7 +1816,8 @@ func TestWebSocketConfigInitWebHook(t *testing.T) {
 	{ // WEBHOOK
 		_, p, err := ws.ReadMessage()
 		if err != nil {
-			t.Errorf("%v", err)
+			t.Errorf("%v",
+				err)
 		}
 		receivedMsg := api_types.WebSocketMessage{}
 		json.Unmarshal(p, &receivedMsg)
@@ -1804,7 +1858,8 @@ func TestWebSocketConfigInitServiceData(t *testing.T) {
 	}
 	data, _ := json.Marshal(msg)
 	if err := ws.WriteMessage(websocket.TextMessage, data); err != nil {
-		t.Errorf("%v", err)
+		t.Errorf("%v",
+			err)
 	}
 	time.Sleep(time.Second)
 
@@ -1824,7 +1879,8 @@ func TestWebSocketConfigInitServiceData(t *testing.T) {
 	{ // SERVICE
 		_, p, err := ws.ReadMessage()
 		if err != nil {
-			t.Errorf("%v", err)
+			t.Errorf("%v",
+				err)
 		}
 		receivedMsg := api_types.WebSocketMessage{}
 		json.Unmarshal(p, &receivedMsg)
@@ -1862,7 +1918,8 @@ func TestWebSocketConfigInitServiceService(t *testing.T) {
 	}
 	data, _ := json.Marshal(msg)
 	if err := ws.WriteMessage(websocket.TextMessage, data); err != nil {
-		t.Errorf("%v", err)
+		t.Errorf("%v",
+			err)
 	}
 	time.Sleep(time.Second)
 
@@ -1882,7 +1939,8 @@ func TestWebSocketConfigInitServiceService(t *testing.T) {
 	{ // SERVICE
 		_, p, err := ws.ReadMessage()
 		if err != nil {
-			t.Errorf("%v", err)
+			t.Errorf("%v",
+				err)
 		}
 		receivedMsg := api_types.WebSocketMessage{}
 		json.Unmarshal(p, &receivedMsg)
@@ -1934,7 +1992,8 @@ func TestWebSocketConfigInitServiceDeployedVersion(t *testing.T) {
 	}
 	data, _ := json.Marshal(msg)
 	if err := ws.WriteMessage(websocket.TextMessage, data); err != nil {
-		t.Errorf("%v", err)
+		t.Errorf("%v",
+			err)
 	}
 	time.Sleep(time.Second)
 
@@ -1954,7 +2013,8 @@ func TestWebSocketConfigInitServiceDeployedVersion(t *testing.T) {
 	{ // SERVICE
 		_, p, err := ws.ReadMessage()
 		if err != nil {
-			t.Errorf("%v", err)
+			t.Errorf("%v",
+				err)
 		}
 		receivedMsg := api_types.WebSocketMessage{}
 		json.Unmarshal(p, &receivedMsg)
@@ -2009,7 +2069,8 @@ func TestWebSocketConfigInitServiceServiceURLCommands(t *testing.T) {
 	}
 	data, _ := json.Marshal(msg)
 	if err := ws.WriteMessage(websocket.TextMessage, data); err != nil {
-		t.Errorf("%v", err)
+		t.Errorf("%v",
+			err)
 	}
 	time.Sleep(time.Second)
 
@@ -2029,7 +2090,8 @@ func TestWebSocketConfigInitServiceServiceURLCommands(t *testing.T) {
 	{ // SERVICE
 		_, p, err := ws.ReadMessage()
 		if err != nil {
-			t.Errorf("%v", err)
+			t.Errorf("%v",
+				err)
 		}
 		receivedMsg := api_types.WebSocketMessage{}
 		json.Unmarshal(p, &receivedMsg)
@@ -2067,7 +2129,8 @@ func TestWebSocketConfigInitServiceServiceNotify(t *testing.T) {
 	}
 	data, _ := json.Marshal(msg)
 	if err := ws.WriteMessage(websocket.TextMessage, data); err != nil {
-		t.Errorf("%v", err)
+		t.Errorf("%v",
+			err)
 	}
 	time.Sleep(time.Second)
 
@@ -2087,7 +2150,8 @@ func TestWebSocketConfigInitServiceServiceNotify(t *testing.T) {
 	{ // SERVICE
 		_, p, err := ws.ReadMessage()
 		if err != nil {
-			t.Errorf("%v", err)
+			t.Errorf("%v",
+				err)
 		}
 		receivedMsg := api_types.WebSocketMessage{}
 		json.Unmarshal(p, &receivedMsg)
@@ -2125,7 +2189,8 @@ func TestWebSocketConfigInitServiceServiceWebhook(t *testing.T) {
 	}
 	data, _ := json.Marshal(msg)
 	if err := ws.WriteMessage(websocket.TextMessage, data); err != nil {
-		t.Errorf("%v", err)
+		t.Errorf("%v",
+			err)
 	}
 	time.Sleep(time.Second)
 
@@ -2145,7 +2210,8 @@ func TestWebSocketConfigInitServiceServiceWebhook(t *testing.T) {
 	{ // SERVICE
 		_, p, err := ws.ReadMessage()
 		if err != nil {
-			t.Errorf("%v", err)
+			t.Errorf("%v",
+				err)
 		}
 		receivedMsg := api_types.WebSocketMessage{}
 		json.Unmarshal(p, &receivedMsg)
@@ -2183,7 +2249,8 @@ func TestWebSocketConfigInitServiceCommand(t *testing.T) {
 	}
 	data, _ := json.Marshal(msg)
 	if err := ws.WriteMessage(websocket.TextMessage, data); err != nil {
-		t.Errorf("%v", err)
+		t.Errorf("%v",
+			err)
 	}
 	time.Sleep(time.Second)
 
@@ -2203,7 +2270,8 @@ func TestWebSocketConfigInitServiceCommand(t *testing.T) {
 	{ // SERVICE
 		_, p, err := ws.ReadMessage()
 		if err != nil {
-			t.Errorf("%v", err)
+			t.Errorf("%v",
+				err)
 		}
 		receivedMsg := api_types.WebSocketMessage{}
 		json.Unmarshal(p, &receivedMsg)
@@ -2245,7 +2313,8 @@ func TestWebSocketUnknownPage(t *testing.T) {
 	}
 	data, _ := json.Marshal(msg)
 	if err := ws.WriteMessage(websocket.TextMessage, data); err != nil {
-		t.Errorf("%v", err)
+		t.Errorf("%v",
+			err)
 	}
 	time.Sleep(time.Second)
 

--- a/webhook/announce_test.go
+++ b/webhook/announce_test.go
@@ -56,6 +56,7 @@ func TestAnnounceSendWithChannel(t *testing.T) {
 	var unmarshalled api_types.WebSocketMessage
 	json.Unmarshal(msg, &unmarshalled)
 	if *unmarshalled.WebHookData["test"].Failed != whFailed {
-		t.Errorf("AnnounceSend should have given %v Failed, but got \n%v", whFailed, unmarshalled)
+		t.Errorf("AnnounceSend should have given %v Failed, but got \n%v",
+			whFailed, unmarshalled)
 	}
 }

--- a/webhook/github_test.go
+++ b/webhook/github_test.go
@@ -35,7 +35,8 @@ func TestSetCustomHeadersNil(t *testing.T) {
 	// GIVEN CustomHeaders are nil
 	req, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
 	if err != nil {
-		t.Errorf("http.NewRequest failed - %s", err.Error())
+		t.Errorf("http.NewRequest failed - %s",
+			err.Error())
 	}
 	webhook := WebHook{CustomHeaders: nil}
 	// WHEN SetCustomHeaders is called
@@ -44,7 +45,8 @@ func TestSetCustomHeadersNil(t *testing.T) {
 	want := 0
 	got := len(req.Header)
 	if got != want {
-		t.Errorf("SetCustomHeaders of nil altered the Header count. Want nil, got %v", got)
+		t.Errorf("SetCustomHeaders of nil altered the Header count. Want nil, got %v",
+			got)
 	}
 }
 
@@ -52,7 +54,8 @@ func TestSetCustomHeadersWithJinjaTemplate(t *testing.T) {
 	// GIVEN CustomHeaders contain a Jinja template
 	req, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
 	if err != nil {
-		t.Errorf("http.NewRequest failed - %s", err.Error())
+		t.Errorf("http.NewRequest failed - %s",
+			err.Error())
 	}
 	webhook := WebHook{
 		CustomHeaders: &map[string]string{
@@ -68,7 +71,8 @@ func TestSetCustomHeadersWithJinjaTemplate(t *testing.T) {
 	got := req.Header["Jinja-Expression"]
 	want := "bang 1.2.3 bang"
 	if len(got) == 1 && got[0] != want {
-		t.Errorf("Pongo2 template not evaluated correctly. Want %q, got %q", want, got[0])
+		t.Errorf("Pongo2 template not evaluated correctly. Want %q, got %q",
+			want, got[0])
 	}
 }
 
@@ -77,7 +81,8 @@ func TestSetGitHubHeadersXGithubEvent(t *testing.T) {
 	secret := "secret"
 	req, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
 	if err != nil {
-		t.Errorf("http.NewRequest failed - %s", err.Error())
+		t.Errorf("http.NewRequest failed - %s",
+			err.Error())
 	}
 	payload, err := json.Marshal(GitHub{
 		Ref:    "refs/heads/master",
@@ -85,7 +90,8 @@ func TestSetGitHubHeadersXGithubEvent(t *testing.T) {
 		After:  "0123456789012345678901234567890123456789",
 	})
 	if err != nil {
-		t.Errorf("json.Marshal failed - %s", err.Error())
+		t.Errorf("json.Marshal failed - %s",
+			err.Error())
 	}
 
 	// WHEN SetGitHubHeaders is called
@@ -96,7 +102,8 @@ func TestSetGitHubHeadersXGithubEvent(t *testing.T) {
 	want := "push"
 
 	if req.Header[key][0] != want {
-		t.Errorf("%s - Wanted %s, got %s", key, want, req.Header[key][0])
+		t.Errorf("%s - Wanted %s, got %s",
+			key, want, req.Header[key][0])
 	}
 }
 
@@ -105,7 +112,8 @@ func TestSetGitHubHeadersXGithubHookInstallationTargetType(t *testing.T) {
 	secret := "secret"
 	req, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
 	if err != nil {
-		t.Errorf("http.NewRequest failed - %s", err.Error())
+		t.Errorf("http.NewRequest failed - %s",
+			err.Error())
 	}
 	payload, err := json.Marshal(GitHub{
 		Ref:    "refs/heads/master",
@@ -113,7 +121,8 @@ func TestSetGitHubHeadersXGithubHookInstallationTargetType(t *testing.T) {
 		After:  "0123456789012345678901234567890123456789",
 	})
 	if err != nil {
-		t.Errorf("json.Marshal failed - %s", err.Error())
+		t.Errorf("json.Marshal failed - %s",
+			err.Error())
 	}
 
 	// WHEN SetGitHubHeaders is called
@@ -124,7 +133,8 @@ func TestSetGitHubHeadersXGithubHookInstallationTargetType(t *testing.T) {
 	want := "repository"
 
 	if req.Header[key][0] != want {
-		t.Errorf("%s - Wanted %s, got %s", key, want, req.Header[key][0])
+		t.Errorf("%s - Wanted %s, got %s",
+			key, want, req.Header[key][0])
 	}
 }
 
@@ -133,7 +143,8 @@ func TestSetGitHubHeadersXGithubHookId(t *testing.T) {
 	secret := "secret"
 	req, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
 	if err != nil {
-		t.Errorf("http.NewRequest failed - %s", err.Error())
+		t.Errorf("http.NewRequest failed - %s",
+			err.Error())
 	}
 	payload, err := json.Marshal(GitHub{
 		Ref:    "refs/heads/master",
@@ -141,7 +152,8 @@ func TestSetGitHubHeadersXGithubHookId(t *testing.T) {
 		After:  "0123456789012345678901234567890123456789",
 	})
 	if err != nil {
-		t.Errorf("json.Marshal failed - %s", err.Error())
+		t.Errorf("json.Marshal failed - %s",
+			err.Error())
 	}
 
 	// WHEN SetGitHubHeaders is called
@@ -151,7 +163,8 @@ func TestSetGitHubHeadersXGithubHookId(t *testing.T) {
 	regex := "^[0-9]{9}$"
 	key := "X-Github-Hook-Id"
 	if match, _ := regexp.MatchString(regex, req.Header[key][0]); !match {
-		t.Errorf("%s - Wanted %s, got %s", key, regex, req.Header[key][0])
+		t.Errorf("%s - Wanted %s, got %s",
+			key, regex, req.Header[key][0])
 	}
 }
 
@@ -160,7 +173,8 @@ func TestSetGitHubHeadersXGithubDelivery(t *testing.T) {
 	secret := "secret"
 	req, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
 	if err != nil {
-		t.Errorf("http.NewRequest failed - %s", err.Error())
+		t.Errorf("http.NewRequest failed - %s",
+			err.Error())
 	}
 	payload, err := json.Marshal(GitHub{
 		Ref:    "refs/heads/master",
@@ -168,7 +182,8 @@ func TestSetGitHubHeadersXGithubDelivery(t *testing.T) {
 		After:  "0123456789012345678901234567890123456789",
 	})
 	if err != nil {
-		t.Errorf("json.Marshal failed - %s", err.Error())
+		t.Errorf("json.Marshal failed - %s",
+			err.Error())
 	}
 
 	// WHEN SetGitHubHeaders is called
@@ -178,7 +193,8 @@ func TestSetGitHubHeadersXGithubDelivery(t *testing.T) {
 	regex := "^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$"
 	key := "X-Github-Delivery"
 	if match, _ := regexp.MatchString(regex, req.Header[key][0]); !match {
-		t.Errorf("%s - Wanted %s, got %s", key, regex, req.Header[key][0])
+		t.Errorf("%s - Wanted %s, got %s",
+			key, regex, req.Header[key][0])
 	}
 }
 
@@ -187,7 +203,8 @@ func TestSetGitHubHeadersXGithubHookInstallationTargetId(t *testing.T) {
 	secret := "secret"
 	req, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
 	if err != nil {
-		t.Errorf("http.NewRequest failed - %s", err.Error())
+		t.Errorf("http.NewRequest failed - %s",
+			err.Error())
 	}
 	payload, err := json.Marshal(GitHub{
 		Ref:    "refs/heads/master",
@@ -195,7 +212,8 @@ func TestSetGitHubHeadersXGithubHookInstallationTargetId(t *testing.T) {
 		After:  "0123456789012345678901234567890123456789",
 	})
 	if err != nil {
-		t.Errorf("json.Marshal failed - %s", err.Error())
+		t.Errorf("json.Marshal failed - %s",
+			err.Error())
 	}
 
 	// WHEN SetGitHubHeaders is called
@@ -205,7 +223,8 @@ func TestSetGitHubHeadersXGithubHookInstallationTargetId(t *testing.T) {
 	regex := "^[0-9]{9}$"
 	key := "X-Github-Hook-Installation-Target-Id"
 	if match, _ := regexp.MatchString(regex, req.Header[key][0]); !match {
-		t.Errorf("%s - Wanted %s, got %s", key, regex, req.Header[key][0])
+		t.Errorf("%s - Wanted %s, got %s",
+			key, regex, req.Header[key][0])
 	}
 }
 
@@ -214,7 +233,8 @@ func TestSetGitHubHeadersXHubSignature256(t *testing.T) {
 	secret := "secret"
 	req, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
 	if err != nil {
-		t.Errorf("http.NewRequest failed - %s", err.Error())
+		t.Errorf("http.NewRequest failed - %s",
+			err.Error())
 	}
 	payload, err := json.Marshal(GitHub{
 		Ref:    "refs/heads/master",
@@ -222,7 +242,8 @@ func TestSetGitHubHeadersXHubSignature256(t *testing.T) {
 		After:  "0123456789012345678901234567890123456789",
 	})
 	if err != nil {
-		t.Errorf("json.Marshal failed - %s", err.Error())
+		t.Errorf("json.Marshal failed - %s",
+			err.Error())
 	}
 
 	// WHEN SetGitHubHeaders is called
@@ -235,7 +256,8 @@ func TestSetGitHubHeadersXHubSignature256(t *testing.T) {
 	wantVal := hex.EncodeToString(hash.Sum(nil))
 	want := "sha256=" + wantVal
 	if req.Header[key][0] != "sha256="+wantVal {
-		t.Errorf("%s - Wanted %s, got %s", key, want, req.Header[key][0])
+		t.Errorf("%s - Wanted %s, got %s",
+			key, want, req.Header[key][0])
 	}
 }
 
@@ -244,7 +266,8 @@ func TestSetGitHubHeadersXHubSignature(t *testing.T) {
 	secret := "secret"
 	req, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
 	if err != nil {
-		t.Errorf("http.NewRequest failed - %s", err.Error())
+		t.Errorf("http.NewRequest failed - %s",
+			err.Error())
 	}
 	payload, err := json.Marshal(GitHub{
 		Ref:    "refs/heads/master",
@@ -252,7 +275,8 @@ func TestSetGitHubHeadersXHubSignature(t *testing.T) {
 		After:  "0123456789012345678901234567890123456789",
 	})
 	if err != nil {
-		t.Errorf("json.Marshal failed - %s", err.Error())
+		t.Errorf("json.Marshal failed - %s",
+			err.Error())
 	}
 
 	// WHEN SetGitHubHeaders is called
@@ -265,6 +289,7 @@ func TestSetGitHubHeadersXHubSignature(t *testing.T) {
 	wantVal := hex.EncodeToString(hash.Sum(nil))
 	want := "sha1=" + wantVal
 	if req.Header[key][0] != want {
-		t.Errorf("%s - Wanted %s, got %s", key, want, req.Header[key][0])
+		t.Errorf("%s - Wanted %s, got %s",
+			key, want, req.Header[key][0])
 	}
 }

--- a/webhook/gitlab_test.go
+++ b/webhook/gitlab_test.go
@@ -25,7 +25,8 @@ func TestSetGitLabParameterWithoutQueryParams(t *testing.T) {
 	// GIVEN a URL without query params
 	req, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
 	if err != nil {
-		t.Errorf("http.NewRequest failed - %s", err.Error())
+		t.Errorf("http.NewRequest failed - %s",
+			err.Error())
 	}
 	whSecret := "secret"
 
@@ -36,7 +37,8 @@ func TestSetGitLabParameterWithoutQueryParams(t *testing.T) {
 	want := "ref=master&token=secret"
 	got := req.URL.RawQuery
 	if got != want {
-		t.Errorf("SetGitLabParameter failed. Want %s, got %s", want, got)
+		t.Errorf("SetGitLabParameter failed. Want %s, got %s",
+			want, got)
 	}
 }
 
@@ -44,7 +46,8 @@ func TestSetGitLabParameterWithQueryParams(t *testing.T) {
 	// GIVEN a URL with query params
 	req, err := http.NewRequest(http.MethodGet, "https://example.com?test=123", nil)
 	if err != nil {
-		t.Errorf("http.NewRequest failed - %s", err.Error())
+		t.Errorf("http.NewRequest failed - %s",
+			err.Error())
 	}
 	whSecret := "secret"
 
@@ -55,6 +58,7 @@ func TestSetGitLabParameterWithQueryParams(t *testing.T) {
 	want := "ref=master&test=123&token=secret"
 	got := req.URL.RawQuery
 	if got != want {
-		t.Errorf("SetGitLabParameter failed. Want %s, got %s", want, got)
+		t.Errorf("SetGitLabParameter failed. Want %s, got %s",
+			want, got)
 	}
 }

--- a/webhook/init_test.go
+++ b/webhook/init_test.go
@@ -35,7 +35,8 @@ func TestSliceInitWithNilSlice(t *testing.T) {
 	got := len(slice)
 	want := 0
 	if got != want {
-		t.Errorf("Got len %d, when expecting %d", got, want)
+		t.Errorf("Got len %d, when expecting %d",
+			got, want)
 	}
 }
 
@@ -51,7 +52,8 @@ func TestSliceInitWithNilWebHook(t *testing.T) {
 
 	// THEN the function initialises the nil WebHook
 	if slice["0"] == nil {
-		t.Errorf("Slice['0'] shouldn't be %v still", slice["0"])
+		t.Errorf("Slice['0'] shouldn't be %v still",
+			slice["0"])
 	}
 }
 
@@ -73,7 +75,8 @@ func TestSliceInitWithNonNil(t *testing.T) {
 	got := len(slice)
 	want := 1
 	if got != want {
-		t.Errorf("Got len %d, when expecting %d", got, want)
+		t.Errorf("Got len %d, when expecting %d",
+			got, want)
 	}
 }
 
@@ -125,7 +128,8 @@ func TestSliceInitMainsHandedOut(t *testing.T) {
 	// THEN the mains are handed out correctly
 	for key := range slice {
 		if slice[key].Main != mains[key] {
-			t.Errorf("Main not handed to %s", key)
+			t.Errorf("Main not handed to %s",
+				key)
 		}
 	}
 }
@@ -140,7 +144,8 @@ func TestSliceInitDefaultsHandedOut(t *testing.T) {
 	// THEN the defaults are handed out correctly
 	for key := range slice {
 		if *slice[key].Defaults != defaults {
-			t.Errorf("Defaults not handed to %s", key)
+			t.Errorf("Defaults not handed to %s",
+				key)
 		}
 	}
 }
@@ -155,7 +160,8 @@ func TestSliceInitHardDefaultsHandedOut(t *testing.T) {
 	// THEN the hard defaults are handed out correctly
 	for key := range slice {
 		if *slice[key].HardDefaults != hardDefaults {
-			t.Errorf("HardDefaults not handed to %s", key)
+			t.Errorf("HardDefaults not handed to %s",
+				key)
 		}
 	}
 }
@@ -173,7 +179,8 @@ func TestSliceInitNotifiersHandedOut(t *testing.T) {
 	// THEN the notifiers are handed out correctly
 	for key := range slice {
 		if slice[key].Notifiers.Shoutrrr == nil {
-			t.Errorf("Notifiers %v weren't handed to %s", notifiers, key)
+			t.Errorf("Notifiers %v weren't handed to %s",
+				notifiers, key)
 		}
 	}
 }
@@ -201,7 +208,8 @@ func TestGetAllowInvalidCertsWhenTrue(t *testing.T) {
 
 	// THEN the function returns true
 	if got != wanted {
-		t.Errorf("GetAllowInvalidCerts - wanted %t, got %t", wanted, got)
+		t.Errorf("GetAllowInvalidCerts - wanted %t, got %t",
+			wanted, got)
 	}
 }
 
@@ -217,7 +225,8 @@ func TestGetAllowInvalidCertsWhenFalse(t *testing.T) {
 
 	// THEN the function returns false
 	if got != wanted {
-		t.Errorf("GetAllowInvalidCerts - wanted %t, got %t", wanted, got)
+		t.Errorf("GetAllowInvalidCerts - wanted %t, got %t",
+			wanted, got)
 	}
 }
 
@@ -234,7 +243,8 @@ func TestGetDelayDuration(t *testing.T) {
 
 	// THEN the function returns the X as a time.Duration
 	if got != wanted {
-		t.Errorf("GetDelayDuration - wanted %s, got %s", wanted, got)
+		t.Errorf("GetDelayDuration - wanted %s, got %s",
+			wanted, got)
 	}
 }
 
@@ -250,7 +260,8 @@ func TestGetDesiredStatusCode(t *testing.T) {
 
 	// THEN the function returns the hardDefault
 	if got != wanted {
-		t.Errorf("GetDesiredStatusCode - wanted %d, got %d", wanted, got)
+		t.Errorf("GetDesiredStatusCode - wanted %d, got %d",
+			wanted, got)
 	}
 }
 
@@ -266,7 +277,8 @@ func TestGetMaxTries(t *testing.T) {
 
 	// THEN the function returns X
 	if got != wanted {
-		t.Errorf("GetMaxTries - wanted %d, got %d", wanted, got)
+		t.Errorf("GetMaxTries - wanted %d, got %d",
+			wanted, got)
 	}
 }
 
@@ -282,7 +294,8 @@ func TestGetType(t *testing.T) {
 
 	// THEN the function returns "X"
 	if got != wanted {
-		t.Errorf("GetType - wanted %s, got %s", wanted, got)
+		t.Errorf("GetType - wanted %s, got %s",
+			wanted, got)
 	}
 }
 
@@ -298,7 +311,8 @@ func TestGetSecret(t *testing.T) {
 
 	// THEN the function returns "X"
 	if *got != wanted {
-		t.Errorf("GetSecret - wanted %s, got %s", wanted, *got)
+		t.Errorf("GetSecret - wanted %s, got %s",
+			wanted, *got)
 	}
 }
 
@@ -314,7 +328,8 @@ func TestGetSilentFailsWhenTrue(t *testing.T) {
 
 	// THEN the function returns true
 	if got != wanted {
-		t.Errorf("GetSilentFails - wanted %t, got %t", wanted, got)
+		t.Errorf("GetSilentFails - wanted %t, got %t",
+			wanted, got)
 	}
 }
 
@@ -330,7 +345,8 @@ func TestGetSilentFailsWhenFalse(t *testing.T) {
 
 	// THEN the function returns false
 	if got != wanted {
-		t.Errorf("GetSilentFails - wanted %t, got %t", wanted, got)
+		t.Errorf("GetSilentFails - wanted %t, got %t",
+			wanted, got)
 	}
 }
 
@@ -346,7 +362,8 @@ func TestGetURLWithNoTemplating(t *testing.T) {
 
 	// THEN the function returns the hardDefault
 	if *got != wanted {
-		t.Errorf("GetURL - wanted %s, got %s", wanted, *got)
+		t.Errorf("GetURL - wanted %s, got %s",
+			wanted, *got)
 	}
 }
 
@@ -363,7 +380,8 @@ func TestGetURLWithTemplatingWorks(t *testing.T) {
 
 	// THEN the function returns the default
 	if *got != wanted {
-		t.Errorf("GetURL - wanted %s, got %s", wanted, *got)
+		t.Errorf("GetURL - wanted %s, got %s",
+			wanted, *got)
 	}
 }
 func TestGetURLWithTemplatingUnchangesTemplate(t *testing.T) {
@@ -379,7 +397,8 @@ func TestGetURLWithTemplatingUnchangesTemplate(t *testing.T) {
 
 	// THEN the template stays intact
 	if *got != wanted {
-		t.Errorf("GetURL modified the template - wanted %s, got %s", wanted, *got)
+		t.Errorf("GetURL modified the template - wanted %s, got %s",
+			wanted, *got)
 	}
 }
 
@@ -434,17 +453,20 @@ func TestGetRequestGitHubValidURL(t *testing.T) {
 	key := "Content-Type"
 	want := "application/json"
 	if req.Header[key][0] != want {
-		t.Errorf("%s should have been %s, got %s", key, want, req.Header[key][0])
+		t.Errorf("%s should have been %s, got %s",
+			key, want, req.Header[key][0])
 	}
 	key = "foo"
 	want = "bar"
 	if req.Header[key][0] != want {
-		t.Errorf("%s should have been %s, got %s", key, want, req.Header[key][0])
+		t.Errorf("%s should have been %s, got %s",
+			key, want, req.Header[key][0])
 	}
 	key = "X-Github-Event"
 	want = "push"
 	if req.Header[key][0] != want {
-		t.Errorf("%s should have been %s, got %s", key, want, req.Header[key][0])
+		t.Errorf("%s should have been %s, got %s",
+			key, want, req.Header[key][0])
 	}
 }
 
@@ -499,7 +521,8 @@ func TestGetRequestGitLabValidURL(t *testing.T) {
 	key := "Content-Type"
 	want := "application/x-www-form-urlencoded"
 	if req.Header[key][0] != want {
-		t.Errorf("%s should have been %s, got %s", key, want, req.Header[key][0])
+		t.Errorf("%s should have been %s, got %s",
+			key, want, req.Header[key][0])
 	}
 	if req.URL.RawQuery == "" {
 		t.Error("RawQuery was empty when it should have been encoded data")
@@ -760,7 +783,8 @@ func TestResetFailsWithSlice(t *testing.T) {
 	// THEN all the fails become nil and the count stays the same
 	for i := range slice {
 		if (*slice[i]).Failed != nil {
-			t.Errorf("Reset failed, got %t", *(*slice[i]).Failed)
+			t.Errorf("Reset failed, got %t",
+				*(*slice[i]).Failed)
 		}
 	}
 }

--- a/webhook/send.go
+++ b/webhook/send.go
@@ -50,7 +50,8 @@ func (w *Slice) Send(
 	for range *w {
 		err := <-errChan
 		if err != nil {
-			errs = fmt.Errorf("%s\n%w", utils.ErrorToString(errs), err)
+			errs = fmt.Errorf("%s\n%w",
+				utils.ErrorToString(errs), err)
 		}
 	}
 	return
@@ -91,11 +92,13 @@ func (w *WebHook) Send(
 		jLog.Error(err, logFrom, true)
 		metrics.IncreasePrometheusCounterActions(metrics.WebHookMetric, *w.ID, serviceInfo.ID, "", "FAIL")
 		triesLeft--
-		errs = fmt.Errorf("%s\n%w", utils.ErrorToString(errs), err)
+		errs = fmt.Errorf("%s\n%w",
+			utils.ErrorToString(errs), err)
 
 		// Give up after MaxTries.
 		if triesLeft == 0 {
-			err := fmt.Errorf("failed %d times to send the WebHook (%s)", w.GetMaxTries(), *w.ID)
+			err := fmt.Errorf("failed %d times to send the WebHook (%s)",
+				w.GetMaxTries(), *w.ID)
 			jLog.Error(err, logFrom, true)
 			failed := true
 			w.Failed = &failed

--- a/webhook/send_test.go
+++ b/webhook/send_test.go
@@ -46,7 +46,8 @@ func TestTryWithInvalidURL(t *testing.T) {
 
 	// THEN err is not nil
 	if err == nil {
-		t.Errorf("try should have failed with invalid %q URL. err is %s", whURL, err.Error())
+		t.Errorf("try should have failed with invalid %q URL. err is %s",
+			whURL, err.Error())
 	}
 }
 
@@ -74,7 +75,8 @@ func TestTryWithUnknownHostAndAllowInvalidCerts(t *testing.T) {
 	startsWith := "Post \"https://test\": dial tcp: lookup test"
 	e := utils.ErrorToString(err)
 	if !strings.HasPrefix(e, startsWith) {
-		t.Errorf("try with %v should have errored starting %q. Got %q", webhook, startsWith, e)
+		t.Errorf("try with %v should have errored starting %q. Got %q",
+			webhook, startsWith, e)
 	}
 }
 
@@ -102,7 +104,8 @@ func TestTryWithUnknownHostAndRejectInvalidCerts(t *testing.T) {
 	startsWith := "Post \"https://test\": dial tcp: lookup test"
 	e := utils.ErrorToString(err)
 	if !strings.HasPrefix(e, startsWith) {
-		t.Errorf("try with %v should have errored starting %q. Got %q", webhook, startsWith, e)
+		t.Errorf("try with %v should have errored starting %q. Got %q",
+			webhook, startsWith, e)
 	}
 }
 
@@ -117,7 +120,8 @@ func TestTryWithKnownHostAndAllowAnyStatusCode(t *testing.T) {
 
 	// THEN err is nil
 	if err != nil {
-		t.Errorf("try with %v shouldn't have errored %q", webhook, err.Error())
+		t.Errorf("try with %v shouldn't have errored %q",
+			webhook, err.Error())
 	}
 }
 
@@ -141,7 +145,8 @@ func TestTryWithKnownHostAndRejectStatusCode(t *testing.T) {
 		}
 		startsWith := fmt.Sprintf("WebHook didn't %d:", *webhook.DesiredStatusCode)
 		if !strings.HasPrefix(e, startsWith) {
-			t.Errorf("try with %v should have started with %q, but got %q", webhook, startsWith, e)
+			t.Errorf("try with %v should have started with %q, but got %q",
+				webhook, startsWith, e)
 		}
 		return
 	}
@@ -167,7 +172,8 @@ func TestWebHookSendFailWithSilentFails(t *testing.T) {
 		}
 		contains := "WebHook didn't 2XX"
 		if !strings.Contains(e, contains) {
-			t.Errorf("Send with %v should have errored %q. Got %q", webhook, contains, e)
+			t.Errorf("Send with %v should have errored %q. Got %q",
+				webhook, contains, e)
 		}
 		return
 	}
@@ -205,7 +211,8 @@ func TestWebHookSendFailWithoutSilentFails(t *testing.T) {
 	contains := "WebHook didn't 2XX"
 	e := utils.ErrorToString(err)
 	if !strings.Contains(e, contains) {
-		t.Errorf("Send with %v should have errored %q. Got %q", webhook, contains, e)
+		t.Errorf("Send with %v should have errored %q. Got %q",
+			webhook, contains, e)
 	}
 }
 
@@ -220,7 +227,8 @@ func TestWebHookSendSuccess(t *testing.T) {
 
 	// THEN err is nil
 	if err != nil {
-		t.Errorf("try with %v shouldn't have errored %q", webhook, err.Error())
+		t.Errorf("try with %v shouldn't have errored %q",
+			webhook, err.Error())
 	}
 }
 
@@ -237,7 +245,8 @@ func TestWebHookSendSuccessWithDelay(t *testing.T) {
 	// THEN it took >= 5s to return
 	elapsed := time.Since(start)
 	if elapsed < 5*time.Second {
-		t.Errorf("Send with useDelay should have taken atleast %v. Only took %s", webhook.Delay, elapsed)
+		t.Errorf("Send with useDelay should have taken atleast %v. Only took %s",
+			webhook.Delay, elapsed)
 	}
 }
 
@@ -252,7 +261,8 @@ func TestSliceSendWithNilSlice(t *testing.T) {
 	// THEN it returns almost instantly
 	elapsed := time.Since(start)
 	if elapsed > time.Second {
-		t.Errorf("Send took more than 1s (%fs) with a %v Slice", elapsed.Seconds(), slice)
+		t.Errorf("Send took more than 1s (%fs) with a %v Slice",
+			elapsed.Seconds(), slice)
 	}
 }
 
@@ -271,7 +281,29 @@ func TestSliceSendFail(t *testing.T) {
 	contains := "WebHook didn't 2XX"
 	e := utils.ErrorToString(err)
 	if !strings.Contains(e, contains) {
-		t.Errorf("Send with %v should have errored %q. Got %q", *slice["test"], contains, e)
+		t.Errorf("Send with %v should have errored %q. Got %q",
+			*slice["test"], contains, e)
+	}
+}
+
+func TestSliceSendWithMultipleFails(t *testing.T) {
+	// GIVEN a Slice with a WebHook which will err on Send
+	jLog = utils.NewJLog("WARN", false)
+	webhook := testWebHookFailing()
+	slice := Slice{
+		"test":  &webhook,
+		"other": &webhook,
+	}
+
+	// WHEN Send is called on this Slice
+	err := slice.Send(utils.ServiceInfo{}, false)
+
+	// THEN err is about the failure
+	contains := "WebHook didn't 2XX"
+	e := utils.ErrorToString(err)
+	if strings.Count(e, contains) != len(slice) {
+		t.Errorf("Send with %v should have errored %q %d times. Got %q",
+			*slice["test"], contains, len(slice), e)
 	}
 }
 
@@ -288,7 +320,8 @@ func TestSliceSendSuccess(t *testing.T) {
 
 	// THEN err is nil
 	if err != nil {
-		t.Errorf("try with %v shouldn't have errored %q", *slice["test"], err.Error())
+		t.Errorf("try with %v shouldn't have errored %q",
+			*slice["test"], err.Error())
 	}
 }
 
@@ -301,7 +334,8 @@ func TestNotifiersSendWithNil(t *testing.T) {
 
 	// THEN err is nil
 	if err != nil {
-		t.Errorf("Send on %v Notifiers shouldn't have err'd. Got %s", notifiers, err.Error())
+		t.Errorf("Send on %v Notifiers shouldn't have err'd. Got %s",
+			notifiers, err.Error())
 	}
 }
 
@@ -334,6 +368,7 @@ func TestNotifiersSendWithNotifier(t *testing.T) {
 	// THEN err is a 404
 	e := utils.ErrorToString(err)
 	if !strings.Contains(e, "HTTP 404") {
-		t.Errorf("Send on %v Notifiers should have 404'd. Got \n%s", notifiers, e)
+		t.Errorf("Send on %v Notifiers should have 404'd. Got \n%s",
+			notifiers, e)
 	}
 }

--- a/webhook/verify.go
+++ b/webhook/verify.go
@@ -30,12 +30,14 @@ func (w *Slice) CheckValues(prefix string) (errs error) {
 
 	for key := range *w {
 		if err := (*w)[key].CheckValues(prefix + "    "); err != nil {
-			errs = fmt.Errorf("%s%s  %s:\\%w", utils.ErrorToString(errs), prefix, key, err)
+			errs = fmt.Errorf("%s%s  %s:\\%w",
+				utils.ErrorToString(errs), prefix, key, err)
 		}
 	}
 
 	if errs != nil {
-		errs = fmt.Errorf("%swebhook:\\%s", prefix, utils.ErrorToString(errs))
+		errs = fmt.Errorf("%swebhook:\\%s",
+			prefix, utils.ErrorToString(errs))
 	}
 	return
 }
@@ -49,20 +51,24 @@ func (w *WebHook) CheckValues(prefix string) (errs error) {
 			*w.Delay += "s"
 		}
 		if _, err := time.ParseDuration(*w.Delay); err != nil {
-			errs = fmt.Errorf("%s%sdelay: %q <invalid> (Use 'AhBmCs' duration format)", utils.ErrorToString(errs), prefix, *w.Delay)
+			errs = fmt.Errorf("%s%sdelay: %q <invalid> (Use 'AhBmCs' duration format)",
+				utils.ErrorToString(errs), prefix, *w.Delay)
 		}
 	}
 
 	if w.Main != nil {
 		types := []string{"github", "gitlab"}
 		if !utils.Contains(types, w.GetType()) {
-			errs = fmt.Errorf("%s%stype: %q <invalid> (supported types = %s)\\", utils.ErrorToString(errs), prefix, w.GetType(), types)
+			errs = fmt.Errorf("%s%stype: %q <invalid> (supported types = %s)\\",
+				utils.ErrorToString(errs), prefix, w.GetType(), types)
 		}
 		if w.GetURL() == nil {
-			errs = fmt.Errorf("%s%surl: <required> (here, or in webhook.%s)\\", utils.ErrorToString(errs), prefix, *w.ID)
+			errs = fmt.Errorf("%s%surl: <required> (here, or in webhook.%s)\\",
+				utils.ErrorToString(errs), prefix, *w.ID)
 		}
 		if w.GetSecret() == nil {
-			errs = fmt.Errorf("%s%ssecret: <required> (here, or in webhook.%s)\\", utils.ErrorToString(errs), prefix, *w.ID)
+			errs = fmt.Errorf("%s%ssecret: <required> (here, or in webhook.%s)\\",
+				utils.ErrorToString(errs), prefix, *w.ID)
 		}
 	}
 	return

--- a/webhook/verify_test.go
+++ b/webhook/verify_test.go
@@ -31,7 +31,8 @@ func TestSliceCheckValuesWithNil(t *testing.T) {
 
 	// THEN err is nil
 	if err != nil {
-		t.Errorf("CheckValues on %v returned an err - %s", slice, err.Error())
+		t.Errorf("CheckValues on %v returned an err - %s",
+			slice, err.Error())
 	}
 }
 
@@ -56,7 +57,8 @@ func TestSliceCheckValuesWithInvalid(t *testing.T) {
 
 	// THEN err is not nil
 	if err == nil {
-		t.Errorf("CheckValues on %v should have err'd. Got %v", slice, err)
+		t.Errorf("CheckValues on %v should have err'd. Got %v",
+			slice, err)
 	}
 }
 
@@ -72,7 +74,8 @@ func TestSliceCheckValuesWithValid(t *testing.T) {
 
 	// THEN err is nil
 	if err != nil {
-		t.Errorf("CheckValues on %v shouldn't have err'd. Got %s", slice, err.Error())
+		t.Errorf("CheckValues on %v shouldn't have err'd. Got %s",
+			slice, err.Error())
 	}
 }
 
@@ -85,7 +88,8 @@ func TestWebHookCheckValuesWithNil(t *testing.T) {
 
 	// THEN err is nil
 	if err != nil {
-		t.Errorf("CheckValues on %v shouldn't have err'd. Got %s", webhook, err.Error())
+		t.Errorf("CheckValues on %v shouldn't have err'd. Got %s",
+			webhook, err.Error())
 	}
 }
 
@@ -109,7 +113,8 @@ func TestWebHookCheckValuesWithNilDelay(t *testing.T) {
 
 	// THEN err is nil
 	if err != nil {
-		t.Errorf("CheckValues on %v shouldn't have err'd. Got %s", webhook, err.Error())
+		t.Errorf("CheckValues on %v shouldn't have err'd. Got %s",
+			webhook, err.Error())
 	}
 }
 
@@ -137,7 +142,8 @@ func TestWebHookCheckValuesWithIntDelay(t *testing.T) {
 	got := webhook.GetDelay()
 	want := declaredDelay + "s"
 	if got != want {
-		t.Errorf("CheckValues on %v should have converted %s to seconds. Got %s, want %s", webhook, delay, got, want)
+		t.Errorf("CheckValues on %v should have converted %s to seconds. Got %s, want %s",
+			webhook, delay, got, want)
 	}
 }
 
@@ -165,7 +171,8 @@ func TestWebHookCheckValuesWithDurationDelay(t *testing.T) {
 	got := webhook.GetDelay()
 	want := declaredDelay
 	if got != want {
-		t.Errorf("CheckValues on %v should have converted %s to seconds. Got %s, want %s", webhook, delay, got, want)
+		t.Errorf("CheckValues on %v should have converted %s to seconds. Got %s, want %s",
+			webhook, delay, got, want)
 	}
 }
 
@@ -191,7 +198,8 @@ func TestWebHookCheckValuesWithInvalidDurationDelay(t *testing.T) {
 
 	// THEN Delay is converted to seconds
 	if err == nil {
-		t.Errorf("CheckValues on %v should have failed parsing %s. Got %s err", webhook, declaredDelay, err)
+		t.Errorf("CheckValues on %v should have failed parsing %s. Got %s err",
+			webhook, declaredDelay, err)
 	}
 }
 
@@ -217,7 +225,8 @@ func TestWebHookCheckValuesWithInvalidType(t *testing.T) {
 
 	// THEN Delay is converted to seconds
 	if err == nil {
-		t.Errorf("CheckValues on %v should have failed parsing %s Type. Got %s err", webhook, wType, err)
+		t.Errorf("CheckValues on %v should have failed parsing %s Type. Got %s err",
+			webhook, wType, err)
 	}
 }
 
@@ -244,7 +253,8 @@ func TestWebHookCheckValuesWithNilURL(t *testing.T) {
 
 	// THEN Delay is converted to seconds
 	if err == nil {
-		t.Errorf("CheckValues on %v should have failed parsing nil URL. Got %s err", webhook, err)
+		t.Errorf("CheckValues on %v should have failed parsing nil URL. Got %s err",
+			webhook, err)
 	}
 }
 
@@ -271,7 +281,8 @@ func TestWebHookCheckValuesWithNilSecret(t *testing.T) {
 
 	// THEN Delay is converted to seconds
 	if err == nil {
-		t.Errorf("CheckValues on %v should have failed parsing nil Secret. Got %s err", webhook, err)
+		t.Errorf("CheckValues on %v should have failed parsing nil Secret. Got %s err",
+			webhook, err)
 	}
 }
 
@@ -293,7 +304,8 @@ func TestWebHookCheckValuesWithNilMain(t *testing.T) {
 
 	// THEN err is nil
 	if err != nil {
-		t.Errorf("CheckValues on %v shouldn't have err'd. Got %s", webhook, err.Error())
+		t.Errorf("CheckValues on %v shouldn't have err'd. Got %s",
+			webhook, err.Error())
 	}
 }
 
@@ -309,7 +321,8 @@ func TestWebHookCheckValuesWithValid(t *testing.T) {
 
 	// THEN the program returns an err
 	if err != nil {
-		t.Errorf("CheckValues on %v shouldn't have err'd. Got %s", slice, err.Error())
+		t.Errorf("CheckValues on %v shouldn't have err'd. Got %s",
+			slice, err.Error())
 	}
 }
 
@@ -328,7 +341,8 @@ func TestSlicePrintWithFreshWebHook(t *testing.T) {
 	out, _ := ioutil.ReadAll(r)
 	os.Stdout = stdout
 	if string(out) != "" {
-		t.Errorf("Print had output %q with %v WebHook", string(out), webhook)
+		t.Errorf("Print had output %q with %v WebHook",
+			string(out), webhook)
 	}
 }
 
@@ -371,7 +385,8 @@ func TestSlicePrintWithFullWebHook(t *testing.T) {
 	out, _ := ioutil.ReadAll(r)
 	os.Stdout = stdout
 	if string(out) != want {
-		t.Errorf("Print had output %q with %v Slice. Wanted %q", string(out), webhook, want)
+		t.Errorf("Print had output %q with %v Slice. Wanted %q",
+			string(out), webhook, want)
 	}
 }
 
@@ -390,7 +405,8 @@ func TestSlicePrintWithNilSlice(t *testing.T) {
 	out, _ := ioutil.ReadAll(r)
 	os.Stdout = stdout
 	if string(out) != "" {
-		t.Errorf("Print had output %q with %v Slice", string(out), slice)
+		t.Errorf("Print had output %q with %v Slice",
+			string(out), slice)
 	}
 }
 
@@ -427,6 +443,7 @@ func TestSlicePrintWithNonNilSlice(t *testing.T) {
 	out, _ := ioutil.ReadAll(r)
 	os.Stdout = stdout
 	if string(out) != want && string(out) != wantOther {
-		t.Errorf("Print had output %q with %v Slice. Wanted %q", string(out), slice, want)
+		t.Errorf("Print had output %q with %v Slice. Wanted %q",
+			string(out), slice, want)
 	}
 }


### PR DESCRIPTION
(and fix an issue with `notify` being used, but crashing if there were no defaults)