### PR TITLE
feat: Add prometheus metrics for different version between latest and deployed

### DIFF
--- a/service/new.go
+++ b/service/new.go
@@ -360,7 +360,7 @@ func (s *Service) CheckFetches() (err error) {
 	}()
 
 	logFrom := util.LogFrom{Primary: s.ID, Secondary: "CheckFetches"}
-
+	var latestVersion string
 	// Fetch latest version
 	{
 		// Erase DeployedVersion so that 'require' is checked
@@ -375,6 +375,7 @@ func (s *Service) CheckFetches() (err error) {
 			return
 		}
 		s.Status.SetDeployedVersion(deployedVersion, false)
+		latestVersion = s.Status.LatestVersion()
 	}
 
 	// Fetch deployed version
@@ -388,6 +389,7 @@ func (s *Service) CheckFetches() (err error) {
 			return
 		}
 		s.Status.SetDeployedVersion(version, false)
+		s.DeployedVersionLookup.DifferentVersion(version != latestVersion)
 	}
 
 	return

--- a/service/new.go
+++ b/service/new.go
@@ -360,7 +360,7 @@ func (s *Service) CheckFetches() (err error) {
 	}()
 
 	logFrom := util.LogFrom{Primary: s.ID, Secondary: "CheckFetches"}
-	var latestVersion string
+
 	// Fetch latest version
 	{
 		// Erase DeployedVersion so that 'require' is checked
@@ -375,7 +375,6 @@ func (s *Service) CheckFetches() (err error) {
 			return
 		}
 		s.Status.SetDeployedVersion(deployedVersion, false)
-		latestVersion = s.Status.LatestVersion()
 	}
 
 	// Fetch deployed version
@@ -389,7 +388,7 @@ func (s *Service) CheckFetches() (err error) {
 			return
 		}
 		s.Status.SetDeployedVersion(version, false)
-		s.DeployedVersionLookup.DifferentVersion(version != latestVersion)
+		s.DeployedVersionLookup.DifferentVersion(version != s.Status.LatestVersion())
 	}
 
 	return

--- a/web/metrics/prometheus.go
+++ b/web/metrics/prometheus.go
@@ -72,6 +72,12 @@ var (
 		[]string{
 			"id",
 		})
+	DifferentVersion = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "deployed_version_different_than_latest_version",
+		Help: "Whether this service's last deployed version different than latest version (0=no, 1=yes)."},
+		[]string{
+			"id",
+		})
 	AckWaiting = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "ack_waiting",
 		Help: "Whether a new release is waiting to be acknowledged (skipped/approved; 0=no, 1=yes)."},


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe it.**
I wanted to have a prometheus metric when deployed and latest version are not the same in an alert by my grafana instance.

**Describe the solution you want**
I add a prometheus metric `deployed_version_different_than_latest_version` that is set to 1 if version are different and 0 if not.

**Additional context**
Good luck with the review and the maintenance of this awesome project !