### PR TITLE
fix(notify): get access_token `password`s working for matrix

### DIFF
--- a/notifiers/shoutrrr/shoutrrr.go
+++ b/notifiers/shoutrrr/shoutrrr.go
@@ -130,7 +130,6 @@ func (s *Shoutrrr) GetURL() (url string) {
 		// matrix://user:password@host[:port][/port]/[?rooms=!roomID1[,roomAlias2]][&disableTLS=yes]
 		port := s.GetURLField("port")
 		path := s.GetURLField("path")
-		user := s.GetURLField("user")
 		rooms := s.GetParam("rooms")
 		rooms = util.ValueIfNotDefault(rooms, "?rooms="+rooms)
 		disableTLS := s.GetParam("disabletls")
@@ -142,8 +141,8 @@ func (s *Shoutrrr) GetURL() (url string) {
 				disableTLS = "?" + disableTLS
 			}
 		}
-		url = fmt.Sprintf("matrix://%s%s@%s%s%s/%s%s",
-			util.ValueIfNotDefault(user, user+":"),
+		url = fmt.Sprintf("matrix://%s:%s@%s%s%s/%s%s",
+			s.GetURLField("user"),
 			s.GetURLField("password"),
 			s.GetURLField("host"),
 			util.ValueIfNotDefault(port, ":"+port),
@@ -297,7 +296,7 @@ func (s *Shoutrrr) Send(
 	for {
 		msg := fmt.Sprintf("Sending %q to %q", toSend, url)
 		jLog.Verbose(msg, logFrom, !jLog.IsLevel("debug"))
-		jLog.Debug(msg+fmt.Sprintf(" with params=%q", *params), logFrom, jLog.IsLevel("debug"))
+		jLog.Debug(fmt.Sprintf("%s with params=%q", msg, *params), logFrom, jLog.IsLevel("debug"))
 		err := sender.Send(toSend, params)
 
 		failed := false

--- a/notifiers/shoutrrr/shoutrrr_test.go
+++ b/notifiers/shoutrrr/shoutrrr_test.go
@@ -67,7 +67,7 @@ func TestGetURL(t *testing.T) {
 			urlFields: map[string]string{"host": "HOST", "token": "TOKEN", "username": "USERNAME", "port": "8443"}},
 		"mattermost - base + port + path": {sType: "mattermost", want: "mattermost://USERNAME@HOST:8443/PATH/TOKEN",
 			urlFields: map[string]string{"host": "HOST", "token": "TOKEN", "username": "USERNAME", "path": "PATH", "port": "8443"}},
-		"matrix - base": {sType: "matrix", want: "matrix://PASSWORD@HOST/",
+		"matrix - base": {sType: "matrix", want: "matrix://:PASSWORD@HOST/",
 			urlFields: map[string]string{"host": "HOST", "password": "PASSWORD"}},
 		"matrix - base + user": {sType: "matrix", want: "matrix://USER:PASSWORD@HOST/",
 			urlFields: map[string]string{"host": "HOST", "password": "PASSWORD", "user": "USER"}},

--- a/notifiers/shoutrrr/verify.go
+++ b/notifiers/shoutrrr/verify.go
@@ -244,7 +244,7 @@ func (s *Shoutrrr) checkValuesMaster(prefix string, errs *error, errsOptions *er
 				util.ErrorToString(*errsURLFields), prefix)
 		}
 		if s.GetURLField("password") == "" {
-			*errsURLFields = fmt.Errorf("%s%s  password: <required> e.g. 'pass123' OR 'access_token'\\",
+			*errsURLFields = fmt.Errorf("%s%s  password: <required> e.g. 'pass123' (with user) OR 'access_token' (no user)\\",
 				util.ErrorToString(*errsURLFields), prefix)
 		}
 	case "opsgenie":

--- a/testing/shoutrrr.go
+++ b/testing/shoutrrr.go
@@ -97,6 +97,7 @@ func findShoutrrr(
 			slice["test"].HardDefaults = &emptyShoutrrs
 			slice["test"].InitMaps()
 			slice["test"].Main.InitMaps()
+			slice["test"].Failed = &map[string]*bool{}
 
 			notifyType := slice["test"].GetType()
 			if cfg.Defaults.Notify[notifyType] != nil {


### PR DESCRIPTION
shoutrrr wants `matrix://:password@...` not `matrix://password@...`

fixes: https://github.com/release-argus/Argus/issues/193