### PR TITLE
fix(webhook): `custom_headers` from main/defaults

### DIFF
--- a/utils/util.go
+++ b/utils/util.go
@@ -80,8 +80,12 @@ func DefaultIfNil[T comparable](check *T) T {
 	return *check
 }
 
+type customComparable interface {
+	bool | int | map[string]string | string | uint
+}
+
 // GetFirstNonNilPtr will return the first pointer in `pointers` that is not nil.
-func GetFirstNonNilPtr[T comparable](pointers ...*T) *T {
+func GetFirstNonNilPtr[T customComparable](pointers ...*T) *T {
 	for _, pointer := range pointers {
 		if pointer != nil {
 			return pointer

--- a/web/api/v1/help_test.go
+++ b/web/api/v1/help_test.go
@@ -436,14 +436,14 @@ func TestConvertWebHookToAPITypeWebHookDidCopyHeaders(t *testing.T) {
 	)
 	wh := webhook.WebHook{
 		URL:           "https://example.com",
-		CustomHeaders: headers,
+		CustomHeaders: &headers,
 	}
 
 	// WHEN convertWebHookToAPITypeWebHook is called on it
 	got := convertWebHookToAPITypeWebHook(&wh)
 
 	// THEN the slice was converted correctly
-	if (*got.CustomHeaders)["X-Something"] != wh.CustomHeaders["X-Something"] {
+	if (*got.CustomHeaders)["X-Something"] != (*wh.CustomHeaders)["X-Something"] {
 		t.Errorf("converted incorrectly\nfrom: %v\nto:   %v",
 			wh, got)
 	}

--- a/web/api/v1/websocket.go
+++ b/web/api/v1/websocket.go
@@ -579,7 +579,7 @@ func convertWebHookToAPITypeWebHook(webhook *webhook.WebHook) (apiElement *api_t
 		Type:              &webhook.Type,
 		URL:               &webhook.URL,
 		Secret:            utils.ValueIfNotNil(&webhook.Secret, "<secret>"),
-		CustomHeaders:     &webhook.CustomHeaders,
+		CustomHeaders:     webhook.CustomHeaders,
 		DesiredStatusCode: webhook.DesiredStatusCode,
 		Delay:             webhook.Delay,
 		MaxTries:          webhook.MaxTries,

--- a/webhook/announce_test.go
+++ b/webhook/announce_test.go
@@ -48,7 +48,7 @@ func TestAnnounceSend(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			webhook := testWebHook(true, true, false)
+			webhook := testWebHook(true, true, false, false)
 			(*webhook.Failed)[webhook.ID] = tc.failed
 			webhook.ServiceStatus.AnnounceChannel = nil
 			if !tc.nilChannel {

--- a/webhook/headers.go
+++ b/webhook/headers.go
@@ -32,12 +32,13 @@ type GitHub struct {
 
 // SetCustomHeaders of the req.
 func (w *WebHook) SetCustomHeaders(req *http.Request) {
-	if len(w.CustomHeaders) == 0 {
+	customHeaders := utils.GetFirstNonNilPtr(w.CustomHeaders, w.Main.CustomHeaders, w.Defaults.CustomHeaders)
+	if customHeaders == nil {
 		return
 	}
 
 	serviceInfo := utils.ServiceInfo{ID: *w.ServiceStatus.ServiceID, LatestVersion: w.ServiceStatus.LatestVersion}
-	for key, value := range w.CustomHeaders {
+	for key, value := range *customHeaders {
 		value = utils.TemplateString(value, serviceInfo)
 		req.Header[key] = []string{value}
 	}

--- a/webhook/help_test.go
+++ b/webhook/help_test.go
@@ -52,7 +52,7 @@ func testLogging(level string) {
 	shoutrrrLogs.Init(jLog, nil, nil, nil, nil)
 }
 
-func testWebHook(failing bool, forService bool, selfSignedCert bool) *WebHook {
+func testWebHook(failing bool, forService bool, selfSignedCert bool, customHeaders bool) *WebHook {
 	desiredStatusCode := 0
 	whMaxTries := uint(1)
 	webhook := &WebHook{
@@ -80,6 +80,14 @@ func testWebHook(failing bool, forService bool, selfSignedCert bool) *WebHook {
 	}
 	if failing {
 		webhook.Secret = "invalid"
+	}
+	if customHeaders {
+		webhook.URL = strings.Replace(webhook.URL, "github-style", "single-header", 1)
+		if failing {
+			webhook.CustomHeaders = &map[string]string{"X-Test": "invalid"}
+		} else {
+			webhook.CustomHeaders = &map[string]string{"X-Test": "secret"}
+		}
 	}
 	return webhook
 }

--- a/webhook/init_test.go
+++ b/webhook/init_test.go
@@ -39,7 +39,7 @@ func TestInitMetrics(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			webhook := testWebHook(true, tc.forService, false)
+			webhook := testWebHook(true, tc.forService, false, false)
 			if tc.forService {
 				webhook.ID = name + "TestInitMetrics"
 				webhook.ServiceStatus.ServiceID = stringPtr(name + "TestInitMetrics")
@@ -66,7 +66,7 @@ func TestInitMetrics(t *testing.T) {
 
 func TestInit(t *testing.T) {
 	// GIVEN a WebHook and vars for the Init
-	webhook := testWebHook(true, true, false)
+	webhook := testWebHook(true, true, false, false)
 	var notifiers shoutrrr.Slice
 	var main WebHook
 	var defaults WebHook
@@ -125,13 +125,13 @@ func TestSliceInit(t *testing.T) {
 	}{
 		"nil slice":   {slice: nil, nilSlice: true},
 		"empty slice": {slice: &Slice{}},
-		"no mains":    {slice: &Slice{"fail": testWebHook(true, true, false), "pass": testWebHook(false, true, false)}},
+		"no mains":    {slice: &Slice{"fail": testWebHook(true, true, false, false), "pass": testWebHook(false, true, false, false)}},
 		"slice with nil element and matching main": {slice: &Slice{"fail": nil},
-			mains: &Slice{"fail": testWebHook(false, true, false)}},
-		"have matching mains": {slice: &Slice{"fail": testWebHook(true, true, false), "pass": testWebHook(false, true, false)},
-			mains: &Slice{"fail": testWebHook(false, true, false), "pass": testWebHook(true, true, false)}},
-		"some matching mains": {slice: &Slice{"fail": testWebHook(true, true, false), "pass": testWebHook(false, true, false)},
-			mains: &Slice{"other": testWebHook(false, true, false), "pass": testWebHook(true, true, false)}},
+			mains: &Slice{"fail": testWebHook(false, true, false, false)}},
+		"have matching mains": {slice: &Slice{"fail": testWebHook(true, true, false, false), "pass": testWebHook(false, true, false, false)},
+			mains: &Slice{"fail": testWebHook(false, true, false, false), "pass": testWebHook(true, true, false, false)}},
+		"some matching mains": {slice: &Slice{"fail": testWebHook(true, true, false, false), "pass": testWebHook(false, true, false, false)},
+			mains: &Slice{"other": testWebHook(false, true, false, false), "pass": testWebHook(true, true, false, false)}},
 	}
 
 	for name, tc := range tests {
@@ -236,7 +236,7 @@ func TestGetAllowInvalidCerts(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			webhook := testWebHook(true, true, false)
+			webhook := testWebHook(true, true, false, false)
 			webhook.AllowInvalidCerts = tc.allowInvalidCertsRoot
 			webhook.Main.AllowInvalidCerts = tc.allowInvalidCertsMain
 			webhook.Defaults.AllowInvalidCerts = tc.allowInvalidCertsDefault
@@ -275,7 +275,7 @@ func TestGetDelay(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			webhook := testWebHook(true, true, false)
+			webhook := testWebHook(true, true, false, false)
 			webhook.Delay = tc.delayRoot
 			webhook.Main.Delay = tc.delayMain
 			webhook.Defaults.Delay = tc.delayDefault
@@ -314,7 +314,7 @@ func TestGetDelayDuration(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			webhook := testWebHook(true, true, false)
+			webhook := testWebHook(true, true, false, false)
 			webhook.Delay = tc.delayRoot
 			webhook.Main.Delay = tc.delayMain
 			webhook.Defaults.Delay = tc.delayDefault
@@ -353,7 +353,7 @@ func TestGetDesiredStatusCode(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			webhook := testWebHook(true, true, false)
+			webhook := testWebHook(true, true, false, false)
 			webhook.DesiredStatusCode = tc.desiredStatusCodeRoot
 			webhook.Main.DesiredStatusCode = tc.desiredStatusCodeMain
 			webhook.Defaults.DesiredStatusCode = tc.desiredStatusCodeDefault
@@ -383,7 +383,7 @@ func TestGetFailStatus(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			webhook := testWebHook(true, true, false)
+			webhook := testWebHook(true, true, false, false)
 			want := stringifyPointer(tc.failed)
 			(*webhook.Failed)[webhook.ID] = tc.failed
 
@@ -420,7 +420,7 @@ func TestGetMaxTries(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			webhook := testWebHook(true, true, false)
+			webhook := testWebHook(true, true, false, false)
 			webhook.MaxTries = tc.maxTriesRoot
 			webhook.Main.MaxTries = tc.maxTriesMain
 			webhook.Defaults.MaxTries = tc.maxTriesDefault
@@ -446,9 +446,9 @@ func TestGetRequest(t *testing.T) {
 		customHeaders map[string]string
 		wantNil       bool
 	}{
-		"valid github type": {webhookType: "github", url: "release-argus/Argus"},
+		"valid github type":            {webhookType: "github", url: "release-argus/Argus"},
 		"catch invalid github request": {webhookType: "github", url: "release-argus	/	Argus", wantNil: true},
-		"valid gitlab type": {webhookType: "gitlab", url: "https://release-argus.io"},
+		"valid gitlab type":            {webhookType: "gitlab", url: "https://release-argus.io"},
 		"catch invalid gitlab request": {webhookType: "gitlab", url: "release-argus	/	Argus", wantNil: true},
 		"sets custom headers for github": {webhookType: "github", url: "release-argus/Argus",
 			customHeaders: map[string]string{"X-Foo": "bar"}},
@@ -458,10 +458,10 @@ func TestGetRequest(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			webhook := testWebHook(true, true, false)
+			webhook := testWebHook(true, true, false, false)
 			webhook.Type = tc.webhookType
 			webhook.URL = tc.url
-			webhook.CustomHeaders = tc.customHeaders
+			webhook.CustomHeaders = &tc.customHeaders
 
 			// WHEN GetRequest is called
 			req := webhook.GetRequest()
@@ -541,7 +541,7 @@ func TestGetType(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			webhook := testWebHook(true, true, false)
+			webhook := testWebHook(true, true, false, false)
 			webhook.Type = tc.typeRoot
 			webhook.Main.Type = tc.typeMain
 			webhook.Defaults.Type = tc.typeDefault
@@ -580,7 +580,7 @@ func TestGetSecret(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			webhook := testWebHook(true, true, false)
+			webhook := testWebHook(true, true, false, false)
 			webhook.Secret = tc.secretRoot
 			webhook.Main.Secret = tc.secretMain
 			webhook.Defaults.Secret = tc.secretDefault
@@ -619,7 +619,7 @@ func TestGetSilentFails(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			webhook := testWebHook(true, true, false)
+			webhook := testWebHook(true, true, false, false)
 			webhook.SilentFails = tc.silentFailsRoot
 			webhook.Main.SilentFails = tc.silentFailsMain
 			webhook.Defaults.SilentFails = tc.silentFailsDefault
@@ -663,7 +663,7 @@ func TestGetURL(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			webhook := testWebHook(true, true, false)
+			webhook := testWebHook(true, true, false, false)
 			webhook.URL = tc.urlRoot
 			webhook.Main.URL = tc.urlMain
 			webhook.Defaults.URL = tc.urlDefault
@@ -695,7 +695,7 @@ func TestGetIsRunnable(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			webhook := testWebHook(true, true, false)
+			webhook := testWebHook(true, true, false, false)
 			webhook.NextRunnable = tc.nextRunnable
 			time.Sleep(time.Nanosecond)
 
@@ -723,7 +723,7 @@ func TestSetFailStatus(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			webhook := testWebHook(true, true, false)
+			webhook := testWebHook(true, true, false, false)
 			want := stringifyPointer(tc.failed)
 			webhook.SetFailStatus(tc.failed)
 
@@ -785,7 +785,7 @@ func TestSetNextRunnable(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			webhook := testWebHook(true, true, false)
+			webhook := testWebHook(true, true, false, false)
 			webhook.SetFailStatus(tc.failed)
 			webhook.Delay = tc.delay
 			maxTries := uint(tc.maxTries)

--- a/webhook/types.go
+++ b/webhook/types.go
@@ -35,7 +35,7 @@ type WebHook struct {
 	Type              string                 `yaml:"type,omitempty"`                // "github"/"url"
 	URL               string                 `yaml:"url,omitempty"`                 // "https://example.com"
 	AllowInvalidCerts *bool                  `yaml:"allow_invalid_certs,omitempty"` // default - false = Disallows invalid HTTPS certificates.
-	CustomHeaders     map[string]string      `yaml:"custom_headers,omitempty"`      // Custom Headers for the WebHook
+	CustomHeaders     *map[string]string     `yaml:"custom_headers,omitempty"`      // Custom Headers for the WebHook
 	Secret            string                 `yaml:"secret,omitempty"`              // "SECRET"
 	DesiredStatusCode *int                   `yaml:"desired_status_code,omitempty"` // e.g. 202
 	Delay             string                 `yaml:"delay,omitempty"`               // The delay before sending the WebHook.

--- a/webhook/verify.go
+++ b/webhook/verify.go
@@ -77,10 +77,12 @@ func (w *WebHook) CheckValues(prefix string) (errs error) {
 		}
 	}
 	var headerErrs error
-	for key := range w.CustomHeaders {
-		if !utils.CheckTemplate(w.CustomHeaders[key]) {
-			headerErrs = fmt.Errorf("%s%s  %s: %q <invalid> (didn't pass templating)\\",
-				utils.ErrorToString(headerErrs), prefix, key, w.CustomHeaders[key])
+	if w.CustomHeaders != nil {
+		for key := range *w.CustomHeaders {
+			if !utils.CheckTemplate((*w.CustomHeaders)[key]) {
+				headerErrs = fmt.Errorf("%s%s  %s: %q <invalid> (didn't pass templating)\\",
+					utils.ErrorToString(headerErrs), prefix, key, (*w.CustomHeaders)[key])
+			}
 		}
 	}
 	if headerErrs != nil {
@@ -110,6 +112,12 @@ func (w *WebHook) Print(prefix string) {
 	utils.PrintlnIfNotDefault(w.Type, fmt.Sprintf("%stype: %s", prefix, w.Type))
 	utils.PrintlnIfNotDefault(w.URL, fmt.Sprintf("%surl: %s", prefix, w.URL))
 	utils.PrintlnIfNotNil(w.AllowInvalidCerts, fmt.Sprintf("%sallow_invalid_certs: %t", prefix, utils.DefaultIfNil(w.AllowInvalidCerts)))
+	if w.CustomHeaders != nil {
+		fmt.Printf("%scustom_headers:\n", prefix)
+		for key := range *w.CustomHeaders {
+			fmt.Printf("%s  - %s: %s\n", prefix, key, (*w.CustomHeaders)[key])
+		}
+	}
 	utils.PrintlnIfNotDefault(w.Secret, fmt.Sprintf("%ssecret: %q", prefix, w.Secret))
 	utils.PrintlnIfNotNil(w.DesiredStatusCode, fmt.Sprintf("%sdesired_status_code: %d", prefix, utils.DefaultIfNil(w.DesiredStatusCode)))
 	utils.PrintlnIfNotDefault(w.Delay, fmt.Sprintf("%sdelay: %s", prefix, w.Delay))

--- a/webhook/verify_test.go
+++ b/webhook/verify_test.go
@@ -32,7 +32,7 @@ func TestWebHookPrint(t *testing.T) {
 		webhook WebHook
 		lines   int
 	}{
-		"all fields":     {lines: 8, webhook: *testWebHook(true, true, false)},
+		"all fields":     {lines: 10, webhook: *testWebHook(true, true, false, true)},
 		"partial fields": {lines: 2, webhook: WebHook{Type: "github", URL: "https://release-argus.io"}},
 	}
 
@@ -68,7 +68,7 @@ func TestSlicePrint(t *testing.T) {
 		"nil slice": {lines: 0, slice: nil},
 		"single element slice": {lines: 4, slice: &Slice{"single": &WebHook{Type: "github", URL: "https://release-argus.io"}},
 			regexMatches: []string{"^webhook:$", "^  single:$", "^    type: "}},
-		"multiple element slice": {lines: 13, slice: &Slice{"first": &WebHook{Type: "github", URL: "https://release-argus.io"}, "second": testWebHook(true, true, false)},
+		"multiple element slice": {lines: 13, slice: &Slice{"first": &WebHook{Type: "github", URL: "https://release-argus.io"}, "second": testWebHook(true, true, false, false)},
 			regexMatches: []string{"^webhook:$", "^  first:$", "^    type: ", "^  second:$", "^    delay"}},
 	}
 
@@ -137,7 +137,7 @@ func TestWebHookCheckValues(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			webhook := testWebHook(true, !tc.noMain, false)
+			webhook := testWebHook(true, !tc.noMain, false, false)
 			if tc.delay != "" {
 				webhook.Delay = tc.delay
 			}
@@ -150,7 +150,7 @@ func TestWebHookCheckValues(t *testing.T) {
 			if tc.secret != nil {
 				webhook.Secret = *tc.secret
 			}
-			webhook.CustomHeaders = tc.customHeaders
+			webhook.CustomHeaders = &tc.customHeaders
 
 			// WHEN CheckValues is called
 			err := webhook.CheckValues("")
@@ -178,9 +178,9 @@ func TestSliceCheckValues(t *testing.T) {
 		errRegex string
 	}{
 		"nil slice":                    {errRegex: "^$"},
-		"valid single element slice":   {errRegex: "^$", slice: &Slice{"a": testWebHook(true, true, false)}},
+		"valid single element slice":   {errRegex: "^$", slice: &Slice{"a": testWebHook(true, true, false, false)}},
 		"invalid single element slice": {errRegex: "delay: .* <invalid>", slice: &Slice{"a": &WebHook{Delay: "5x"}}},
-		"valid multi element slice":    {errRegex: "^$", slice: &Slice{"a": testWebHook(true, true, false), "b": testWebHook(false, true, false)}},
+		"valid multi element slice":    {errRegex: "^$", slice: &Slice{"a": testWebHook(true, true, false, false), "b": testWebHook(false, true, false, false)}},
 		"invalid multi element slice": {errRegex: "delay: .* <invalid>.*type: .* <invalid>",
 			slice: &Slice{"a": &WebHook{Delay: "5x"}, "b": &WebHook{Type: "foo", Main: &WebHook{}, Defaults: &WebHook{}, HardDefaults: &WebHook{}}}},
 	}


### PR DESCRIPTION
`custom_headers` for WebHook `ABC` wasn't using headers defined in `webhook.ABC.custom_headers` or `defaults.webhook.custom_headers`. It'd only use those in `service.XYZ.webhook.ABC.custom_headers`