### PR TITLE
fix(notify): don't login to matrix to verify (could rate-limit fail)

### DIFF
--- a/notifiers/shoutrrr/verify.go
+++ b/notifiers/shoutrrr/verify.go
@@ -76,11 +76,14 @@ func (s *Shoutrrr) CheckValues(prefix string) (errs error) {
 	if s.Main != nil {
 		s.checkValuesMaster(prefix, &errs, &errsOptions, &errsURLFields, &errsParams)
 
-		//#nosec G104 -- Disregard as we're not giving any rawURLs
-		sender, _ := shoutrrr_lib.CreateSender()
-		if _, err := sender.Locate(s.GetURL()); err != nil {
-			errsLocate = fmt.Errorf("%s%s^ %w\\",
-				util.ErrorToString(errsLocate), prefix, err)
+		// Exclude matrix since it logs in, so may run into a rate-limit
+		if s.GetType() != "matrix" {
+			//#nosec G104 -- Disregard as we're not giving any rawURLs
+			sender, _ := shoutrrr_lib.CreateSender()
+			if _, err := sender.Locate(s.GetURL()); err != nil {
+				errsLocate = fmt.Errorf("%s%s^ %w\\",
+					util.ErrorToString(errsLocate), prefix, err)
+			}
 		}
 	}
 

--- a/notifiers/shoutrrr/verify_test.go
+++ b/notifiers/shoutrrr/verify_test.go
@@ -487,6 +487,8 @@ func TestShoutrrrCheckValues(t *testing.T) {
 			main: &Shoutrrr{}, sType: "gotify"},
 		"does field check service shoutrrrs - invalid params + locate fail": {errRegex: "fromaddress: <required>.*toaddresses: <required>", serviceShoutrrr: true,
 			urlFields: map[string]string{"host": "https://release-argus.io"}, main: &Shoutrrr{}, sType: "smtp"},
+		"valid matrix - skip Locate": {errRegex: "^$", serviceShoutrrr: true,
+			main: &Shoutrrr{URLFields: map[string]string{"host": "matrix.example.io", "password": "access_token"}}, sType: "matrix"},
 	}
 
 	for name, tc := range tests {


### PR DESCRIPTION
`.Locate` logs in on Matrix types. Skip the Locate for them to help against login rate-limiting
```
2023/01/11 20:25:15 DEBUG: 1/109 org/repo1 Init
2023/01/11 20:25:15 DEBUG: 2/109 org/repo2 Init
2023/01/11 20:25:15 DEBUG: 3/109 org/repo3 Init
2023/01/11 20:25:15 DEBUG: 4/109 org/repo4 Init
2023/01/11 20:25:15 DEBUG: 5/109 org/repo5 Init
...
  org/repo1:
    notify:
      matrix:
        ^ failed to log in: Too Many Requests
  org/repo2:
    notify:
      matrix:
        ^ failed to log in: Too Many Requests
  org/repo3:
    notify:
      matrix:
        ^ failed to log in: Too Many Requests
  org/repo4:
    notify:
      matrix:
        ^ failed to log in: Too Many Requests
  org/repo5:
    notify:
      matrix:
        ^ failed to log in: Too Many Requests
```