### PR TITLE
fix(ui): have VersionWithRefresh depend on original data

### DIFF
--- a/web/ui/react-app/src/components/modals/service-edit/version-with-refresh.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/version-with-refresh.tsx
@@ -63,7 +63,7 @@ const VersionWithRefresh: FC<Props> = ({
 		return convertUIDeployedVersionDataEditToAPI(
 			original as DeployedVersionLookupEditType,
 		);
-	}, [serviceID, dataTarget]);
+	}, [original, serviceID, dataTarget]);
 	const url: string | undefined = useWatch({ name: `${dataTarget}.url` });
 	const dataTargetErrors = useErrors(dataTarget, true);
 	const { data, refetchData } = useValuesRefetch(dataTarget);

--- a/web/ui/react-app/src/utils/is-empty.tsx
+++ b/web/ui/react-app/src/utils/is-empty.tsx
@@ -4,9 +4,8 @@
  * @param arg - The array to check.
  * @returns true when array is empty, null, or undefined. false otherwise.
  */
-export const isEmptyArray = <T extends unknown[] | undefined>(
-	arg: T,
-): boolean => ((arg as unknown[]) ?? []).length === 0;
+export const isEmptyArray = (arg?: unknown[]): arg is [] | undefined =>
+	((arg as unknown[]) ?? []).length === 0;
 
 export const isEmptyObject = <T extends Record<string, unknown> | undefined>(
 	arg: T,


### PR DESCRIPTION
`convertedOriginal` wasn't depending on the service data, so with the move from placeholder skeletons, to empty form, having the serviceID doesn't mean it can get the data. So the diff on refresh was comparing the form data with null, and so always sent the current form values as query params. This makes the refresh only happen on your browser session and does not trigger a version change in the backend.