### PR TITLE
Clean up Docker image apt files the right way

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ LABEL maintainer="The Argus Authors <developers@release-argus.io>"
 RUN \
     apt-get update && \
     apt-get install ca-certificates -y && \
-    apt-get clean
+    rm -rf /var/lib/apt/lists/*
 
 COPY entrypoint.sh /entrypoint.sh
 COPY --from=0 /build/argus               /usr/bin/argus


### PR DESCRIPTION
According to the official best practices guidelines outlined in the following document:
https://docs.docker.com/develop/develop-images/dockerfile_best-practices/

The official Debian/Ubuntu images have been configured to do apt-get clean automatically. Consequently, performing another `apt-get clean` is unnecessary. Instead, it is crucial to clear the cache for the index file by executing this command: `rm -rf /var/lib/apt/lists/*`.


The image size before and after the change for reference:

```
REPOSITORY       TAG                 IMAGE ID       CREATED             SIZE
after            latest              40ad44683af3   55 minutes ago      116MB
before           latest              ce25232e7649   About an hour ago   134MB
```