### PR TITLE
fix(log): call log init at start

### DIFF
--- a/cmd/argus/main.go
+++ b/cmd/argus/main.go
@@ -47,6 +47,8 @@ func main() {
 	flagset := make(map[string]bool)
 	flag.Visit(func(f *flag.Flag) { flagset[f.Name] = true })
 
+	logutil.Init("error", true)
+
 	var config cfg.Config
 	config.Load(*configFile, &flagset)
 	logutil.Log.SetTimestamps(*config.Settings.LogTimestamps())


### PR DESCRIPTION
Call log.Init at start: fix nil pointer error when a config error is thrown.