### PR TITLE
fix(service): use `Connection` header on HTTP requests

### DIFF
--- a/service/deployed_version/deployed_version.go
+++ b/service/deployed_version/deployed_version.go
@@ -176,6 +176,7 @@ func (l *Lookup) httpRequest(logFrom utils.LogFrom) (rawBody []byte, err error) 
 	}
 
 	// Set headers
+	req.Header.Set("Connection", "close")
 	for _, header := range l.Headers {
 		req.Header.Set(header.Key, header.Value)
 	}
@@ -190,7 +191,7 @@ func (l *Lookup) httpRequest(logFrom utils.LogFrom) (rawBody []byte, err error) 
 	if err != nil {
 		// Don't crash on invalid certs.
 		if strings.Contains(err.Error(), "x509") {
-			err = fmt.Errorf("x509 (Cert invalid)")
+			err = fmt.Errorf("x509 (certificate invalid)")
 			jLog.Warn(err, logFrom, true)
 			return
 		}

--- a/service/latest_version/filters/docker.go
+++ b/service/latest_version/filters/docker.go
@@ -75,6 +75,7 @@ func (r *Require) DockerTagCheck(
 			req.Header.Set("Authorization", "Bearer "+token)
 		}
 	}
+	req.Header.Set("Connection", "close")
 	// Do the request
 	client := &http.Client{}
 	resp, err := client.Do(req)
@@ -82,8 +83,9 @@ func (r *Require) DockerTagCheck(
 		return fmt.Errorf("%s:%s - %s",
 			r.Docker.Image, tag, err)
 	}
-	defer resp.Body.Close()
+
 	// Parse the body
+	defer resp.Body.Close()
 	body, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("%s:%s - %s",
@@ -215,6 +217,7 @@ func (d *DockerCheck) refreshDockerHubToken() (err error) {
 	if err != nil {
 		return err
 	}
+	req.Header.Set("Connection", "close")
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	// Do the request
 	client := &http.Client{}
@@ -223,8 +226,9 @@ func (d *DockerCheck) refreshDockerHubToken() (err error) {
 		jLog.Error(err, utils.LogFrom{Primary: "docker-hub", Secondary: d.Image}, true)
 		return
 	}
-	defer resp.Body.Close()
+
 	// Parse the body
+	defer resp.Body.Close()
 	body, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf(string(body))

--- a/service/latest_version/query.go
+++ b/service/latest_version/query.go
@@ -126,13 +126,14 @@ func (l *Lookup) httpRequest(logFrom utils.LogFrom) (rawBody []byte, err error) 
 		return
 	}
 
+	// Set headers
+	req.Header.Set("Connection", "close")
 	if l.Type == "github" && utils.DefaultIfNil(l.GetAccessToken()) != "" {
 		req.Header.Set("Authorization", fmt.Sprintf("token %s", *l.GetAccessToken()))
 	}
 
 	client := &http.Client{Transport: customTransport}
 	resp, err := client.Do(req)
-
 	if err != nil {
 		// Don't crash on invalid certs.
 		if strings.Contains(err.Error(), "x509") {

--- a/web/web.go
+++ b/web/web.go
@@ -39,6 +39,8 @@ func NewRouter(cfg *config.Config, jLog *utils.JLog, hub *api_v1.Hub) *mux.Route
 
 	// WebSocket
 	api.Router.HandleFunc("/ws", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Connection", "close")
+		defer r.Body.Close()
 		api_v1.ServeWs(api, hub, w, r)
 	})
 

--- a/webhook/init.go
+++ b/webhook/init.go
@@ -165,6 +165,7 @@ func (w *WebHook) GetRequest() (req *http.Request) {
 
 		SetGitLabParameter(req, w.GetSecret())
 	}
+	req.Header.Set("Connection", "close")
 	w.SetCustomHeaders(req)
 	return
 }


### PR DESCRIPTION
> A significant difference between HTTP/1.1 and earlier versions of HTTP is that persistent connections are the default behavior of any HTTP connection.

Inform the server that the client wants to close the connection after the transaction is complete. This can be done by setting the [Connection](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Connection) header
[source](http://craigwickesser.com/2015/01/golang-http-to-many-open-files/)

[fix?](https://github.com/release-argus/Argus/issues/153#issuecomment-1245847113)