### PR TITLE
feat(config): hash `basic_auth.(username|password)` locally

### DIFF
--- a/config/defaults.go
+++ b/config/defaults.go
@@ -233,26 +233,30 @@ func mapEnvToStruct(src interface{}, prefix string, envVars *[]string) (err erro
 
 // CheckValues are valid.
 func (d *Defaults) CheckValues(prefix string) (errs error) {
-	itemPrefix := prefix + "  "
+	itemPrefix := prefix + "    "
 
 	// Service
 	if err := d.Service.CheckValues(itemPrefix); err != nil {
-		errs = fmt.Errorf("%s%sservice:\\%w",
+		errs = fmt.Errorf("%s%s  service:\\%w",
 			util.ErrorToString(errs), prefix, err)
 	}
 
 	// Notify
-	if err := d.Notify.CheckValues(prefix); err != nil {
+	if err := d.Notify.CheckValues(prefix + "  "); err != nil {
 		errs = fmt.Errorf("%s%w",
 			util.ErrorToString(errs), err)
 	}
 
 	// WebHook
 	if err := d.WebHook.CheckValues(itemPrefix); err != nil {
-		errs = fmt.Errorf("%s%swebhook:\\%w",
+		errs = fmt.Errorf("%s%s  webhook:\\%w",
 			util.ErrorToString(errs), prefix, err)
 	}
 
+	if errs != nil {
+		errs = fmt.Errorf("%sdefaults:\\%w",
+			prefix, errs)
+	}
 	return
 }
 

--- a/config/defaults_test.go
+++ b/config/defaults_test.go
@@ -281,7 +281,7 @@ func TestDefaults_MapEnvToStruct(t *testing.T) {
 				"ARGUS_SERVICE_LATEST_VERSION_REQUIRE_DOCKER_HUB_TOKEN":    "tokenForDockerHub",
 				"ARGUS_SERVICE_LATEST_VERSION_REQUIRE_DOCKER_HUB_USERNAME": "usernameForDockerHub",
 				"ARGUS_SERVICE_LATEST_VERSION_REQUIRE_DOCKER_QUAY_TOKEN":   "tokenForQuay"},
-			errRegex: `service:[^ ]+  latest_version:[^ ]+    require:[^ ]+      docker:[^ ]+        type: "foo" <invalid> `,
+			errRegex: `defaults[^ ]+  service:[^ ]+    latest_version:[^ ]+      require:[^ ]+        docker:[^ ]+          type: "foo" <invalid> `,
 		},
 		"service.latest_version - invalid bool - allow_invalid_certs": {
 			env: map[string]string{
@@ -374,7 +374,7 @@ func TestDefaults_MapEnvToStruct(t *testing.T) {
 						&map[string]string{
 							"delay": "foo"},
 						nil, nil)}},
-			errRegex: `notify:[^ ]+  discord:[^ ]+    options:[^ ]+      delay: "foo" <invalid>`,
+			errRegex: `defaults:[^ ]+  notify:[^ ]+    discord:[^ ]+      options:[^ ]+        delay: "foo" <invalid>`,
 		},
 		"notify.smtp": {
 			env: map[string]string{
@@ -930,7 +930,7 @@ func TestDefaults_MapEnvToStruct(t *testing.T) {
 					case string:
 						if !regexp.MustCompile(tc.errRegex).MatchString(r.(string)) {
 							t.Errorf("want error matching:\n%v\ngot:\n%v",
-								tc.errRegex, t)
+								tc.errRegex, r.(string))
 						}
 					default:
 						t.Fatalf("unexpected panic: %v", r)
@@ -966,9 +966,10 @@ func TestDefaults_CheckValues(t *testing.T) {
 			input: &Defaults{Service: service.Defaults{
 				Options: *opt.NewDefaults("10x", nil)}},
 			errRegex: []string{
-				`^service:$`,
-				`^  options:$`,
-				`^    interval: "10x" <invalid>`},
+				`^defaults:$`,
+				`^  service:$`,
+				`^    options:$`,
+				`^      interval: "10x" <invalid>`},
 		},
 		"Service.LatestVersion.Require.Docker.Type": {
 			input: &Defaults{Service: service.Defaults{
@@ -978,11 +979,12 @@ func TestDefaults_CheckValues(t *testing.T) {
 							"pizza",
 							"", "", "", "", nil)}}}},
 			errRegex: []string{
-				`^service:$`,
-				`^  latest_version:$`,
-				`^    require:$`,
-				`^      docker:$`,
-				`^        type: "pizza" <invalid>`},
+				`^defaults:$`,
+				`^  service:$`,
+				`^    latest_version:$`,
+				`^      require:$`,
+				`^        docker:$`,
+				`^          type: "pizza" <invalid>`},
 		},
 		"Service.Interval + Service.DeployedVersionLookup.Regex": {
 			input: &Defaults{Service: service.Defaults{
@@ -993,13 +995,14 @@ func TestDefaults_CheckValues(t *testing.T) {
 							"pizza",
 							"", "", "", "", nil)}}}},
 			errRegex: []string{
-				`^service:$`,
-				`^  options:$`,
-				`^    interval: "10x" <invalid>`,
-				`^  latest_version:$`,
-				`^    require:$`,
-				`^      docker:$`,
-				`^        type: "pizza" <invalid>`},
+				`^defaults:$`,
+				`^  service:$`,
+				`^    options:$`,
+				`^      interval: "10x" <invalid>`,
+				`^    latest_version:$`,
+				`^      require:$`,
+				`^        docker:$`,
+				`^          type: "pizza" <invalid>`},
 		},
 		"Notify.x.Delay": {
 			input: &Defaults{Notify: shoutrrr.SliceDefaults{
@@ -1008,17 +1011,19 @@ func TestDefaults_CheckValues(t *testing.T) {
 					&map[string]string{"delay": "10x"},
 					nil, nil)}},
 			errRegex: []string{
-				`^notify:$`,
-				`^  slack:$`,
-				`^    options:`,
-				`^      delay: "10x" <invalid>`},
+				`^defaults:$`,
+				`^  notify:$`,
+				`^    slack:$`,
+				`^      options:`,
+				`^        delay: "10x" <invalid>`},
 		},
 		"WebHook.Delay": {
 			input: &Defaults{WebHook: *webhook.NewDefaults(
 				nil, nil, "10x", nil, nil, "", nil, "", "")},
 			errRegex: []string{
-				`^webhook:$`,
-				`^  delay: "10x" <invalid>`},
+				`^defaults:$`,
+				`^  webhook:$`,
+				`^    delay: "10x" <invalid>`},
 		},
 	}
 

--- a/config/verify.go
+++ b/config/verify.go
@@ -25,9 +25,11 @@ import (
 // CheckValues are valid.
 func (c *Config) CheckValues() {
 	var errs error
-	if err := c.Defaults.CheckValues("  "); err != nil {
-		errs = fmt.Errorf("defaults:\\%w",
-			err)
+	c.Settings.CheckValues()
+
+	if err := c.Defaults.CheckValues(""); err != nil {
+		errs = fmt.Errorf("%s%w",
+			util.ErrorToString(errs), err)
 	}
 
 	if err := c.Notify.CheckValues(""); err != nil {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@commitlint/config-conventional": "^18.6.0"
       },
       "devDependencies": {
-        "husky": "^9.0.7",
+        "husky": "^9.0.10",
         "standard-version": "^9.5.0"
       }
     },
@@ -1571,12 +1571,12 @@
       }
     },
     "node_modules/husky": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-9.0.7.tgz",
-      "integrity": "sha512-vWdusw+y12DUEeoZqW1kplOFqk3tedGV8qlga8/SF6a3lOiWLqGZZQvfWvY0fQYdfiRi/u1DFNpudTSV9l1aCg==",
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.0.10.tgz",
+      "integrity": "sha512-TQGNknoiy6bURzIO77pPRu+XHi6zI7T93rX+QnJsoYFf3xdjKOur+IlfqzJGMHIK/wXrLg+GsvMs8Op7vI2jVA==",
       "dev": true,
       "bin": {
-        "husky": "bin.js"
+        "husky": "bin.mjs"
       },
       "engines": {
         "node": ">=18"
@@ -4065,9 +4065,9 @@
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="
     },
     "husky": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-9.0.7.tgz",
-      "integrity": "sha512-vWdusw+y12DUEeoZqW1kplOFqk3tedGV8qlga8/SF6a3lOiWLqGZZQvfWvY0fQYdfiRi/u1DFNpudTSV9l1aCg==",
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.0.10.tgz",
+      "integrity": "sha512-TQGNknoiy6bURzIO77pPRu+XHi6zI7T93rX+QnJsoYFf3xdjKOur+IlfqzJGMHIK/wXrLg+GsvMs8Op7vI2jVA==",
       "dev": true
     },
     "import-fresh": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "husky": "^9.0.7",
+    "husky": "^9.0.10",
     "standard-version": "^9.5.0"
   },
   "dependencies": {

--- a/web/api/v1/http_test.go
+++ b/web/api/v1/http_test.go
@@ -91,6 +91,10 @@ func TestHTTP_BasicAuth(t *testing.T) {
 
 			cfg := config.Config{}
 			cfg.Settings.Web.BasicAuth = tc.basicAuth
+			// Hash the username/password
+			if cfg.Settings.Web.BasicAuth != nil {
+				cfg.Settings.Web.BasicAuth.CheckValues()
+			}
 			cfg.Settings.Web.RoutePrefix = stringPtr("")
 			api := NewAPI(&cfg, util.NewJLog("WARN", false))
 			api.Router.HandleFunc("/test", func(rw http.ResponseWriter, req *http.Request) {
@@ -130,7 +134,7 @@ func TestHTTP_BasicAuth(t *testing.T) {
 	}
 }
 
-func TestHTTP_SetupFaviconRoute(t *testing.T) {
+func TestHTTP_SetupRoutesFavicon(t *testing.T) {
 	// GIVEN an API with/without favicon overrides
 	tests := map[string]struct {
 		favicon *config.FaviconSettings
@@ -159,7 +163,7 @@ func TestHTTP_SetupFaviconRoute(t *testing.T) {
 			cfg := testBareConfig()
 			cfg.Settings.Web.Favicon = testFaviconSettings(tc.urlPNG, tc.urlSVG)
 			api := NewAPI(cfg, util.NewJLog("WARN", false))
-			api.SetupFaviconRoute()
+			api.SetupRoutesFavicon()
 			ts := httptest.NewServer(api.Router)
 			defer ts.Close()
 			client := http.Client{}

--- a/web/api/v1/util.go
+++ b/web/api/v1/util.go
@@ -69,6 +69,19 @@ func (api *API) announceEdit(oldData *api_type.ServiceSummary, newData *api_type
 	*api.Config.HardDefaults.Service.Status.AnnounceChannel <- payloadData
 }
 
+// ConstantTimeCompare returns true if the two slices, x and y, have equal contents
+// and false otherwise. The time taken is a function of the length of the slices and
+// is independent of the contents.
+func ConstantTimeCompare(x, y [32]byte) bool {
+	var result byte
+
+	for i := 0; i < len(x); i++ {
+		result |= x[i] ^ y[i]
+	}
+
+	return result == 0
+}
+
 //
 // Defaults
 //

--- a/web/api/v1/util_test.go
+++ b/web/api/v1/util_test.go
@@ -17,6 +17,7 @@
 package v1
 
 import (
+	"crypto/sha256"
 	"testing"
 	"time"
 
@@ -32,6 +33,50 @@ import (
 	api_type "github.com/release-argus/Argus/web/api/types"
 	"github.com/release-argus/Argus/webhook"
 )
+
+func TestConstantTimeCompare(t *testing.T) {
+	// GIVEN two hashes
+	tests := map[string]struct {
+		hash1 string
+		hash2 string
+	}{
+		"equal - 1": {
+			hash1: "a",
+			hash2: "a",
+		},
+		"equal - 2": {
+			hash1: "abc",
+			hash2: "abc",
+		},
+		"not equal - 1": {
+			hash1: "a",
+			hash2: "b",
+		},
+		"not equal - 2": {
+			hash1: "abc",
+			hash2: "abb",
+		},
+	}
+
+	for name, tc := range tests {
+		name, tc := name, tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			hash1 := sha256.Sum256([]byte(tc.hash1))
+			hash2 := sha256.Sum256([]byte(tc.hash2))
+
+			// WHEN ConstantTimeCompare is called
+			got := ConstantTimeCompare(hash1, hash2)
+
+			// THEN the result should be as expected
+			want := tc.hash1 == tc.hash2
+			if got != (want) {
+				t.Errorf("want %v, got %v",
+					want, got)
+			}
+		})
+	}
+}
 
 func TestConvertAndCensorNotifySliceDefaults(t *testing.T) {
 	// GIVEN a shoutrrr.SliceDefaults


### PR DESCRIPTION
* sha256 the username/password and store in the config as 'h__HASH'
* basic_auth removed if both username and password are empty
* favicon removed if both svg and png overrides are empty