### PR TITLE
fix(service): close latest/deployed version http connections

### DIFF
--- a/service/deployed_version/deployed_version.go
+++ b/service/deployed_version/deployed_version.go
@@ -199,6 +199,7 @@ func (l *Lookup) httpRequest(logFrom utils.LogFrom) (rawBody []byte, err error) 
 	}
 
 	// Read the response body.
+	defer resp.Body.Close()
 	rawBody, err = io.ReadAll(resp.Body)
 	jLog.Error(err, logFrom, err != nil)
 	return

--- a/service/latest_version/query.go
+++ b/service/latest_version/query.go
@@ -145,6 +145,7 @@ func (l *Lookup) httpRequest(logFrom utils.LogFrom) (rawBody []byte, err error) 
 	}
 
 	// Read the response body.
+	defer resp.Body.Close()
 	rawBody, err = io.ReadAll(resp.Body)
 	jLog.Error(err, logFrom, err != nil)
 	return


### PR DESCRIPTION
https://github.com/release-argus/Argus/issues/153

wasn't closing latest/deployed version connections with
> defer resp.Body.close