### PR TITLE
fix(ui): handle null oldObj in deepDiff to prevent refresh failure

### DIFF
--- a/web/ui/react-app/src/components/approvals/service-info.tsx
+++ b/web/ui/react-app/src/components/approvals/service-info.tsx
@@ -60,9 +60,9 @@ export const ServiceInfo: FC<Props> = ({
 		() => ({
 			// If the version hasn't been found.
 			not_found:
-				isEmptyOrNull(service?.status?.deployed_version) ||
-				isEmptyOrNull(service?.status?.latest_version) ||
-				isEmptyOrNull(service?.status?.last_queried),
+				isEmptyOrNull(service.status?.deployed_version) ||
+				isEmptyOrNull(service.status?.latest_version) ||
+				isEmptyOrNull(service.status?.last_queried),
 			// If a new version has been found (and not skipped).
 			warning: updateAvailable && !updateSkipped,
 			// If the latest version is the same as the approved version.

--- a/web/ui/react-app/src/utils/is-empty-or-null.tsx
+++ b/web/ui/react-app/src/utils/is-empty-or-null.tsx
@@ -4,7 +4,7 @@
  * @param value - The value to check.
  * @returns true when value is empty, null, or undefined. false otherwise.
  */
-const isEmptyOrNull = (value: unknown): boolean => {
+const isEmptyOrNull = (value: unknown): value is null | undefined | '' => {
 	return (value ?? '') === '';
 };
 

--- a/web/ui/react-app/src/utils/query-params.tsx
+++ b/web/ui/react-app/src/utils/query-params.tsx
@@ -5,6 +5,7 @@ import {
 
 import { ArgType } from 'types/service-edit';
 import { isEmptyObject } from './is-empty';
+import isEmptyOrNull from './is-empty-or-null';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type DiffObject = { [key: string]: any };
@@ -22,9 +23,9 @@ export const deepDiff = (
 ): DiffObject => {
 	const diff: DiffObject = {};
 
-	// If oldObj undefined, return newObj,
+	// If oldObj empty/undefined/null, return newObj,
 	// e.g. DeployedVersion has no defaults.
-	if (oldObj === undefined) return newObj;
+	if (isEmptyOrNull(oldObj)) return newObj;
 
 	// get all keys from both objects.
 	const keys = Object.keys(oldObj).concat(Object.keys(newObj));


### PR DESCRIPTION
```js
if (oldObj === undefined) return newObj;
const keys = Object.keys(oldObj).concat(Object.keys(newObj));
```
If 'oldObj' is null, it would get past the undefined check, but crash on Object.keys of null

fixes #514