### PR TITLE
test(utils): table-driven tests

### DIFF
--- a/utils/help_test.go
+++ b/utils/help_test.go
@@ -1,0 +1,36 @@
+// Copyright [2022] [Argus]
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build unit
+
+package utils
+
+func boolPtr(val bool) *bool {
+	return &val
+}
+func intPtr(val int) *int {
+	return &val
+}
+func stringPtr(val string) *string {
+	return &val
+}
+
+func testServiceInfo() ServiceInfo {
+	return ServiceInfo{
+		ID:            "something",
+		URL:           "example.com",
+		WebURL:        "other.com",
+		LatestVersion: "NEW",
+	}
+}

--- a/utils/lists.go
+++ b/utils/lists.go
@@ -88,7 +88,7 @@ func Swap[T comparable](list *[]T, aStart int, aEnd int, bStart int, bEnd int) {
 
 // RemoveIndex from list
 func RemoveIndex[T comparable](list *[]T, index int) {
-	if index > len(*list) {
+	if index >= len(*list) {
 		return
 	}
 

--- a/utils/lists_test.go
+++ b/utils/lists_test.go
@@ -20,188 +20,165 @@ import (
 	"testing"
 )
 
-func TestSwapMoveMatchingSize(t *testing.T) {
-	// GIVEN a list of comparable
-	lst := []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
-
-	// WHEN Swap is called on it with matching size swaps
-	Swap(&lst, 0, 1, 8, 9)
-	wantLst := []int{8, 9, 2, 3, 4, 5, 6, 7, 0, 1}
-
-	// THEN the Swap is successfuly
-	for i := range lst {
-		if lst[i] != wantLst[i] {
-			t.Errorf(`Swap got %v, want %v`, lst, wantLst)
-		}
+func TestSwap(t *testing.T) {
+	// GIVEN a set of lists
+	tests := map[string]struct {
+		had    []int
+		want   []int
+		aStart int
+		aEnd   int
+		bStart int
+		bEnd   int
+	}{
+		"handles []int": {
+			had:    []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+			want:   []int{0, 7, 8, 9, 2, 3, 4, 5, 6, 1},
+			aStart: 7, aEnd: 9,
+			bStart: 1, bEnd: 1,
+		},
+		"swap singl element": {
+			had:    []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+			want:   []int{9, 1, 2, 3, 4, 5, 6, 7, 8, 0},
+			aStart: 0, aEnd: 0,
+			bStart: 9, bEnd: 9,
+		},
+		"matching swap sizes": {
+			had:    []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+			want:   []int{8, 9, 2, 3, 4, 5, 6, 7, 0, 1},
+			aStart: 0, aEnd: 1,
+			bStart: 8, bEnd: 9,
+		},
+		"more on left": {
+			had:    []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+			want:   []int{0, 8, 9, 5, 6, 7, 1, 2, 3, 4},
+			aStart: 1, aEnd: 4,
+			bStart: 8, bEnd: 9,
+		},
+		"more on right": {
+			had:    []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+			want:   []int{0, 7, 8, 9, 2, 3, 4, 5, 6, 1},
+			aStart: 1, aEnd: 1,
+			bStart: 7, bEnd: 9,
+		},
+		"indices wrong way round": {
+			had:    []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+			want:   []int{0, 7, 8, 9, 2, 3, 4, 5, 6, 1},
+			aStart: 7, aEnd: 9,
+			bStart: 1, bEnd: 1,
+		},
 	}
-	if len(lst) != len(wantLst) {
-		t.Errorf(`Swap added/removed elements! Got %v, want %v`, lst, wantLst)
-	}
-}
 
-func TestSwapMoveMoreOnLeft(t *testing.T) {
-	// GIVEN a list of comparable
-	lst := []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// WHEN Swap is called on a list
+			Swap(&tc.had, tc.aStart, tc.aEnd, tc.bStart, tc.bEnd)
 
-	// WHEN Swap is called with more elements moving from the left
-	Swap(&lst, 5, 9, 14, 15)
-	wantLst := []int{0, 1, 2, 3, 4, 14, 15, 10, 11, 12, 13, 5, 6, 7, 8, 9, 16, 17, 18, 19, 20}
-
-	// THEN the Swap is successful
-	for i := range lst {
-		if lst[i] != wantLst[i] {
-			t.Errorf(`Swap got %v, want %v`, lst, wantLst)
-		}
-	}
-	if len(lst) != len(wantLst) {
-		t.Errorf(`Swap added/removed elements! Got %v, want %v`, lst, wantLst)
-	}
-}
-
-func TestSwapMoveMoreOnRight(t *testing.T) {
-	// GIVEN a list of comparable
-	lst := []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}
-
-	// WHEN Swap is called with more elements moving from the right
-	Swap(&lst, 7, 7, 14, 15)
-	wantLst := []int{0, 1, 2, 3, 4, 5, 6, 14, 15, 8, 9, 10, 11, 12, 13, 7, 16, 17, 18, 19, 20}
-
-	// THEN the Swap is successful
-	for i := range lst {
-		if lst[i] != wantLst[i] {
-			t.Errorf(`Swap got %v, want %v`, lst, wantLst)
-		}
-	}
-	if len(lst) != len(wantLst) {
-		t.Errorf(`Swap added/removed elements! Got %v, want %v`, lst, wantLst)
-	}
-}
-
-func TestSwapIndicesOppositeWayRound(t *testing.T) {
-	// GIVEN a list of comparable
-	lst := []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}
-
-	// WHEN Swap is called with more elements moving from the left
-	Swap(&lst, 14, 15, 5, 9)
-	wantLst := []int{0, 1, 2, 3, 4, 14, 15, 10, 11, 12, 13, 5, 6, 7, 8, 9, 16, 17, 18, 19, 20}
-
-	// THEN the Swap is successful
-	for i := range lst {
-		if lst[i] != wantLst[i] {
-			t.Errorf(`Swap got %v, want %v`, lst, wantLst)
-		}
-	}
-	if len(lst) != len(wantLst) {
-		t.Errorf(`Swap added/removed elements! Got %v, want %v`, lst, wantLst)
+			// THEN the Swap is successful
+			// int
+			if len(tc.had) != len(tc.want) {
+				t.Fatalf("%s:\nSwap added/removed elements!\nwant:%v\ngot:  %v",
+					name, tc.want, tc.had)
+			}
+			for i := range tc.had {
+				if tc.had[i] != tc.want[i] {
+					t.Fatalf("%s:\nwant: %v\ngot:  %v",
+						name, tc.want, tc.had)
+				}
+			}
+		})
 	}
 }
 
-func TestRemoveIndexStart(t *testing.T) {
-	// GIVEN a list of comparable
-	lstInt := []int{0, 1, 2, 3}
+func TestRemoveIndex(t *testing.T) {
+	// GIVEN a set of lists
+	tests := map[string]struct {
+		had     []int
+		want    []int
+		wantStr []string
+		index   int
+	}{
+		"handles []int": {
+			had:   []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+			want:  []int{0, 1, 2, 3, 5, 6, 7, 8, 9},
+			index: 4,
+		},
+		"out of range": {
+			had:   []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+			want:  []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+			index: 10,
+		},
+		"first index": {
+			had:   []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+			want:  []int{1, 2, 3, 4, 5, 6, 7, 8, 9},
+			index: 0,
+		},
+		"last index": {
+			had:   []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+			want:  []int{0, 1, 2, 3, 4, 5, 6, 7, 8},
+			index: 9,
+		},
+	}
 
-	// WHEN RemoveIndex is called on it with the starting index
-	RemoveIndex(&lstInt, 0)
-	wantLstInt := []int{1, 2, 3}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// WHEN RemoveIndex is called on a list
+			RemoveIndex(&tc.had, tc.index)
 
-	// Then that index is removed
-	if len(lstInt) != len(wantLstInt) {
-		t.Errorf(`Failed removing first index! Got %v, want %v`, lstInt, wantLstInt)
+			// THEN the Removal is successful
+			// int
+			if len(tc.had) != len(tc.want) {
+				t.Fatalf("%s:\nRemove index failed\nwant:%v\ngot:  %v",
+					name, tc.want, tc.had)
+			}
+			for i := range tc.had {
+				if tc.had[i] != tc.want[i] {
+					t.Fatalf("%s:\nwant: %v\ngot:  %v",
+						name, tc.want, tc.had)
+				}
+			}
+		})
 	}
 }
 
-func TestRemoveIndexEnd(t *testing.T) {
-	// GIVEN a list of comparable
-	lstInt := []int{0, 1, 2, 3}
-
-	// WHEN RemoveIndex is called on it with the ending index
-	RemoveIndex(&lstInt, 3)
-	wantLstInt := []int{0, 1, 2}
-
-	// Then that index is removed
-	if len(lstInt) != len(wantLstInt) {
-		t.Errorf(`Failed removing final index! Got %v, want %v`, lstInt, wantLstInt)
+func TestGetIndentation(t *testing.T) {
+	// GIVEN a set of strings with varying indentation
+	tests := map[string]struct {
+		text       string
+		indentSize int
+		want       string
+	}{
+		"no indent": {
+			text:       "foo: bar",
+			indentSize: 2,
+			want:       "",
+		},
+		"indent 4, indent size 4": {
+			text:       "    foo: bar",
+			indentSize: 4,
+			want:       "    ",
+		},
+		"indent 4, indent size 2": {
+			text:       "    foo: bar",
+			indentSize: 2,
+			want:       "    ",
+		},
+		"indent 3, indent size 2": {
+			text:       "   foo: bar",
+			indentSize: 2,
+			want:       "  ",
+		},
 	}
-}
 
-func TestRemoveIndexMiddle(t *testing.T) {
-	// GIVEN a list of comparable
-	lstInt := []int{0, 1, 2, 3}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// WHEN GetIndentation is called on a string
+			got := GetIndentation(tc.text, uint8(tc.indentSize))
 
-	// WHEN RemoveIndex is called on it with an index not at the start/end
-	RemoveIndex(&lstInt, 1)
-	wantLstInt := []int{0, 2, 3}
-
-	// Then that index is removed
-	if len(lstInt) != len(wantLstInt) {
-		t.Errorf(`Failed removing an index not at the edge! Got %v, want %v`, lstInt, wantLstInt)
-	}
-}
-
-func TestRemoveIndexOutOfRange(t *testing.T) {
-	// GIVEN a list of comparable
-	lstInt := []int{0, 1, 2, 3}
-
-	// WHEN RemoveIndex is called on it with an index not at the start/end
-	RemoveIndex(&lstInt, 10)
-	wantLstInt := []int{0, 1, 2, 3}
-
-	// Then that index is removed
-	if len(lstInt) != len(wantLstInt) {
-		t.Errorf(`Tried to remove an index out of bounds of the array and got %v, want %v`, lstInt, wantLstInt)
-	}
-}
-
-func TestGetIndentationNone(t *testing.T) {
-	// GIVEN a string with no indentation
-	str := "foo: bar"
-
-	// WHEN GetIndentation is called on it
-	gotIndentation := GetIndentation(str, 2)
-	want := ""
-
-	// THEN the returned indentation is correct (none)
-	if gotIndentation != want {
-		t.Errorf(`GetIndentation gave %v, want match for %q`, gotIndentation, want)
-	}
-}
-
-func TestGetIndentationIndentSizeOne(t *testing.T) {
-	// GIVEN a string with one space indentation
-	str := " foo: bar"
-
-	// WHEN GetIndentation is called on it with indentSize 1
-	gotIndentation := GetIndentation(str, 1)
-	want := " "
-
-	// THEN the returned indentation is correct (one space)
-	if gotIndentation != want {
-		t.Errorf(`GetIndentation gave %q, want match for %q`, gotIndentation, want)
-	}
-}
-func TestGetIndentationIndentSizeTwo(t *testing.T) {
-	// GIVEN a string with less than indentSize an indent
-	str := " foo: bar"
-
-	// WHEN GetIndentation is called on it with indentSize 2
-	gotIndentation := GetIndentation(str, 2)
-	want := ""
-
-	// THEN the returned indentation is none as there's no leading blocks of two spaces
-	if gotIndentation != want {
-		t.Errorf(`GetIndentation gave %q, want match for %q`, gotIndentation, want)
-	}
-}
-func TestGetIndentationMultipleIndents(t *testing.T) {
-	// GIVEN a string with multiple indents
-	str := "    foo: bar"
-
-	// WHEN GetIndentation is called on it with indentSize 2
-	gotIndentation := GetIndentation(str, 2)
-	want := "    "
-
-	// THEN the returned indentation is the correct indentation
-	if gotIndentation != want {
-		t.Errorf(`GetIndentation gave %v, want match for %q`, gotIndentation, want)
+			// THEN the expected indentation is returned
+			if got != tc.want {
+				t.Fatalf("%s:\nwant:%q\ngot:  %q",
+					name, tc.want, got)
+			}
+		})
 	}
 }

--- a/utils/log.go
+++ b/utils/log.go
@@ -22,7 +22,7 @@ import (
 )
 
 var (
-	levelMap = map[string]int{
+	levelMap = map[string]uint{
 		"ERROR":   0,
 		"WARN":    1,
 		"INFO":    2,
@@ -40,9 +40,8 @@ type JLog struct {
 	// 2 = INFO,  3 = VERBOSE,
 	// 4 = DEBUG
 	Level      uint
-	LevelStr   string // The string value of Level (ERROR/WARN/INFO/VERBOSE/DEBUG)
-	Timestamps bool   // whether to log timestamps with the msg, or just the msg.
-	Testing    bool   // Whether we're in tests (don't Fatal)
+	Timestamps bool // whether to log timestamps with the msg, or just the msg.
+	Testing    bool // Whether we're in tests (don't Fatal)
 }
 
 type LogFrom struct {
@@ -63,7 +62,6 @@ func NewJLog(level string, timestamps bool) *JLog {
 func (l *JLog) SetLevel(level string) {
 	level = strings.ToUpper(level)
 	value := levelMap[level]
-	l.LevelStr = level
 
 	msg := fmt.Sprintf("%q is not a valid log.level. It should be one of ERROR, WARN, INFO, VERBOSE or DEBUG.", level)
 	l.Fatal(msg, LogFrom{}, value == 0 && level != "ERROR")
@@ -112,7 +110,7 @@ func (l *JLog) IsLevel(level string) bool {
 	if value == 0 && level != "ERROR" {
 		return false
 	}
-	return l.Level == uint(value)
+	return l.Level == value
 }
 
 // Error log the msg.

--- a/utils/regex_test.go
+++ b/utils/regex_test.go
@@ -20,64 +20,53 @@ import (
 	"testing"
 )
 
-func TestRegexCheckPass(t *testing.T) {
-	// GIVEN a string and matching RegEx
-	regex := "^abc"
-	str := "abc123"
+func TestRegexCheck(t *testing.T) {
+	// GIVEN a variety of RegEx's to apply to a string
+	str := `testing\n"beta-release": "0.1.2-beta"\n"stable-release": "0.1.1"`
+	tests := map[string]struct {
+		regex string
+		match bool
+	}{
+		"regex match":    {regex: `release": "[0-9.]+"`, match: true},
+		"no regex match": {regex: `release": "[0-9.]+-alpha"`, match: false},
+	}
 
-	// WHEN RegexCheck is called on them
-	match := RegexCheck(regex, str)
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// WHEN RegexCheck is called
+			got := RegexCheck(tc.regex, str)
 
-	// THEN a match is found
-	if !match {
-		t.Errorf("%q should have matched the %q RegEx",
-			str, regex)
+			// THEN the regex matches when expected
+			if got != tc.match {
+				t.Errorf("%s:wanted match=%t, not %t\n%q on %q",
+					name, tc.match, got, tc.regex, str)
+			}
+		})
 	}
 }
 
-func TestRegexCheckFail(t *testing.T) {
-	// GIVEN a string and non-matching RegEx
-	regex := "^abc"
-	str := "123abc"
-
-	// WHEN RegexCheck is called on them
-	match := RegexCheck(regex, str)
-
-	// THEN a match is not found
-	if match {
-		t.Errorf("%q shouldn't have matched the %q RegEx",
-			str, regex)
+func TestRegexCheckWithParams(t *testing.T) {
+	// GIVEN a variety of RegEx's to apply to a string
+	str := `testing\n"beta-release": "0.1.2-beta"\n"stable-release": "0.1.1"`
+	tests := map[string]struct {
+		regex   string
+		version string
+		match   bool
+	}{
+		"regex match":    {regex: `release": "{{ version }}"`, version: "0.1.1", match: true},
+		"no regex match": {regex: `release": "{{ version }}"`, version: "0.1.2", match: false},
 	}
-}
 
-func TestRegexCheckWithParamsRunsOnTemplatedStringPass(t *testing.T) {
-	// GIVEN a string and matching RegEx
-	regex := "^abc{{ version }}$"
-	str := "abc1.2.3"
-	version := "1.2.3"
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// WHEN RegexCheck is called
+			got := RegexCheckWithParams(tc.regex, str, tc.version)
 
-	// WHEN RegexCheck is called on them
-	match := RegexCheckWithParams(regex, str, version)
-
-	// THEN a match is found
-	if !match {
-		t.Errorf("%q (version=%s) should have matched the %q RegEx",
-			str, version, regex)
-	}
-}
-
-func TestRegexCheckWithParamsRunsOnTemplatedStringFail(t *testing.T) {
-	// GIVEN a string and matching RegEx
-	regex := "^abc{{ version }}$"
-	str := "abc4.5.6"
-	version := "1.2.3"
-
-	// WHEN RegexCheck is called on them
-	match := RegexCheckWithParams(regex, str, version)
-
-	// THEN a match is found
-	if match {
-		t.Errorf("%q (version=%s) should not have matched the %q RegEx",
-			str, version, regex)
+			// THEN the regex matches when expected
+			if got != tc.match {
+				t.Errorf("%s:wanted match=%t, not %t\n%q on %q",
+					name, tc.match, got, tc.regex, str)
+			}
+		})
 	}
 }


### PR DESCRIPTION
coverage decrease from removed lines
```
- | LevelStr   string // The string value of Level (ERROR/WARN/INFO/VERBOSE/DEBUG)
- | l.LevelStr = level
```
was being set but never used