### PR TITLE
fix(docker): remove hardcoded USER to restore custom UID/GID support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,8 +52,6 @@ RUN \
   chown -R argus:argus /app
 WORKDIR /app
 
-USER argus:argus
-
 EXPOSE     8080
 VOLUME     [ "/app/data" ]
 ENTRYPOINT [ "/entrypoint.sh" ]


### PR DESCRIPTION
With this, the entrypoint runs as 'argus:argus', so it wouldn't have permissions to change the UID/GID when ARGUS_UID/ARGUS_GID are set. This breaks upgrades as the file would be owned by a different user, so 911:911 wouldn't be able to write to the db.

fixes #519 