### PR TITLE
fix(ui): send type with refresh of new GitHub `latest_version` and diff `latest_version.require` properly

### DIFF
--- a/web/ui/react-app/src/components/approvals/service-info.tsx
+++ b/web/ui/react-app/src/components/approvals/service-info.tsx
@@ -79,7 +79,7 @@ export const ServiceInfo: FC<Props> = ({
 			placement="top"
 			delay={{ show: 500, hide: 500 }}
 			overlay={
-				<Tooltip id={`tooltip-deployed-service`}>
+				<Tooltip id="tooltip-deployed-service">
 					of the deployed {service.id}
 				</Tooltip>
 			}
@@ -87,6 +87,7 @@ export const ServiceInfo: FC<Props> = ({
 			<FontAwesomeIcon
 				style={{ paddingLeft: '0.5rem', paddingBottom: '0.1rem' }}
 				icon={faSatelliteDish}
+				aria-label="Monitoring the deployed service's version"
 			/>
 		</OverlayTrigger>
 	) : null;
@@ -98,7 +99,7 @@ export const ServiceInfo: FC<Props> = ({
 				placement="top"
 				delay={{ show: 500, hide: 500 }}
 				overlay={
-					<Tooltip id={`tooltip-skipped-version`}>
+					<Tooltip id="tooltip-skipped-version">
 						Skipped {service.status.approved_version.slice('SKIP_'.length)}
 					</Tooltip>
 				}
@@ -106,6 +107,7 @@ export const ServiceInfo: FC<Props> = ({
 				<FontAwesomeIcon
 					icon={faInfoCircle}
 					style={{ paddingLeft: '0.5rem', paddingBottom: '0.1rem' }}
+					aria-describedby="tooltip-skipped-version"
 				/>
 			</OverlayTrigger>
 		) : null;
@@ -120,7 +122,7 @@ export const ServiceInfo: FC<Props> = ({
 				placement="top"
 				delay={{ show: 500, hide: 500 }}
 				overlay={
-					<Tooltip id={`tooltip-resend`}>
+					<Tooltip id="tooltip-resend">
 						{updateSkipped
 							? 'Approve this release'
 							: `Resend the ${actionType}`}
@@ -132,6 +134,7 @@ export const ServiceInfo: FC<Props> = ({
 					size="sm"
 					onClick={() => showModal(updateSkipped ? 'SEND' : 'RESEND', service)}
 					disabled={service.loading || service.active === false}
+					aria-describedby="tooltip-resend"
 				>
 					<FontAwesomeIcon
 						icon={updateSkipped ? faCheck : faArrowRotateRight}
@@ -177,6 +180,7 @@ export const ServiceInfo: FC<Props> = ({
 								className="btn-flex btn-update-action"
 								variant="primary"
 								onClick={toggleShowUpdateInfo}
+								aria-label="Show update details"
 							>
 								<FontAwesomeIcon icon={faInfo} />
 							</Button>
@@ -190,6 +194,7 @@ export const ServiceInfo: FC<Props> = ({
 									showModal(status.updateApproved ? 'RESEND' : 'SEND', service)
 								}
 								disabled={!(service.webhook || service.command)}
+								aria-label="Approve release"
 							>
 								<FontAwesomeIcon icon={faCheck} />
 							</Button>
@@ -203,6 +208,7 @@ export const ServiceInfo: FC<Props> = ({
 										service,
 									)
 								}
+								aria-label="Reject release"
 							>
 								<FontAwesomeIcon icon={faTimes} color="white" />
 							</Button>
@@ -235,7 +241,7 @@ export const ServiceInfo: FC<Props> = ({
 									delay={{ show: 500, hide: 500 }}
 									overlay={
 										service?.status?.deployed_version_timestamp ? (
-											<Tooltip id={`tooltip-deployed-version`}>
+											<Tooltip id="tooltip-deployed-version">
 												<>
 													{formatRelative(
 														new Date(service.status.deployed_version_timestamp),
@@ -248,7 +254,10 @@ export const ServiceInfo: FC<Props> = ({
 										)
 									}
 								>
-									<p style={{ margin: 0 }}>
+									<p
+										style={{ margin: 0 }}
+										aria-describedby="tooltip-deployed-version"
+									>
 										{service?.status?.deployed_version
 											? service.status.deployed_version
 											: 'Unknown'}{' '}

--- a/web/ui/react-app/src/components/approvals/service-update-info.tsx
+++ b/web/ui/react-app/src/components/approvals/service-update-info.tsx
@@ -39,7 +39,7 @@ const UpdateInfo: FC<Props> = ({ service, visible }) => (
 					placement="top"
 					delay={{ show: 500, hide: 500 }}
 					overlay={
-						<Tooltip id={`tooltip-deployed-version`}>
+						<Tooltip id="tooltip-deployed-version">
 							{service.status?.deployed_version_timestamp ? (
 								<>
 									{formatRelative(
@@ -52,6 +52,7 @@ const UpdateInfo: FC<Props> = ({ service, visible }) => (
 							)}
 						</Tooltip>
 					}
+					aria-describedby="tooltip-deployed-version"
 				>
 					<p style={{ marginTop: 5, marginBottom: 5, maxWidth: 'fit-content' }}>
 						<strong>From:</strong>{' '}
@@ -65,7 +66,7 @@ const UpdateInfo: FC<Props> = ({ service, visible }) => (
 					placement="bottom"
 					delay={{ show: 500, hide: 500 }}
 					overlay={
-						<Tooltip id={`tooltip-latest-version`}>
+						<Tooltip id="tooltip-latest-version">
 							{service.status?.latest_version_timestamp ? (
 								<>
 									{formatRelative(
@@ -79,7 +80,10 @@ const UpdateInfo: FC<Props> = ({ service, visible }) => (
 						</Tooltip>
 					}
 				>
-					<p style={{ marginBottom: 0, maxWidth: 'fit-content' }}>
+					<p
+						style={{ marginBottom: 0, maxWidth: 'fit-content' }}
+						aria-describedby="tooltip-latest-version"
+					>
 						<strong>To:</strong>{' '}
 						{service?.status?.latest_version
 							? service.status.latest_version

--- a/web/ui/react-app/src/components/approvals/service.tsx
+++ b/web/ui/react-app/src/components/approvals/service.tsx
@@ -1,4 +1,4 @@
-import { Button, Card } from 'react-bootstrap';
+import { Button, Card, OverlayTrigger, Tooltip } from 'react-bootstrap';
 import { FC, memo, useCallback, useContext, useMemo, useState } from 'react';
 import { ModalType, ServiceSummaryType } from 'types/summary';
 import { ServiceImage, ServiceInfo, UpdateInfo } from 'components/approvals';
@@ -67,24 +67,30 @@ const Service: FC<Props> = ({ service, editable = false }) => {
 					<strong>{service.name ?? service.id}</strong>
 				</a>
 				{editable && (
-					<Button
-						className="btn-icon-center"
-						size="sm"
-						variant="secondary"
-						onClick={() => showModal('EDIT', service)}
-						style={{
-							height: '1.5rem',
-							width: '1.5rem',
-
-							// lay it on top.
-							zIndex: 1,
-							position: 'absolute',
-							top: '0.5rem',
-							right: '0.5rem',
-						}}
+					<OverlayTrigger
+						delay={{ show: 500, hide: 500 }}
+						overlay={<Tooltip id="tooltip-edit">Edit service</Tooltip>}
 					>
-						<FontAwesomeIcon icon={faPen} className="fa-sm" />
-					</Button>
+						<Button
+							className="btn-icon-center"
+							size="sm"
+							variant="secondary"
+							onClick={() => showModal('EDIT', service)}
+							style={{
+								height: '1.5rem',
+								width: '1.5rem',
+
+								// lay it on top.
+								zIndex: 1,
+								position: 'absolute',
+								top: '0.5rem',
+								right: '0.5rem',
+							}}
+							aria-describedby="tooltip-edit"
+						>
+							<FontAwesomeIcon icon={faPen} className="fa-sm" />
+						</Button>
+					</OverlayTrigger>
 				)}
 			</Card.Title>
 

--- a/web/ui/react-app/src/components/approvals/toolbar/edit-mode-toggle.tsx
+++ b/web/ui/react-app/src/components/approvals/toolbar/edit-mode-toggle.tsx
@@ -1,7 +1,7 @@
 import { FC, useContext } from 'react';
 import { faPen, faPlus } from '@fortawesome/free-solid-svg-icons';
 
-import { Button } from 'react-bootstrap';
+import ButtonWithTooltip from 'components/generic/button-with-tooltip';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { ModalContext } from 'contexts/modal';
 
@@ -16,17 +16,19 @@ const EditModeToggle: FC<Props> = ({ editMode, toggleEditMode }) => {
 	return (
 		<>
 			{editMode && (
-				<Button
-					variant="secondary"
-					className="border-0"
+				<ButtonWithTooltip
+					hoverTooltip
+					tooltip="Create a service"
 					onClick={() => handleModal('EDIT', { id: '', loading: false })}
-				>
-					<FontAwesomeIcon icon={faPlus} />
-				</Button>
+					icon={<FontAwesomeIcon icon={faPlus} />}
+				/>
 			)}
-			<Button variant="secondary" className="border-0" onClick={toggleEditMode}>
-				<FontAwesomeIcon icon={faPen} />
-			</Button>
+			<ButtonWithTooltip
+				hoverTooltip
+				tooltip="Toggle edit mode"
+				onClick={toggleEditMode}
+				icon={<FontAwesomeIcon icon={faPen} />}
+			/>
 		</>
 	);
 };

--- a/web/ui/react-app/src/components/approvals/toolbar/filter-dropdown.tsx
+++ b/web/ui/react-app/src/components/approvals/toolbar/filter-dropdown.tsx
@@ -1,4 +1,9 @@
-import { ButtonGroup, Dropdown } from 'react-bootstrap';
+import {
+	ButtonGroup,
+	Dropdown,
+	OverlayTrigger,
+	Tooltip,
+} from 'react-bootstrap';
 import { FC, useMemo } from 'react';
 
 import { ApprovalsToolbarOptions } from 'types/util';
@@ -66,12 +71,22 @@ const FilterDropdown: FC<Props> = ({ values, setValue }) => {
 				break;
 		}
 	};
+	const filterButtonTooltip = 'Filter shown services';
 
 	return (
 		<Dropdown as={ButtonGroup}>
-			<Dropdown.Toggle variant="secondary" className="border-0">
-				<FontAwesomeIcon icon={faEye} />
-			</Dropdown.Toggle>
+			<OverlayTrigger
+				delay={{ show: 500, hide: 500 }}
+				overlay={<Tooltip id="tooltip-help">{filterButtonTooltip}</Tooltip>}
+			>
+				<Dropdown.Toggle
+					variant="secondary"
+					className="border-0"
+					aria-label={filterButtonTooltip}
+				>
+					<FontAwesomeIcon icon={faEye} />
+				</Dropdown.Toggle>
+			</OverlayTrigger>
 			<Dropdown.Menu>
 				{hideOptions.map(({ key, label, value }) => (
 					<Dropdown.Item

--- a/web/ui/react-app/src/components/approvals/toolbar/search-bar.tsx
+++ b/web/ui/react-app/src/components/approvals/toolbar/search-bar.tsx
@@ -77,9 +77,14 @@ const SearchBar: FC<Props> = ({ search, setSearch }) => {
 				placeholder={placeholder}
 				value={search}
 				onChange={(e) => setSearch(e.target.value)}
+				aria-label="Search and filter services by name"
 			/>
 			{search && (
-				<Button variant="outline-secondary" onClick={() => setSearch('')}>
+				<Button
+					variant="outline-secondary"
+					onClick={() => setSearch('')}
+					aria-label="Clear search"
+				>
 					<FontAwesomeIcon icon={faTimes} />
 				</Button>
 			)}

--- a/web/ui/react-app/src/components/approvals/toolbar/tag-select.tsx
+++ b/web/ui/react-app/src/components/approvals/toolbar/tag-select.tsx
@@ -50,6 +50,7 @@ const TagSelect: FC<Props> = ({ tags, setTags }) => {
 				noOptionsMessage={() => 'No matches'}
 				components={customComponents}
 				styles={customStylesFixedHeight}
+				aria-label="Select tag to filter services by"
 			/>
 		</Col>
 	);

--- a/web/ui/react-app/src/components/generic/boolean-with-default.tsx
+++ b/web/ui/react-app/src/components/generic/boolean-with-default.tsx
@@ -61,8 +61,12 @@ const BooleanWithDefault: FC<Props> = ({
 			style={{ display: 'flex', alignItems: 'center' }}
 		>
 			<>
-				{label && <FormLabel style={{ float: 'left' }}>{label}</FormLabel>}
-				{tooltip && <HelpTooltip text={tooltip} />}
+				{label && (
+					<FormLabel id={name + '-label'} style={{ float: 'left' }}>
+						{label}
+					</FormLabel>
+				)}
+				{tooltip && <HelpTooltip id={name + '-tooltip'} tooltip={tooltip} />}
 			</>
 
 			<div
@@ -80,7 +84,10 @@ const BooleanWithDefault: FC<Props> = ({
 						const boolValue = strToBool(value);
 						return (
 							<>
-								<ButtonGroup>
+								<ButtonGroup
+									aria-labelledby={name + '-label'}
+									aria-describedby={tooltip && name + '-tooltip'}
+								>
 									{options.map((option) => (
 										<Button
 											name={`${name}-${option.value}`}

--- a/web/ui/react-app/src/components/generic/button-with-tooltip.tsx
+++ b/web/ui/react-app/src/components/generic/button-with-tooltip.tsx
@@ -1,0 +1,49 @@
+import { Button, OverlayTrigger, Tooltip } from 'react-bootstrap';
+import { FC, ReactElement } from 'react';
+
+type ButtonWithTooltipProps = {
+	hoverTooltip?: boolean;
+	tooltip: string;
+	onClick: () => void;
+	icon: ReactElement;
+};
+
+/**
+ * A button that displays a tooltip on hover.
+ *
+ * @param hoverTooltip - Whether the tooltip should be displayed on hover.
+ * @param tooltip - The text to display in the tooltip.
+ * @param onClick - The function to call when the button is clicked.
+ * @param icon - The icon to display on the button.
+ */
+const ButtonWithTooltip: FC<ButtonWithTooltipProps> = ({
+	hoverTooltip,
+	tooltip,
+	onClick,
+	icon,
+}) => {
+	const button = (
+		<Button
+			variant="secondary"
+			className="border-0"
+			onClick={onClick}
+			aria-label={tooltip}
+		>
+			{icon}
+		</Button>
+	);
+
+	if (hoverTooltip) {
+		return (
+			<OverlayTrigger
+				delay={{ show: 500, hide: 500 }}
+				overlay={<Tooltip id="tooltip-help">{tooltip}</Tooltip>}
+			>
+				{button}
+			</OverlayTrigger>
+		);
+	}
+	return button;
+};
+
+export default ButtonWithTooltip;

--- a/web/ui/react-app/src/components/generic/form-check.tsx
+++ b/web/ui/react-app/src/components/generic/form-check.tsx
@@ -1,13 +1,14 @@
 import { Col, FormCheck as FormCheckRB, FormGroup } from 'react-bootstrap';
-import { FC, JSX } from 'react';
 
+import { FC } from 'react';
 import { FormCheckType } from 'react-bootstrap/esm/FormCheck';
 import FormLabel from './form-label';
 import { Position } from 'types/config';
+import { TooltipWithAriaProps } from './tooltip';
 import { formPadding } from './util';
 import { useFormContext } from 'react-hook-form';
 
-interface FormCheckProps {
+type Props = {
 	name: string;
 
 	col_xs?: number;
@@ -15,12 +16,13 @@ interface FormCheckProps {
 	size?: 'sm' | 'lg';
 	label?: string;
 	smallLabel?: boolean;
-	tooltip?: string | JSX.Element;
 	type?: FormCheckType;
 
 	position?: Position;
 	positionXS?: Position;
-}
+};
+
+type FormCheckProps = TooltipWithAriaProps & Props;
 
 /**
  * A form checkbox
@@ -32,6 +34,7 @@ interface FormCheckProps {
  * @param label - The form label to display.
  * @param smallLabel - Whether the label should be small.
  * @param tooltip - The tooltip to display.
+ * @param tooltipAriaLabel - The aria label for the tooltip (Defaults to the tooltip).
  * @param type - The type of the checkbox.
  * @param position - The position of the field.
  * @param positionXS - The position of the field on extra small screens.
@@ -46,6 +49,7 @@ const FormCheck: FC<FormCheckProps> = ({
 	label,
 	smallLabel,
 	tooltip,
+	tooltipAriaLabel,
 	type = 'checkbox',
 
 	position = 'left',
@@ -54,14 +58,25 @@ const FormCheck: FC<FormCheckProps> = ({
 	const { register } = useFormContext();
 
 	const padding = formPadding({ col_xs, col_sm, position, positionXS });
+	const getTooltipProps = () => {
+		if (!tooltip) return {};
+		if (typeof tooltip === 'string') return { tooltip, tooltipAriaLabel };
+		return { tooltip, tooltipAriaLabel };
+	};
 
 	return (
 		<Col xs={col_xs} sm={col_sm} className={`${padding} pt-1 pb-1 col-form`}>
 			<FormGroup>
 				{label && (
-					<FormLabel text={label} tooltip={tooltip} small={!!smallLabel} />
+					<FormLabel
+						htmlFor={name}
+						text={label}
+						{...getTooltipProps()}
+						small={!!smallLabel}
+					/>
 				)}
 				<FormCheckRB
+					id={name}
 					className={`form-check${size === 'lg' ? '-large' : ''}`}
 					type={type}
 					autoFocus={false}

--- a/web/ui/react-app/src/components/generic/form-colour.tsx
+++ b/web/ui/react-app/src/components/generic/form-colour.tsx
@@ -4,6 +4,7 @@ import { useFormContext, useWatch } from 'react-hook-form';
 import { FC } from 'react';
 import FormLabel from './form-label';
 import { Position } from 'types/config';
+import cx from 'classnames';
 import { formPadding } from './util';
 import { useError } from 'hooks/errors';
 
@@ -49,6 +50,7 @@ const FormColour: FC<Props> = ({
 	const hexColour: string = useWatch({ name: name });
 	const trimmedHex = hexColour?.replace('#', '');
 	const error = useError(name, true);
+
 	const padding = formPadding({ col_xs, col_sm, position, positionXS });
 	const setColour = (hex: string) =>
 		setValue(name, hex.substring(1), { shouldDirty: true });
@@ -57,12 +59,17 @@ const FormColour: FC<Props> = ({
 		<Col xs={col_xs} sm={col_sm} className={`${padding} pt-1 pb-1 col-form`}>
 			<FormGroup style={{ display: 'flex', flexDirection: 'column' }}>
 				<div>
-					<FormLabel text={label} tooltip={tooltip} />
+					<FormLabel htmlFor={name} text={label} tooltip={tooltip} />
 				</div>
 				<div style={{ display: 'flex', flexWrap: 'nowrap' }}>
 					<InputGroup className="mb-2">
-						<InputGroup.Text>#</InputGroup.Text>
+						<InputGroup.Text aria-hidden="true">#</InputGroup.Text>
 						<FormControl
+							id={name}
+							aria-describedby={cx(
+								error && name + '-error',
+								tooltip && name + '-tooltip',
+							)}
 							style={{ width: '25%' }}
 							type="text"
 							defaultValue={trimmedHex}
@@ -78,10 +85,11 @@ const FormColour: FC<Props> = ({
 							isInvalid={error !== undefined}
 						/>
 						<FormControl
+							aria-label="Select a colour"
 							className="form-control-color"
 							style={{ width: '30%' }}
 							type="color"
-							title="Choose your color"
+							title="Choose your colour"
 							value={`#${trimmedHex || defaultVal?.replace('#', '')}`}
 							onChange={(event) => setColour(event.target.value)}
 							autoFocus={false}
@@ -90,7 +98,9 @@ const FormColour: FC<Props> = ({
 				</div>
 			</FormGroup>
 			{error && (
-				<small className="error-msg">{error['message'] || 'err'}</small>
+				<small id={name + '-error'} className="error-msg" role="alert">
+					{error['message'] || 'err'}
+				</small>
 			)}
 		</Col>
 	);

--- a/web/ui/react-app/src/components/generic/form-key-val.tsx
+++ b/web/ui/react-app/src/components/generic/form-key-val.tsx
@@ -34,6 +34,7 @@ const FormKeyVal: FC<Props> = ({
 	<>
 		<Col xs={2} sm={1} style={{ padding: '0.25rem' }}>
 			<Button
+				aria-label="Delete this key-value pair"
 				className="btn-secondary-outlined btn-icon-center"
 				variant="secondary"
 				onClick={removeMe}

--- a/web/ui/react-app/src/components/generic/form-label.tsx
+++ b/web/ui/react-app/src/components/generic/form-label.tsx
@@ -1,33 +1,42 @@
-import { FC, JSX } from 'react';
-
+import { FC } from 'react';
 import { Form } from 'react-bootstrap';
 import { HelpTooltip } from 'components/generic';
+import { TooltipWithAriaProps } from './tooltip';
 
-interface FormLabelProps {
+type Props = {
+	id?: string;
+	htmlFor?: string;
 	text: string;
-	tooltip?: string | JSX.Element;
 	heading?: boolean;
 	required?: boolean;
 	small?: boolean;
-}
+};
+
+type FormLabelProps = TooltipWithAriaProps & Props;
 
 /**
  * A label for a form item.
  *
+ * @param id - The ID of this label.
+ * @param htmlFor - The ID of the item this label is for.
  * @param text - The text of the label.
  * @param tooltip - The tooltip of the label.
+ * @param tooltipAriaLabel - The aria label for the tooltip (Defaults to the tooltip).
  * @param heading - Whether the label is a heading.
  * @param required - Whether the label is required.
  * @param small - Whether the label is small.
  * @returns A label for a form item.
  */
 const FormLabel: FC<FormLabelProps> = ({
+	id,
+	htmlFor,
 	text,
 	tooltip,
+	tooltipAriaLabel,
 	heading,
 	required,
 	small,
-}: FormLabelProps) => {
+}) => {
 	const style = () => {
 		if (heading)
 			return {
@@ -43,10 +52,16 @@ const FormLabel: FC<FormLabelProps> = ({
 	};
 
 	return (
-		<Form.Label style={style()}>
+		<Form.Label id={id} htmlFor={htmlFor} style={style()}>
 			{text}
 			{required && <span className="text-danger">*</span>}
-			{tooltip && <HelpTooltip text={tooltip} />}
+			{tooltip && (
+				<HelpTooltip
+					id={`${htmlFor}-tooltip`}
+					tooltip={tooltip}
+					tooltipAriaLabel={tooltipAriaLabel ?? tooltip}
+				/>
+			)}
 		</Form.Label>
 	);
 };

--- a/web/ui/react-app/src/components/generic/form-text-area.tsx
+++ b/web/ui/react-app/src/components/generic/form-text-area.tsx
@@ -1,8 +1,10 @@
 import { Col, FormControl, FormGroup } from 'react-bootstrap';
-import { FC, JSX } from 'react';
 
+import { FC } from 'react';
 import FormLabel from './form-label';
 import { Position } from 'types/config';
+import { TooltipWithAriaProps } from './tooltip';
+import cx from 'classnames';
 import { formPadding } from './util';
 import { requiredTest } from './form-validate';
 import { useError } from 'hooks/errors';
@@ -15,7 +17,6 @@ interface Props {
 	col_xs?: number;
 	col_sm?: number;
 	label?: string;
-	tooltip?: string | JSX.Element;
 
 	defaultVal?: string;
 	placeholder?: string;
@@ -24,6 +25,8 @@ interface Props {
 	position?: Position;
 	positionXS?: Position;
 }
+
+type FormTextAreaProps = TooltipWithAriaProps & Props;
 
 /**
  * A form textarea
@@ -34,6 +37,7 @@ interface Props {
  * @param col_sm - The number of columns the item takes up on SM+ screens.
  * @param label - The label of the form item.
  * @param tooltip - The tooltip of the form item.
+ * @param tooltipAriaLabel - The aria label for the tooltip (Defaults to the tooltip).
  * @param defaultVal - The default value of the form item.
  * @param placeholder - The placeholder of the form item.
  * @param rows - The number of rows for the textarea.
@@ -41,7 +45,7 @@ interface Props {
  * @param positionXS - The position of the form item on extra small screens.
  * @returns A form textarea with a label and tooltip.
  */
-const FormTextArea: FC<Props> = ({
+const FormTextArea: FC<FormTextAreaProps> = ({
 	name,
 	required,
 
@@ -49,6 +53,7 @@ const FormTextArea: FC<Props> = ({
 	col_sm = 6,
 	label,
 	tooltip,
+	tooltipAriaLabel,
 
 	defaultVal,
 	placeholder,
@@ -61,14 +66,29 @@ const FormTextArea: FC<Props> = ({
 	const error = useError(name, required);
 
 	const padding = formPadding({ col_xs, col_sm, position, positionXS });
+	const getTooltipProps = () => {
+		if (!tooltip) return {};
+		if (typeof tooltip === 'string') return { tooltip, tooltipAriaLabel };
+		return { tooltip, tooltipAriaLabel };
+	};
 
 	return (
 		<Col xs={col_xs} sm={col_sm} className={`${padding} pt-1 pb-1 col-form`}>
 			<FormGroup>
 				{label && (
-					<FormLabel text={label} tooltip={tooltip} required={required} />
+					<FormLabel
+						htmlFor={name}
+						text={label}
+						{...getTooltipProps()}
+						required={required}
+					/>
 				)}
 				<FormControl
+					id={name}
+					aria-describedby={cx(
+						error && name + '-error',
+						tooltip && name + '-tooltip',
+					)}
 					type={'textarea'}
 					as="textarea"
 					rows={rows}
@@ -89,7 +109,9 @@ const FormTextArea: FC<Props> = ({
 					isInvalid={!!error}
 				/>
 				{error && (
-					<small className="error-msg">{error['message'] || 'err'}</small>
+					<small id={name + '-error'} className="error-msg" role="alert">
+						{error['message'] || 'err'}
+					</small>
 				)}
 			</FormGroup>
 		</Col>

--- a/web/ui/react-app/src/components/generic/form-text-with-preview.tsx
+++ b/web/ui/react-app/src/components/generic/form-text-with-preview.tsx
@@ -3,6 +3,7 @@ import { FC, useCallback, useEffect, useState } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 
 import FormLabel from './form-label';
+import cx from 'classnames';
 import { urlTest } from './form-validate';
 import { useError } from 'hooks/errors';
 
@@ -63,9 +64,15 @@ const FormTextWithPreview: FC<Props> = ({
 	return (
 		<Col xs={12} sm={12} className={'pt-1 pb-1 col-form'}>
 			<FormGroup>
-				<FormLabel text={label} tooltip={tooltip} />
+				<FormLabel htmlFor={name} text={label} tooltip={tooltip} />
 				<div style={{ display: 'flex', alignItems: 'center' }}>
 					<FormControl
+						id={name}
+						aria-label={`Select options for ${label}`}
+						aria-describedby={cx(
+							error && name + '-error',
+							tooltip && name + '-tooltip',
+						)}
 						type="text"
 						value={formValue}
 						placeholder={placeholder || defaultVal}
@@ -81,6 +88,7 @@ const FormTextWithPreview: FC<Props> = ({
 					/>{' '}
 					{previewURL && (
 						<div
+							aria-label="Preview of the image"
 							style={{
 								maxWidth: '3em',
 								marginLeft: 'auto',
@@ -96,7 +104,9 @@ const FormTextWithPreview: FC<Props> = ({
 				</div>
 			</FormGroup>
 			{error && (
-				<small className="error-msg">{error['message'] || 'err'}</small>
+				<small id={name + '-error'} className="error-msg" role="alert">
+					{error['message'] || 'err'}
+				</small>
 			)}
 		</Col>
 	);

--- a/web/ui/react-app/src/components/generic/form-text.tsx
+++ b/web/ui/react-app/src/components/generic/form-text.tsx
@@ -10,6 +10,8 @@ import {
 
 import FormLabel from './form-label';
 import { Position } from 'types/config';
+import { TooltipWithAriaProps } from './tooltip';
+import cx from 'classnames';
 import { formPadding } from './util';
 import { useError } from 'hooks/errors';
 import { useFormContext } from 'react-hook-form';
@@ -24,7 +26,6 @@ interface Props {
 	col_sm?: number;
 	label?: string;
 	smallLabel?: boolean;
-	tooltip?: string | JSX.Element;
 	type?: 'text' | 'url';
 	labelButton?: JSX.Element;
 
@@ -39,6 +40,8 @@ interface Props {
 	positionXS?: Position;
 }
 
+type FormTextProps = TooltipWithAriaProps & Props;
+
 /**
  * A form text input item.
  *
@@ -51,6 +54,7 @@ interface Props {
  * @param label - The label of the form item.
  * @param smallLabel - Whether the label should be small.
  * @param tooltip - The tooltip of the form item.
+ * @param tooltipAriaLabel - The aria label for the tooltip (Defaults to the tooltip).
  * @param type - The type of the form item.
  * @param isNumber - Whether the form item should be a number.
  * @param isRegex - Whether the form item should be a regex.
@@ -62,7 +66,7 @@ interface Props {
  * @param positionXS - The position of the form item on extra small screens.
  * @returns A form text input item at name with a label and tooltip.
  */
-const FormText: FC<Props> = ({
+const FormText: FC<FormTextProps> = ({
 	name,
 	registerParams = {},
 	required = false,
@@ -73,6 +77,7 @@ const FormText: FC<Props> = ({
 	label,
 	smallLabel,
 	tooltip,
+	tooltipAriaLabel,
 	type = 'text',
 	labelButton,
 
@@ -97,6 +102,11 @@ const FormText: FC<Props> = ({
 	);
 
 	const padding = formPadding({ col_xs, col_sm, position, positionXS });
+	const getTooltipProps = () => {
+		if (!tooltip) return {};
+		if (typeof tooltip === 'string') return { tooltip, tooltipAriaLabel };
+		return { tooltip, tooltipAriaLabel };
+	};
 
 	return (
 		<Col xs={col_xs} sm={col_sm} className={`${padding} pt-1 pb-1 col-form`}>
@@ -109,8 +119,9 @@ const FormText: FC<Props> = ({
 						}
 					>
 						<FormLabel
+							htmlFor={name}
 							text={label}
-							tooltip={tooltip}
+							{...getTooltipProps()}
 							required={required !== false}
 							small={!!smallLabel}
 						/>
@@ -118,6 +129,9 @@ const FormText: FC<Props> = ({
 					</div>
 				)}
 				<FormControl
+					id={name}
+					aria-label={`Select options for ${label}`}
+					aria-describedby={cx(error && name + '-error')}
 					type={type}
 					placeholder={defaultVal || placeholder}
 					autoFocus={false}
@@ -145,7 +159,9 @@ const FormText: FC<Props> = ({
 					isInvalid={!!error}
 				/>
 				{error && (
-					<small className="error-msg">{error['message'] || 'err'}</small>
+					<small id={name + '-error'} className="error-msg" role="alert">
+						{error['message'] || 'err'}
+					</small>
 				)}
 			</FormGroup>
 		</Col>

--- a/web/ui/react-app/src/components/generic/tooltip.tsx
+++ b/web/ui/react-app/src/components/generic/tooltip.tsx
@@ -4,25 +4,41 @@ import { OverlayTrigger, Tooltip } from 'react-bootstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faQuestionCircle } from '@fortawesome/free-solid-svg-icons';
 
-interface Props {
-	text: string | JSX.Element;
+export type TooltipWithAriaProps =
+	| { tooltip: string; tooltipAriaLabel?: string }
+	| { tooltip: JSX.Element; tooltipAriaLabel: string }
+	| { tooltip?: never; tooltipAriaLabel?: never };
+
+type Props = {
+	id?: string;
 	placement?: 'top' | 'right' | 'bottom' | 'left';
-}
+};
+
+type HelpTooltipProps = TooltipWithAriaProps & Props;
 
 /**
  * A tooltip inside a question mark icon.
  *
- * @param text - The text to display in the tooltip.
+ * @param id - The id of the tooltip.
+ * @param tooltip - The text to display in the tooltip.
+ * @param tooltipAriaLabel - The aria label for the tooltip (Defaults to the text).
  * @param placement - The placement of the tooltip.
  * @returns A hoverable tooltip inside a question mark icon.
  */
-const HelpTooltip: FC<Props> = ({ text, placement = 'top' }) => (
+const HelpTooltip: FC<HelpTooltipProps> = ({
+	id,
+	tooltip,
+	tooltipAriaLabel,
+	placement = 'top',
+}) => (
 	<OverlayTrigger
 		placement={placement}
 		delay={{ show: 500, hide: 500 }}
-		overlay={<Tooltip id="help-tooltip">{text}</Tooltip>}
+		overlay={<Tooltip id="tooltip-help">{tooltip}</Tooltip>}
 	>
 		<FontAwesomeIcon
+			id={id}
+			aria-label={tooltipAriaLabel ?? tooltip}
 			icon={faQuestionCircle}
 			style={{
 				paddingLeft: '0.25em',

--- a/web/ui/react-app/src/components/generic/util.tsx
+++ b/web/ui/react-app/src/components/generic/util.tsx
@@ -97,3 +97,15 @@ export const formPadding = ({
 
 	return paddingClasses.join(' ');
 };
+
+/**
+ * Pluralise a string.
+ *
+ * @param str - The string to pluralise.
+ * @param count - The count of the string.
+ * @returns The pluralised string (if count is not 1).
+ */
+export const pluralise = (str: string, count?: number): string => {
+	if (count !== 1) return str + 's';
+	return str;
+};

--- a/web/ui/react-app/src/components/modals/action-release/item.tsx
+++ b/web/ui/react-app/src/components/modals/action-release/item.tsx
@@ -18,6 +18,7 @@ import {
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { ModalType } from 'types/summary';
+import cx from 'classnames';
 
 interface Props {
 	itemType: 'COMMAND' | 'WEBHOOK';
@@ -101,6 +102,7 @@ export const Item: FC<Props> = ({
 		// Resend.
 		return faRedo;
 	};
+	const id = title.replace(' ', '_').toLowerCase();
 
 	return (
 		<Card bg="secondary" className={'no-margin service'}>
@@ -114,7 +116,7 @@ export const Item: FC<Props> = ({
 						placement="top"
 						delay={{ show: 500, hide: 500 }}
 						overlay={
-							<Tooltip id={`tooltip-status`}>
+							<Tooltip id={id + '-resend-date'}>
 								{`Can resend ${formatRelative(
 									new Date(next_runnable),
 									new Date(),
@@ -147,7 +149,7 @@ export const Item: FC<Props> = ({
 						placement="top"
 						delay={{ show: 500, hide: 500 }}
 						overlay={
-							<Tooltip id={`tooltip-status`}>
+							<Tooltip id={id + '-result'}>
 								{failed === true ? 'Failed' : 'Successful'}
 							</Tooltip>
 						}
@@ -179,7 +181,7 @@ export const Item: FC<Props> = ({
 						placement="top"
 						delay={{ show: 500, hide: 500 }}
 						overlay={
-							<Tooltip id={`tooltip-send`}>
+							<Tooltip id={id + '-send'}>
 								{modalType === 'RESEND' || failed !== undefined
 									? 'Retry'
 									: 'Send'}
@@ -187,6 +189,11 @@ export const Item: FC<Props> = ({
 						}
 					>
 						<Button
+							aria-describedby={cx(
+								id + '-send',
+								!sendable && !sending && id + '-resend-date',
+								!sending && failed !== undefined && id + '-result',
+							)}
 							variant="secondary"
 							size="sm"
 							onClick={() => ack(title, itemType === 'WEBHOOK')}

--- a/web/ui/react-app/src/components/modals/action-release/loading.tsx
+++ b/web/ui/react-app/src/components/modals/action-release/loading.tsx
@@ -30,10 +30,11 @@ export const Loading: FC<Props> = ({ modalType, delayedRender }) => {
 
 				{modalType !== 'SKIP' && (
 					<Button
+						aria-label="Loading..."
 						variant="secondary"
 						size="sm"
 						className="float-end"
-						// Disable if success or waiting send response.
+						// Disable if success, or awaiting send response.
 						disabled
 					>
 						<FontAwesomeIcon icon={faSquareFull} />

--- a/web/ui/react-app/src/components/modals/service-edit/command.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/command.tsx
@@ -55,12 +55,17 @@ const Command: FC<Props> = ({ name, removeMe }) => {
 			</Row>
 
 			{removeMe && (
-				<Button className="btn-unchecked float-left" onClick={() => removeMe()}>
+				<Button
+					aria-label="Delete this command"
+					className="btn-unchecked float-left"
+					onClick={() => removeMe()}
+				>
 					<FontAwesomeIcon icon={faTrash} />
 				</Button>
 			)}
 			<ButtonGroup aria-label="Add/Remove arguments" style={{ float: 'right' }}>
 				<Button
+					aria-label="Add an argument"
 					className="btn-unchecked mb-3"
 					style={{ float: 'right' }}
 					onClick={addItem}
@@ -68,6 +73,7 @@ const Command: FC<Props> = ({ name, removeMe }) => {
 					<FontAwesomeIcon icon={faPlus} />
 				</Button>
 				<Button
+					aria-label="Remove the last argument"
 					className="btn-unchecked mb-3"
 					style={{ float: 'right' }}
 					onClick={removeLast}

--- a/web/ui/react-app/src/components/modals/service-edit/deployed-version.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/deployed-version.tsx
@@ -138,6 +138,7 @@ const EditServiceDeployedVersion: FC<Props> = ({
 								<span className="bold-underline">data.version</span>
 							</>
 						}
+						tooltipAriaLabel="If the URL gives JSON, take the var at this location. e.g. data.version"
 					/>
 					<FormText
 						name="deployed_version.regex"
@@ -151,6 +152,7 @@ const EditServiceDeployedVersion: FC<Props> = ({
 								<span className="bold-underline">v([0-9.]+)</span>
 							</>
 						}
+						tooltipAriaLabel="RegEx to extract the version from the URL, e.g. v([0-9.]+)"
 						isRegex
 						position="middle"
 					/>

--- a/web/ui/react-app/src/components/modals/service-edit/latest-version-urlcommand.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/latest-version-urlcommand.tsx
@@ -33,6 +33,7 @@ const FormURLCommand: FC<Props> = ({ name, removeMe }) => {
 		<>
 			<Col xs={2} sm={1} style={{ height: '100%', padding: '0.25rem' }}>
 				<Button
+					aria-label="Delete this URL command"
 					className="btn-secondary-outlined btn-icon-center"
 					variant="secondary"
 					onClick={removeMe}

--- a/web/ui/react-app/src/components/modals/service-edit/latest-version.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/latest-version.tsx
@@ -67,6 +67,20 @@ const EditServiceLatestVersion: FC<Props> = ({
 		[defaults, hard_defaults],
 	);
 
+	const getTooltipProps = () => {
+		if (latestVersionType == 'github')
+			return {
+				tooltip: (
+					<>
+						{'https://github.com/'}
+						<span className="bold-underline">OWNER/REPO</span>
+					</>
+				),
+				tooltipAriaLabel: 'Format: https://github.com/OWNER/REPO',
+			};
+		return {};
+	};
+
 	return (
 		<Accordion>
 			<Accordion.Header>Latest Version:</Accordion.Header>
@@ -85,14 +99,7 @@ const EditServiceLatestVersion: FC<Props> = ({
 						required
 						col_sm={8}
 						col_xs={8}
-						tooltip={
-							latestVersionType === 'github' ? (
-								<>
-									{'https://github.com/'}
-									<span className="bold-underline">OWNER/REPO</span>
-								</>
-							) : undefined
-						}
+						{...getTooltipProps()}
 						position="right"
 					/>
 					{latestVersionType === 'github' ? (

--- a/web/ui/react-app/src/components/modals/service-edit/notifiers.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/notifiers.tsx
@@ -29,7 +29,7 @@ interface Props {
  * @param loading - Whether the modal is loading.
  * @returns The form fields for a mutable list of notifiers.
  */
-const EditServiceNotifies: FC<Props> = ({
+const EditServiceNotifiers: FC<Props> = ({
 	serviceID,
 
 	originals,
@@ -95,4 +95,4 @@ const EditServiceNotifies: FC<Props> = ({
 	);
 };
 
-export default memo(EditServiceNotifies);
+export default memo(EditServiceNotifiers);

--- a/web/ui/react-app/src/components/modals/service-edit/notify-types/discord.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/notify-types/discord.tsx
@@ -98,6 +98,7 @@ const DISCORD = ({
 							/token
 						</>
 					}
+					tooltipAriaLabel="Format: https://discord.com/api/webhooks/WEBHOOK_ID/token"
 					defaultVal={convertedDefaults.url_fields.webhookid}
 				/>
 				<FormText
@@ -110,6 +111,7 @@ const DISCORD = ({
 							<span className="bold-underline">token</span>
 						</>
 					}
+					tooltipAriaLabel="Format: https://discord.com/api/webhooks/webhook_id/TOKEN"
 					defaultVal={convertedDefaults.url_fields.token}
 					position="right"
 				/>

--- a/web/ui/react-app/src/components/modals/service-edit/notify-types/extra/ntfy/action.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/notify-types/extra/ntfy/action.tsx
@@ -42,6 +42,7 @@ const NtfyAction: FC<Props> = ({ name, defaults, removeMe }) => {
 		<>
 			<Col xs={2} sm={1} style={{ padding: '0.25rem' }}>
 				<Button
+					aria-label="Remove this action"
 					className="btn-secondary-outlined btn-icon-center"
 					variant="secondary"
 					onClick={removeMe}

--- a/web/ui/react-app/src/components/modals/service-edit/notify-types/extra/opsgenie/target.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/notify-types/extra/opsgenie/target.tsx
@@ -37,6 +37,7 @@ const OpsGenieTarget: FC<Props> = ({ name, removeMe, defaults }) => {
 		<>
 			<Col xs={2} sm={1} style={{ padding: '0.25rem' }}>
 				<Button
+					aria-label="Remove this target"
 					className="btn-secondary-outlined btn-icon-center"
 					variant="secondary"
 					onClick={removeMe}

--- a/web/ui/react-app/src/components/modals/service-edit/notify-types/generic.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/notify-types/generic.tsx
@@ -198,6 +198,7 @@ const GENERIC = ({
 								<span className="bold-underline">path</span>
 							</>
 						}
+						tooltipAriaLabel="Format: mattermost.example.io/PATH"
 						defaultVal={convertedDefaults.url_fields.path}
 					/>
 					<FormKeyValMap

--- a/web/ui/react-app/src/components/modals/service-edit/notify-types/gotify.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/notify-types/gotify.tsx
@@ -114,6 +114,7 @@ const GOTIFY = ({
 							<span className="bold-underline">path</span>
 						</>
 					}
+					tooltipAriaLabel="Format: gotify.example.io/PATH"
 					defaultVal={convertedDefaults.url_fields.path}
 				/>
 				<FormText

--- a/web/ui/react-app/src/components/modals/service-edit/notify-types/mattermost.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/notify-types/mattermost.tsx
@@ -114,6 +114,7 @@ const MATTERMOST = ({
 							<span className="bold-underline">path</span>
 						</>
 					}
+					tooltipAriaLabel="Format: mattermost.example.io/PATH"
 					defaultVal={convertedDefaults.url_fields.path}
 				/>
 				<FormText

--- a/web/ui/react-app/src/components/modals/service-edit/notify-types/rocketchat.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/notify-types/rocketchat.tsx
@@ -107,6 +107,7 @@ const ROCKET_CHAT = ({
 							<span className="bold-underline">path</span>
 						</>
 					}
+					tooltipAriaLabel="Format: rocketchat.example.io/PATH"
 					defaultVal={convertedDefaults.url_fields.path}
 				/>
 				<FormText

--- a/web/ui/react-app/src/components/modals/service-edit/notify-types/slack.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/notify-types/slack.tsx
@@ -96,6 +96,7 @@ const SLACK = ({
 							<span className="bold-underline">WEBHOOK</span>
 						</>
 					}
+					tooltipAriaLabel="Format: xoxb:BOT-OAUTH-TOKEN or WEBHOOK"
 					defaultVal={convertedDefaults.url_fields.token}
 				/>
 				<FormText

--- a/web/ui/react-app/src/components/modals/service-edit/notify-types/smtp.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/notify-types/smtp.tsx
@@ -268,7 +268,8 @@ const SMTP = ({
 					name={`${name}.params.clienthost`}
 					col_sm={8}
 					label="Client Host"
-					tooltip={`The client host name sent to the SMTP server during HELLO phase. If set to "auto", it will use the OS hostname`}
+					tooltip={`The client host name sent to the SMTP server during HELO phase.
+						If set to "auto", it will use the OS hostname`}
 					defaultVal={convertedDefaults.params.clienthost}
 					position="right"
 				/>

--- a/web/ui/react-app/src/components/modals/service-edit/notify.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/notify.tsx
@@ -125,6 +125,7 @@ const Notify: FC<Props> = ({
 		<Accordion>
 			<div style={{ display: 'flex', alignItems: 'center' }}>
 				<Button
+					aria-label="Delete this notifier"
 					className="btn-unchecked"
 					variant="secondary"
 					onClick={removeMe}
@@ -147,7 +148,7 @@ const Notify: FC<Props> = ({
 						name={`${name}.type`}
 						col_xs={6}
 						label="Type"
-						customValidation={(value) => {
+						customValidation={(value: string) => {
 							if (
 								itemType !== undefined &&
 								mains?.[itemName]?.type &&

--- a/web/ui/react-app/src/components/modals/service-edit/root.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/root.tsx
@@ -48,12 +48,13 @@ const EditServiceRoot: FC<Props> = ({ id, name, original_name, loading }) => {
 			placement="top"
 			delay={{ show: 500, hide: 500 }}
 			overlay={
-				<Tooltip id="help-tooltip">
+				<Tooltip id="name-toggle-tooltip">
 					Toggle to separate ID (service key) and Name in the config YAML
 				</Tooltip>
 			}
 		>
 			<Button
+				aria-describedby="name-toggle-tooltip"
 				name="separate_name_toggle"
 				id="separate_name_toggle"
 				className={`btn-border btn-${separateName ? '' : 'un'}checked pad-no`}
@@ -96,6 +97,28 @@ const EditServiceRoot: FC<Props> = ({ id, name, original_name, loading }) => {
 		);
 	};
 
+	const getTooltipProps = () => {
+		if (!separateName) return {};
+		return {
+			tooltip: (
+				<pre
+					style={{
+						margin: 0,
+						textAlign: 'left',
+						whiteSpace: 'pre-wrap',
+					}}
+				>
+					{'services:\n  '}
+					<span className="bold-underline">ID</span>
+					{':\n    '}
+					<span className="bold-underline">NAME</span>
+					{': service_name\n    latest_version: ...'}
+				</pre>
+			),
+			tooltipAriaLabel: 'Format: services.ID.NAME=service_name',
+		};
+	};
+
 	return (
 		<FormGroup className="mb-2">
 			<Row style={{ position: 'relative' }}>
@@ -118,23 +141,7 @@ const EditServiceRoot: FC<Props> = ({ id, name, original_name, loading }) => {
 						},
 					}}
 					label={separateName ? 'ID' : 'Name'}
-					tooltip={
-						separateName ? (
-							<pre
-								style={{
-									margin: 0,
-									textAlign: 'left',
-									whiteSpace: 'pre-wrap',
-								}}
-							>
-								{'services:\n  '}
-								<span className="bold-underline">ID</span>
-								{':\n    '}
-								<span className="bold-underline">NAME</span>
-								{': service_name\n    latest_version: ...'}
-							</pre>
-						) : undefined
-					}
+					{...getTooltipProps()}
 				/>
 				{separateName && (
 					<FormText

--- a/web/ui/react-app/src/components/modals/service-edit/service.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/service.tsx
@@ -4,7 +4,7 @@ import EditServiceCommands from 'components/modals/service-edit/commands';
 import EditServiceDashboard from 'components/modals/service-edit/dashboard';
 import EditServiceDeployedVersion from 'components/modals/service-edit/deployed-version';
 import EditServiceLatestVersion from 'components/modals/service-edit/latest-version';
-import EditServiceNotifies from 'components/modals/service-edit/notifies';
+import EditServiceNotifiers from 'components/modals/service-edit/notifiers';
 import EditServiceOptions from 'components/modals/service-edit/options';
 import EditServiceRoot from 'components/modals/service-edit/root';
 import EditServiceWebHooks from 'components/modals/service-edit/webhooks';
@@ -72,7 +72,7 @@ const EditService: FC<Props> = ({
 				hard_defaults={otherOptionsData?.hard_defaults?.webhook as WebHookType}
 				loading={loading}
 			/>
-			<EditServiceNotifies
+			<EditServiceNotifiers
 				serviceID={id}
 				originals={defaultData?.notify}
 				mains={otherOptionsData?.notify}

--- a/web/ui/react-app/src/components/modals/service-edit/util/ui-api-conversions.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/util/ui-api-conversions.tsx
@@ -145,19 +145,18 @@ export const convertUILatestVersionDataEditToAPI = (
 	}
 
 	// Latest version - Require
-	if (data?.require)
-		converted.require = {
-			regex_content: data.require?.regex_content ?? '',
-			regex_version: data.require?.regex_version ?? '',
-			command: (data.require.command ?? []).map((obj) => (obj as ArgType).arg),
-			docker: {
-				type: data.require?.docker?.type ?? '',
-				image: data.require?.docker?.image,
-				tag: data.require?.docker?.tag ?? '',
-				username: data.require?.docker?.username ?? '',
-				token: data.require?.docker?.token ?? '',
-			},
-		};
+	converted.require = {
+		regex_content: data?.require?.regex_content ?? '',
+		regex_version: data?.require?.regex_version ?? '',
+		command: (data?.require?.command ?? []).map((obj) => (obj as ArgType).arg),
+		docker: {
+			type: data?.require?.docker?.type ?? '',
+			image: data?.require?.docker?.image,
+			tag: data?.require?.docker?.tag ?? '',
+			username: data?.require?.docker?.username ?? '',
+			token: data?.require?.docker?.token ?? '',
+		},
+	};
 
 	return converted;
 };
@@ -171,32 +170,26 @@ export const convertUILatestVersionDataEditToAPI = (
 export const convertUIDeployedVersionDataEditToAPI = (
 	data?: DeployedVersionLookupEditType,
 ): DeployedVersionLookupType | null => {
-	if (!data?.url) {
-		return null;
-	}
-
 	let converted: DeployedVersionLookupType = {
-		method: data.method,
-		url: data.url,
-		allow_invalid_certs: data.allow_invalid_certs,
-		headers: data.headers,
-		json: data.json ?? '',
-		regex: data.regex ?? '',
-		regex_template: data.regex_template ?? '',
+		method: data?.method,
+		url: data?.url,
+		allow_invalid_certs: data?.allow_invalid_certs,
+		headers: data?.headers ?? [],
+		json: data?.json ?? '',
+		regex: data?.regex ?? '',
+		regex_template: data?.regex_template ?? '',
 	};
 
 	// Method - POST
-	if (data.method === 'POST') {
-		converted.body = data.body ?? '';
+	if (data?.method === 'POST') {
+		converted.body = data?.body ?? '';
 	}
 
 	// Basic Auth
-	if (data.basic_auth?.username || data.basic_auth?.password) {
-		converted.basic_auth = {
-			username: data.basic_auth?.username ?? '',
-			password: data.basic_auth?.password ?? '',
-		};
-	}
+	converted.basic_auth = {
+		username: data?.basic_auth?.username ?? '',
+		password: data?.basic_auth?.password ?? '',
+	};
 
 	return converted;
 };

--- a/web/ui/react-app/src/components/modals/service-edit/version-with-refresh.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/version-with-refresh.tsx
@@ -54,14 +54,18 @@ const VersionWithRefresh: FC<Props> = ({
 	const dataTarget = vType === 0 ? 'latest_version' : 'deployed_version';
 	const convertedOriginal = useMemo(() => {
 		if (original === null) return {};
+		const preparedOriginal = serviceID
+			? original
+			: // Remove type from original if it's a new service.
+			  { ...original, type: '' };
 		// Latest version
 		if (dataTarget === 'latest_version')
 			return convertUILatestVersionDataEditToAPI(
-				original as LatestVersionLookupEditType,
+				preparedOriginal as LatestVersionLookupEditType,
 			);
 		// Deployed version
 		return convertUIDeployedVersionDataEditToAPI(
-			original as DeployedVersionLookupEditType,
+			preparedOriginal as DeployedVersionLookupEditType,
 		);
 	}, [original, serviceID, dataTarget]);
 	const url: string | undefined = useWatch({ name: `${dataTarget}.url` });
@@ -87,7 +91,7 @@ const VersionWithRefresh: FC<Props> = ({
 					params: data,
 					defaults: convertedOriginal,
 					target: dataTarget,
-				})
+			  })
 			: '';
 		return fetchJSON<ServiceRefreshType>({
 			url: `api/v1/${vType === 0 ? 'latest' : 'deployed'}_version/refresh${

--- a/web/ui/react-app/src/components/modals/service-edit/version-with-refresh.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/version-with-refresh.tsx
@@ -156,6 +156,7 @@ const VersionWithRefresh: FC<Props> = ({
 				{vType === 0 ? 'Latest' : 'Deployed'} version: {versionData.version}
 				{data?.url !== '' && isFetching && LoadingSpinner}
 				<Button
+					aria-label="Refresh the version"
 					variant="secondary"
 					style={{ marginLeft: 'auto', padding: '0 1rem' }}
 					onClick={refetch}

--- a/web/ui/react-app/src/components/modals/service-edit/webhook.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/webhook.tsx
@@ -117,6 +117,7 @@ const EditServiceWebHook: FC<Props> = ({
 		<Accordion>
 			<div style={{ display: 'flex', alignItems: 'center' }}>
 				<Button
+					aria-label="Delete this WebHook"
 					className="btn-unchecked"
 					variant="secondary"
 					onClick={removeMe}
@@ -137,7 +138,7 @@ const EditServiceWebHook: FC<Props> = ({
 					/>
 					<FormSelect
 						name={`${name}.type`}
-						customValidation={(value) => {
+						customValidation={(value: string) => {
 							if (
 								itemType !== undefined &&
 								mains?.[itemName]?.type &&

--- a/web/ui/react-app/src/components/notification/index.tsx
+++ b/web/ui/react-app/src/components/notification/index.tsx
@@ -57,6 +57,8 @@ const Notification: FC<NotificationType> = ({
 
 	return (
 		<Toast
+			aria-live="assertive"
+			role="alert"
 			id={`${id}`}
 			className={`m-1 alert-${type}`}
 			bg={type}
@@ -78,6 +80,7 @@ const Notification: FC<NotificationType> = ({
 					{formatRelative(new Date(small), new Date())}
 				</small>
 				<Button
+					aria-label={`Clear notification: ${title}`}
 					key="details"
 					className=""
 					variant="none"

--- a/web/ui/react-app/src/modals/service-edit.tsx
+++ b/web/ui/react-app/src/modals/service-edit.tsx
@@ -114,15 +114,20 @@ const ServiceEditModalGetData: FC<ServiceEditModalGetDataProps> = ({
 	);
 };
 
+type ServiceEditModalHeaderProps = {
+	type: 'Create' | 'Edit';
+};
+
 /**
  * @returns The header for the service edit modal.
  */
-const ServiceEditModalHeader = () => (
+const ServiceEditModalHeader: FC<ServiceEditModalHeaderProps> = ({ type }) => (
 	<Modal.Header closeButton>
 		<Modal.Title>
-			<strong>Edit Service</strong>
+			<strong>{`${type} Service`}</strong>
 			<HelpTooltip
-				text="Greyed out placeholder text represents a default that you can override. (current secrets can be kept by leaving them as '<secret>')"
+				tooltip={`Greyed out placeholder text represents a default that you can override.
+					(current secrets can be kept by leaving them as '<secret>').`}
 				placement="bottom"
 			/>
 		</Modal.Title>
@@ -215,7 +220,7 @@ const ServiceEditModalWithData: FC<ServiceEditModalWithDataProps> = ({
 		<FormProvider {...form}>
 			<Form id="service-edit">
 				<Modal size="lg" show animation={false} onHide={resetAndHideModal}>
-					<ServiceEditModalHeader />
+					<ServiceEditModalHeader type={serviceID ? 'Edit' : 'Create'} />
 					<Modal.Body>
 						<Container
 							fluid


### PR DESCRIPTION
- feat(ui): add aria-X to components for improved accessibility
- fix(ui): always give type on new service version refresh
  - default type is github, and it removes defaults, so wasn't sending it. Because a new service has not type default (for latest_version), this caused the refresh to fail.
- fix(ui): improve version conversion logic for service edit
  - refresh on latest_version would send "require: null" if unused, breaking refresh (if the refresh finds a new version, and no other vars were changed, the service itself wouldn't update from the refresh)