### PR TITLE
fix(log): initialise before first use

### DIFF
--- a/cmd/argus/main.go
+++ b/cmd/argus/main.go
@@ -49,8 +49,6 @@ func main() {
 
 	var config cfg.Config
 	config.Load(*configFile, &flagset)
-	logutil.Log.SetTimestamps(*config.Settings.LogTimestamps())
-	logutil.Log.SetLevel(config.Settings.LogLevel())
 
 	// config.check
 	config.Print(configCheckFlag)

--- a/cmd/argus/main_test.go
+++ b/cmd/argus/main_test.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	"github.com/release-argus/Argus/test"
-	logutil "github.com/release-argus/Argus/util/log"
+	logtest "github.com/release-argus/Argus/test/log"
 )
 
 func resetFlags() {
@@ -36,9 +36,10 @@ func resetFlags() {
 }
 
 func TestTheMain(t *testing.T) {
-	// GIVEN different Configs to test
-	logutil.Init("DEBUG", false)
-	logutil.Log.Testing = true
+	// Log.
+	logtest.InitLog()
+
+	// GIVEN different Configs to test.
 	tests := map[string]struct {
 		file           func(path string, t *testing.T)
 		outputContains *[]string
@@ -66,7 +67,7 @@ func TestTheMain(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			// t.Parallel() - Cannot run in parallel since we're using stdout
+			// t.Parallel() - Cannot run in parallel since we're using stdout.
 			releaseStdout := test.CaptureStdout()
 
 			file := fmt.Sprintf("%s.yml", name)
@@ -78,11 +79,11 @@ func TestTheMain(t *testing.T) {
 			accessToken := os.Getenv("GITHUB_TOKEN")
 			os.Setenv("ARGUS_SERVICE_LATEST_VERSION_ACCESS_TOKEN", accessToken)
 
-			// WHEN Main is called
+			// WHEN Main is called.
 			go main()
 			time.Sleep(3 * time.Second)
 
-			// THEN the program will have printed everything expected
+			// THEN the program will have printed everything expected.
 			stdout := releaseStdout()
 			if tc.outputContains != nil {
 				for _, text := range *tc.outputContains {

--- a/cmd/argus/main_test.go
+++ b/cmd/argus/main_test.go
@@ -37,7 +37,7 @@ func resetFlags() {
 
 func TestTheMain(t *testing.T) {
 	// GIVEN different Configs to test
-	logutil.Init("WARN", false)
+	logutil.Init("DEBUG", false)
 	logutil.Log.Testing = true
 	tests := map[string]struct {
 		file           func(path string, t *testing.T)

--- a/command/help_test.go
+++ b/command/help_test.go
@@ -22,18 +22,17 @@ import (
 
 	"github.com/release-argus/Argus/service/status"
 	"github.com/release-argus/Argus/test"
-	logutil "github.com/release-argus/Argus/util/log"
+	logtest "github.com/release-argus/Argus/test/log"
 )
 
 func TestMain(m *testing.M) {
-	// initialise jLog
-	logutil.Init("DEBUG", false)
-	logutil.Log.Testing = true
+	// Log.
+	logtest.InitLog()
 
-	// run other tests
+	// Run other tests
 	exitCode := m.Run()
 
-	// exit
+	// Exit
 	os.Exit(exitCode)
 }
 

--- a/config/help_test.go
+++ b/config/help_test.go
@@ -31,12 +31,12 @@ import (
 	opt "github.com/release-argus/Argus/service/option"
 	"github.com/release-argus/Argus/service/status"
 	"github.com/release-argus/Argus/test"
+	logtest "github.com/release-argus/Argus/test/log"
 	logutil "github.com/release-argus/Argus/util/log"
 )
 
 func TestMain(m *testing.M) {
-	logutil.Init("DEBUG", true)
-	logutil.Log.Testing = true
+	logtest.InitLog()
 	os.Exit(m.Run())
 }
 
@@ -88,7 +88,6 @@ func testLoad(file string, t *testing.T) *Config {
 	config := &Config{}
 
 	flags := make(map[string]bool)
-	logutil.Init("DEBUG", true)
 	loadMutex.Lock()
 	defer loadMutex.Unlock()
 	config.Load(file, &flags)

--- a/config/help_test.go
+++ b/config/help_test.go
@@ -88,7 +88,7 @@ func testLoad(file string, t *testing.T) *Config {
 	config := &Config{}
 
 	flags := make(map[string]bool)
-	logutil.Init("WARN", true)
+	logutil.Init("DEBUG", true)
 	loadMutex.Lock()
 	defer loadMutex.Unlock()
 	config.Load(file, &flags)

--- a/config/init.go
+++ b/config/init.go
@@ -49,7 +49,8 @@ func (c *Config) Init() {
 
 	c.HardDefaults.Service.Status.SaveChannel = c.SaveChannel
 
-	logutil.Init(c.Settings.LogLevel(), *c.Settings.LogTimestamps())
+	logutil.Log.SetTimestamps(*c.Settings.LogTimestamps())
+	logutil.Log.SetLevel(c.Settings.LogLevel())
 
 	for i, name := range c.Order {
 		service := c.Service[name]
@@ -66,8 +67,10 @@ func (c *Config) Init() {
 
 // Load `file` as Config.
 func (c *Config) Load(file string, flagset *map[string]bool) {
+	// Initialise the Log if it hasn't been already.
+	logutil.Init("ERROR", false)
+
 	c.File = file
-	// Give the log to the other packages.
 	c.Settings.NilUndefinedFlags(flagset)
 
 	//#nosec G304 -- Loading the file asked for by the user.

--- a/config/settings_test.go
+++ b/config/settings_test.go
@@ -1,4 +1,4 @@
-// Copyright [2024] [Argus]
+// Copyright [2025] [Argus]
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ import (
 )
 
 func TestSettings_String(t *testing.T) {
-	// GIVEN a Settings struct
+	// GIVEN a Settings struct.
 	tests := map[string]struct {
 		settings *Settings
 		prefix   string
@@ -71,10 +71,10 @@ func TestSettings_String(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// WHEN String is called on it
+			// WHEN String is called on it.
 			got := tc.settings.String(tc.prefix)
 
-			// THEN it's stringified as expected
+			// THEN it's stringified as expected.
 			if got != tc.want {
 				t.Errorf("want: %q, got: %q", tc.want, got)
 			}
@@ -83,7 +83,7 @@ func TestSettings_String(t *testing.T) {
 }
 
 func TestSettingsBase_CheckValues(t *testing.T) {
-	// GIVEN a Settings struct with some values set
+	// GIVEN a Settings struct with some values set.
 	tests := map[string]struct {
 		env                                map[string]string
 		had, want                          Settings
@@ -232,17 +232,17 @@ func TestSettingsBase_CheckValues(t *testing.T) {
 				t.Cleanup(func() { os.Unsetenv(k) })
 			}
 
-			// WHEN CheckValues is called on it
+			// WHEN CheckValues is called on it.
 			tc.had.CheckValues()
 
-			// THEN the Settings are converted/removed where necessary
+			// THEN the Settings are converted/removed where necessary.
 			hadStr := tc.had.String("")
 			wantStr := tc.want.String("")
 			if hadStr != wantStr {
 				t.Errorf("want:\n%v\ngot:\n%v",
 					wantStr, hadStr)
 			}
-			// AND the BasicAuth username and password are hashed (if they exist)
+			// AND the BasicAuth username and password are hashed (if they exist).
 			if tc.want.Web.BasicAuth != nil {
 				wantUsernameHash := util.FmtHash(util.GetHash(tc.want.Web.BasicAuth.Username))
 				if tc.wantUsernameHash != "" {
@@ -266,7 +266,7 @@ func TestSettingsBase_CheckValues(t *testing.T) {
 }
 
 func TestSettings_NilUndefinedFlags(t *testing.T) {
-	// GIVEN tests with flags set/unset
+	// GIVEN tests with flags set/unset.
 	var settings Settings
 	tests := map[string]struct {
 		flagSet   bool
@@ -292,14 +292,14 @@ func TestSettings_NilUndefinedFlags(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 
-			// WHEN flags are set/unset and NilUndefinedFlags is called
+			// WHEN flags are set/unset and NilUndefinedFlags is called.
 			flagset[flagStr] = tc.flagSet
 			flagset[flagBool] = tc.flagSet
 			LogLevel = tc.setStrTo
 			LogTimestamps = tc.setBoolTo
 			settings.NilUndefinedFlags(&flagset)
 
-			// THEN the flags are defined/undefined correctly
+			// THEN the flags are defined/undefined correctly.
 			gotStr := LogLevel
 			if (tc.flagSet && gotStr == nil) ||
 				(!tc.flagSet && gotStr != nil) {
@@ -317,7 +317,7 @@ func TestSettings_NilUndefinedFlags(t *testing.T) {
 }
 
 func TestSettings_GetString(t *testing.T) {
-	// GIVEN vars set in different at different priority levels in Settings
+	// GIVEN vars set in different at different priority levels in Settings.
 	settings := testSettings()
 	tests := map[string]struct {
 		flag         **string
@@ -332,7 +332,7 @@ func TestSettings_GetString(t *testing.T) {
 	}{
 		"log.level hard default": {
 			getFunc: settings.LogLevel,
-			flag:    &LogLevel, want: "INFO",
+			flag:    &LogLevel, want: "DEBUG",
 			nilConfig: true,
 			configPtr: &settings.Log.Level,
 		},
@@ -439,12 +439,12 @@ func TestSettings_GetString(t *testing.T) {
 		},
 	}
 
-	loadMutex.Lock() // Protect flag env vars
+	loadMutex.Lock() // Protect flag env vars.
 	t.Cleanup(func() { loadMutex.Unlock() })
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			// t.Parallel() - Cannot run in parallel since we're sharing some env vars
+			// t.Parallel() - Cannot run in parallel since we're sharing some env vars.
 			releaseStdout := test.CaptureStdout()
 			defer releaseStdout()
 
@@ -453,7 +453,7 @@ func TestSettings_GetString(t *testing.T) {
 				*tc.flag = tc.flagVal
 			}
 
-			// WHEN Default is called on it
+			// WHEN Default is called on it.
 			settings.Default()
 			if tc.nilConfig {
 				had := *tc.configPtr
@@ -461,7 +461,7 @@ func TestSettings_GetString(t *testing.T) {
 				t.Cleanup(func() { *tc.configPtr = had })
 			}
 
-			// THEN the Service part is initialised to the defined defaults
+			// THEN the Service part is initialised to the defined defaults.
 			var got string
 			if tc.getFunc != nil {
 				got = tc.getFunc()
@@ -478,7 +478,11 @@ func TestSettings_GetString(t *testing.T) {
 }
 
 func TestSettings_MapEnvToStruct(t *testing.T) {
-	// GIVEN vars set for Settings vars
+	// Unset ARGUS_LOG_LEVEL.
+	logLevel := os.Getenv("ARGUS_LOG_LEVEL")
+	os.Unsetenv("ARGUS_LOG_LEVEL")
+	defer os.Setenv("ARGUS_LOG_LEVEL", logLevel)
+	// GIVEN vars set for Settings vars.
 	tests := map[string]struct {
 		env      map[string]string
 		want     *Settings
@@ -574,7 +578,7 @@ func TestSettings_MapEnvToStruct(t *testing.T) {
 			// Catch fatal panics.
 			defer func() {
 				r := recover()
-				// Ignore nil panics
+				// Ignore nil panics.
 				if r == nil {
 					return
 				}
@@ -593,14 +597,14 @@ func TestSettings_MapEnvToStruct(t *testing.T) {
 				}
 			}()
 
-			// WHEN MapEnvToStruct is called on it
+			// WHEN MapEnvToStruct is called on it.
 			settings.MapEnvToStruct()
 
-			// THEN any error is as expected
-			if tc.errRegex != "" { // Expected a FATAL panic to be caught above
+			// THEN any error is as expected.
+			if tc.errRegex != "" { // Expected a FATAL panic to be caught above.
 				t.Fatalf("expected an error matching %q, but got none", tc.errRegex)
 			}
-			// AND the settings are set to the appropriate env vars
+			// AND the settings are set to the appropriate env vars.
 			if settings.String("") != tc.want.String("") {
 				t.Errorf("want:\n%v\ngot:\n%v",
 					tc.want.String(""), settings.String(""))
@@ -610,7 +614,7 @@ func TestSettings_MapEnvToStruct(t *testing.T) {
 }
 
 func TestSettings_GetBool(t *testing.T) {
-	// GIVEN vars set in different at different priority levels in Settings
+	// GIVEN vars set in different at different priority levels in Settings.
 	settings := testSettings()
 	tests := map[string]struct {
 		flag       **bool
@@ -636,7 +640,7 @@ func TestSettings_GetBool(t *testing.T) {
 			want: "true"},
 	}
 
-	loadMutex.Lock() // Protect flag env vars
+	loadMutex.Lock() // Protect flag env vars.
 	t.Cleanup(func() { loadMutex.Unlock() })
 
 	for name, tc := range tests {
@@ -644,7 +648,7 @@ func TestSettings_GetBool(t *testing.T) {
 
 			*tc.flag = tc.flagVal
 
-			// WHEN Default is called on it
+			// WHEN Default is called on it.
 			settings.Default()
 			if tc.nilConfig {
 				had := *tc.configPtr
@@ -652,7 +656,7 @@ func TestSettings_GetBool(t *testing.T) {
 				t.Cleanup(func() { *tc.configPtr = had })
 			}
 
-			// THEN the Service part is initialised to the defined defaults
+			// THEN the Service part is initialised to the defined defaults.
 			var got string
 			if tc.getFunc != nil {
 				got = fmt.Sprint(tc.getFunc())
@@ -681,7 +685,7 @@ func TestSettings_GetWebFile_NotExist(t *testing.T) {
 		HardDefaults: SettingsBase{
 			Log: LogSettings{}}}
 
-	// GIVEN different target vars and their get functions
+	// GIVEN different target vars and their get functions.
 	tests := map[string]struct {
 		getFunc   func() string
 		changeVar interface{}
@@ -708,10 +712,10 @@ func TestSettings_GetWebFile_NotExist(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			// t.Parallel() - Cannot run in parallel since we're sharing the Settings struct
+			// t.Parallel() - Cannot run in parallel since we're sharing the Settings struct.
 
 			//
-			// Test 1
+			// Test 1.
 			//
 			file := ""
 			if ptr, ok := tc.changeVar.(*string); ok {
@@ -719,17 +723,17 @@ func TestSettings_GetWebFile_NotExist(t *testing.T) {
 			} else if ptrPtr, ok := tc.changeVar.(**string); ok {
 				*ptrPtr = &file
 			}
-			// WHEN a get is called with no file path set
+			// WHEN a get is called with no file path set.
 			got := tc.getFunc()
 
-			// THEN the empty string is returned
+			// THEN the empty string is returned.
 			if got != file {
 				t.Errorf("empty string\nwant: %q\ngot:  %q",
 					file, got)
 			}
 
 			//
-			// Test 1
+			// Test 2.
 			//
 			file = fmt.Sprintf("test_%s.pem",
 				strings.ReplaceAll(strings.ToLower(name), " ", "_"))
@@ -740,17 +744,17 @@ func TestSettings_GetWebFile_NotExist(t *testing.T) {
 			} else if ptrPtr, ok := tc.changeVar.(**string); ok {
 				*ptrPtr = &file
 			}
-			// WHEN a get is called with a file path set and that file does exist
+			// WHEN a get is called with a file path set and that file does exist.
 			got = tc.getFunc()
 
-			// THEN the file path is returned
+			// THEN the file path is returned.
 			if got != file {
 				t.Errorf("file path\nwant: %q\ngot:  %q",
 					file, got)
 			}
 
 			//
-			// Test 3
+			// Test 3.
 			//
 			os.Remove(file)
 			if tc.changeVar != nil {
@@ -762,10 +766,10 @@ func TestSettings_GetWebFile_NotExist(t *testing.T) {
 					defer func() { file = "" }()
 				}
 			}
-			// Catch the panic
+			// Catch the panic.
 			defer func() {
 				r := recover()
-				// Ignore nil panics
+				// Ignore nil panics.
 				if r == nil {
 					return
 				}
@@ -778,19 +782,19 @@ func TestSettings_GetWebFile_NotExist(t *testing.T) {
 				tc.changeVar = nil
 			}()
 
-			// WHEN a get is called on files that don't exist
+			// WHEN a get is called on files that don't exist.
 			got = tc.getFunc()
 
-			// THEN call will crash the program as the file doesn't exist
+			// THEN call will crash the program as the file doesn't exist.
 			t.Errorf("deleted file\nwant: panic\ngot:  %q", got)
 		})
 	}
 }
 
 func TestSettings_WebBasicAuthUsernameHash(t *testing.T) {
-	// GIVEN a Settings struct with some values set
+	// GIVEN a Settings struct with some values set.
 	tests := map[string]struct {
-		want string // The string that was hashed
+		want string // The string that was hashed.
 		had  Settings
 	}{
 		"empty": {
@@ -821,17 +825,17 @@ func TestSettings_WebBasicAuthUsernameHash(t *testing.T) {
 			want := util.GetHash(tc.want)
 			tc.had.CheckValues()
 			tc.had.FromFlags.CheckValues()
-			// HardDefaults.Web.BasicAuth will never be nil if Basic Auth is in use
+			// HardDefaults.Web.BasicAuth will never be nil if Basic Auth is in use.
 			tc.had.HardDefaults = SettingsBase{
 				Web: WebSettings{
 					BasicAuth: &WebSettingsBasicAuth{
 						UsernameHash: util.GetHash(""),
 						PasswordHash: util.GetHash("")}}}
 
-			// WHEN WebBasicAuthUsernameHash is called on it
+			// WHEN WebBasicAuthUsernameHash is called on it.
 			got := tc.had.WebBasicAuthUsernameHash()
 
-			// THEN the hash is returned
+			// THEN the hash is returned.
 			if got != want {
 				t.Errorf("want: %s\ngot:  %s",
 					want, got)
@@ -841,9 +845,9 @@ func TestSettings_WebBasicAuthUsernameHash(t *testing.T) {
 }
 
 func TestSettings_WebBasicAuthPasswordHash(t *testing.T) {
-	// GIVEN a Settings struct with some values set
+	// GIVEN a Settings struct with some values set.
 	tests := map[string]struct {
-		want string // The string that was hashed
+		want string // The string that was hashed.
 		had  Settings
 	}{
 		"empty": {
@@ -886,17 +890,17 @@ func TestSettings_WebBasicAuthPasswordHash(t *testing.T) {
 			want := util.GetHash(tc.want)
 			tc.had.CheckValues()
 			tc.had.FromFlags.CheckValues()
-			// HardDefaults.Web.BasicAuth will never be nil if Basic Auth is in use
+			// HardDefaults.Web.BasicAuth will never be nil if Basic Auth is in use.
 			tc.had.HardDefaults = SettingsBase{
 				Web: WebSettings{
 					BasicAuth: &WebSettingsBasicAuth{
 						UsernameHash: util.GetHash(""),
 						PasswordHash: util.GetHash("")}}}
 
-			// WHEN WebBasicAuthPasswordHash is called on it
+			// WHEN WebBasicAuthPasswordHash is called on it.
 			got := tc.had.WebBasicAuthPasswordHash()
 
-			// THEN the hash is returned
+			// THEN the hash is returned.
 			if got != want {
 				t.Errorf("want: %s\ngot:  %s",
 					want, got)
@@ -906,7 +910,7 @@ func TestSettings_WebBasicAuthPasswordHash(t *testing.T) {
 }
 
 func TestWebSettings_String(t *testing.T) {
-	// GIVEN a WebSettings struct
+	// GIVEN a WebSettings struct.
 	tests := map[string]struct {
 		webSettings *WebSettings
 		prefix      string
@@ -950,10 +954,10 @@ func TestWebSettings_String(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// WHEN String is called on it
+			// WHEN String is called on it.
 			got := tc.webSettings.String(tc.prefix)
 
-			// THEN it's stringified as expected
+			// THEN it's stringified as expected.
 			if got != tc.want {
 				t.Errorf("want: %q, got: %q", tc.want, got)
 			}
@@ -962,7 +966,7 @@ func TestWebSettings_String(t *testing.T) {
 }
 
 func TestWebSettings_CheckValues(t *testing.T) {
-	// GIVEN a WebSettings struct with some values set
+	// GIVEN a WebSettings struct with some values set.
 	tests := map[string]struct {
 		env              map[string]string
 		had, want        WebSettings
@@ -1065,10 +1069,10 @@ func TestWebSettings_CheckValues(t *testing.T) {
 				t.Cleanup(func() { os.Unsetenv(k) })
 			}
 
-			// WHEN CheckValues is called on it
+			// WHEN CheckValues is called on it.
 			tc.had.CheckValues()
 
-			// THEN the Settings are converted/removed where necessary
+			// THEN the Settings are converted/removed where necessary.
 			hadStr := tc.had.String("")
 			wantStr := tc.want.String("")
 			if hadStr != wantStr {
@@ -1087,7 +1091,7 @@ func TestWebSettings_CheckValues(t *testing.T) {
 }
 
 func TestWebSettingsBasicAuth_String(t *testing.T) {
-	// GIVEN a WebSettingsBasicAuth struct
+	// GIVEN a WebSettingsBasicAuth struct.
 	tests := map[string]struct {
 		auth   *WebSettingsBasicAuth
 		prefix string
@@ -1131,10 +1135,10 @@ func TestWebSettingsBasicAuth_String(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// WHEN String is called on it
+			// WHEN String is called on it.
 			got := tc.auth.String(tc.prefix)
 
-			// THEN it's stringified as expected
+			// THEN it's stringified as expected.
 			if got != tc.want {
 				t.Errorf("want: %q, got: %q", tc.want, got)
 			}
@@ -1143,7 +1147,7 @@ func TestWebSettingsBasicAuth_String(t *testing.T) {
 }
 
 func TestWebSettingsBasicAuth_CheckValues(t *testing.T) {
-	// GIVEN a WebSettingsBasicAuth struct with some values set
+	// GIVEN a WebSettingsBasicAuth struct with some values set.
 	tests := map[string]struct {
 		env                                map[string]string
 		had, want                          WebSettingsBasicAuth
@@ -1238,17 +1242,17 @@ func TestWebSettingsBasicAuth_CheckValues(t *testing.T) {
 				t.Cleanup(func() { os.Unsetenv(k) })
 			}
 
-			// WHEN CheckValues is called on it
+			// WHEN CheckValues is called on it.
 			tc.had.CheckValues()
 
-			// THEN the Settings are converted/removed where necessary
+			// THEN the Settings are converted/removed where necessary.
 			hadStr := tc.had.String("")
 			wantStr := tc.want.String("")
 			if hadStr != wantStr {
 				t.Errorf("want:\n%v\ngot:\n%v",
 					wantStr, hadStr)
 			}
-			// AND the UsernameHash is calculated correctly
+			// AND the UsernameHash is calculated correctly.
 			want := util.FmtHash(util.GetHash(
 				util.EvalEnvVars(tc.want.Username)))
 			if tc.wantUsernameHash != "" {
@@ -1259,7 +1263,7 @@ func TestWebSettingsBasicAuth_CheckValues(t *testing.T) {
 				t.Errorf("Username Hash\nwant: %s\ngot:  %s",
 					want, got)
 			}
-			// AND the PasswordHash is calculated correctly
+			// AND the PasswordHash is calculated correctly.
 			want = util.FmtHash(util.GetHash(
 				util.EvalEnvVars(tc.want.Password)))
 			if tc.wantPasswordHash != "" {

--- a/db/help_test.go
+++ b/db/help_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/release-argus/Argus/service"
 	"github.com/release-argus/Argus/service/status"
 	"github.com/release-argus/Argus/test"
-	logutil "github.com/release-argus/Argus/util/log"
+	logtest "github.com/release-argus/Argus/test/log"
 )
 
 var cfg *config.Config
@@ -38,8 +38,7 @@ func TestMain(m *testing.M) {
 	databaseFile := "TestDB.db"
 
 	// Log.
-	logutil.Init("DEBUG", false)
-	logutil.Log.Testing = true
+	logtest.InitLog()
 
 	cfg = testConfig()
 	cfg.Settings.Data.DatabaseFile = databaseFile

--- a/notify/shoutrrr/help_test.go
+++ b/notify/shoutrrr/help_test.go
@@ -23,18 +23,17 @@ import (
 
 	"github.com/release-argus/Argus/service/status"
 	"github.com/release-argus/Argus/test"
-	logutil "github.com/release-argus/Argus/util/log"
+	logtest "github.com/release-argus/Argus/test/log"
 )
 
 func TestMain(m *testing.M) {
-	// initialise jLog
-	logutil.Init("DEBUG", false)
-	logutil.Log.Testing = true
+	// Log.
+	logtest.InitLog()
 
-	// run other tests
+	// Run other tests.
 	exitCode := m.Run()
 
-	// exit
+	// Exit.
 	os.Exit(exitCode)
 }
 

--- a/service/deployed_version/help_test.go
+++ b/service/deployed_version/help_test.go
@@ -24,34 +24,33 @@ import (
 	opt "github.com/release-argus/Argus/service/option"
 	"github.com/release-argus/Argus/service/status"
 	"github.com/release-argus/Argus/test"
-	logutil "github.com/release-argus/Argus/util/log"
+	logtest "github.com/release-argus/Argus/test/log"
 )
 
 func TestMain(m *testing.M) {
-	// initialise jLog
-	logutil.Init("DEBUG", false)
-	logutil.Log.Testing = true
+	// Log.
+	logtest.InitLog()
 
-	// run other tests
+	// Run other tests.
 	exitCode := m.Run()
 
-	// exit
+	// Exit.
 	os.Exit(exitCode)
 }
 
 func testLookup() *Lookup {
-	// Hard defaults
+	// HardDefaults.
 	hardDefaults := &Defaults{}
 	hardDefaults.Default()
-	// Defaults
+	// Defaults.
 	defaults := &Defaults{}
-	// Options
+	// Options.
 	hardDefaultOptions := &opt.Defaults{}
 	hardDefaultOptions.Default()
 	options := opt.New(
 		nil, "", test.BoolPtr(true),
 		&opt.Defaults{}, hardDefaultOptions)
-	// Status
+	// Status.
 	announceChannel := make(chan []byte, 24)
 	saveChannel := make(chan bool, 5)
 	databaseChannel := make(chan dbtype.Message, 5)

--- a/service/help_test.go
+++ b/service/help_test.go
@@ -28,18 +28,17 @@ import (
 	opt "github.com/release-argus/Argus/service/option"
 	"github.com/release-argus/Argus/service/status"
 	"github.com/release-argus/Argus/test"
-	logutil "github.com/release-argus/Argus/util/log"
+	logtest "github.com/release-argus/Argus/test/log"
 )
 
 func TestMain(m *testing.M) {
-	// initialise jLog
-	logutil.Init("DEBUG", false)
-	logutil.Log.Testing = true
+	// Log.
+	logtest.InitLog()
 
-	// run other tests
+	// Run other tests.
 	exitCode := m.Run()
 
-	// exit
+	// Exit.
 	os.Exit(exitCode)
 }
 
@@ -83,7 +82,7 @@ func testService(t *testing.T, id string, sType string) *Service {
 	svc.HardDefaults.Status.DatabaseChannel = svc.Status.DatabaseChannel
 	svc.HardDefaults.Status.SaveChannel = svc.Status.SaveChannel
 
-	// Status
+	// Status.
 	svc.Status.Init(
 		0, 0, 0,
 		&svc.ID, &svc.ID,
@@ -101,6 +100,7 @@ func testService(t *testing.T, id string, sType string) *Service {
 		&svc.Status,
 		&deployedver.Defaults{}, &hardDefaults.DeployedVersionLookup)
 
+	// Check the values.
 	err := svc.LatestVersion.CheckValues("")
 	if err != nil {
 		t.Fatalf("testService(), latest_version.CheckValues() error: %v", err)
@@ -134,6 +134,7 @@ func testLatestVersionGitHub(t *testing.T, fail bool) latestver_base.Interface {
 		testStatus(),
 		&latestver_base.Defaults{}, &hardDefaults)
 
+	// Check the values.
 	err := lv.CheckValues("")
 	if err != nil {
 		t.Fatalf("testLatestVersionGitHub(), CheckValues() error: %v", err)
@@ -162,6 +163,7 @@ func testLatestVersionWeb(t *testing.T, fail bool) latestver_base.Interface {
 		testStatus(),
 		&latestver_base.Defaults{}, &hardDefaults)
 
+	// Check the values.
 	err := lv.CheckValues("")
 	if err != nil {
 		t.Fatalf("testLatestVersionWeb(), CheckValues() error: %v", err)
@@ -183,6 +185,7 @@ func testLatestVersion(t *testing.T, lvType string, fail bool) (lv latestver.Loo
 		lv.GetDefaults(), lv.GetHardDefaults())
 	lv.GetStatus().ServiceID = test.StringPtr("TEST_LV")
 
+	// Check the values.
 	err := lv.CheckValues("")
 	if err != nil {
 		t.Fatalf("testLatestVersion(), CheckValues() error: %v", err)
@@ -208,6 +211,7 @@ func testDeployedVersionLookup(t *testing.T, fail bool) *deployedver.Lookup {
 			&deployedver.Defaults{}, &hardDefaults)
 	})
 
+	// Check the values.
 	err := dv.CheckValues("")
 	if err != nil {
 		t.Fatalf("testDeployedVersionLookup(), CheckValues() error: %v", err)

--- a/service/init_test.go
+++ b/service/init_test.go
@@ -344,37 +344,37 @@ func TestService_Init(t *testing.T) {
 				&webhook.SliceDefaults{}, &webhook.Defaults{}, &webhook.Defaults{})
 
 			// THEN pointers to those vars are handed out to the Lookup::
-			// defaults
+			// 	Defaults.
 			if tc.svc.Defaults != tc.defaults {
 				t.Errorf("Defaults were not handed to the Lookup correctly\n want: %v\ngot:  %v",
 					tc.defaults, tc.svc.Defaults)
 			}
-			// dashboard.defaults
+			// 	Dashboard.Defaults.
 			if tc.svc.Dashboard.Defaults != &tc.defaults.Dashboard {
 				t.Errorf("Dashboard defaults were not handed to the Lookup correctly\n want: %v\ngot:  %v",
 					&tc.defaults.Dashboard, tc.svc.Dashboard.Defaults)
 			}
-			// option.defaults
+			// 	Options.defaults.
 			if tc.svc.Options.Defaults != &tc.defaults.Options {
 				t.Errorf("Options defaults were not handed to the Lookup correctly\n want: %v\ngot:  %v",
 					&tc.defaults.Options, tc.svc.Options.Defaults)
 			}
-			// hardDefaults
+			// 	HardDefaults.
 			if tc.svc.HardDefaults != &hardDefaults {
 				t.Errorf("HardDefaults were not handed to the Lookup correctly\n want: %v\ngot:  %v",
 					&hardDefaults, tc.svc.HardDefaults)
 			}
-			// dashboard.hardDefaults
+			// 	Dashboard.HardDefaults.
 			if tc.svc.Dashboard.HardDefaults != &hardDefaults.Dashboard {
 				t.Errorf("Dashboard hardDefaults were not handed to the Lookup correctly\n want: %v\ngot:  %v",
 					&hardDefaults.Dashboard, tc.svc.Dashboard.HardDefaults)
 			}
-			// option.hardDefaults
+			// 	Options.HardDefaults.
 			if tc.svc.Options.HardDefaults != &hardDefaults.Options {
 				t.Errorf("Options hardDefaults were not handed to the Lookup correctly\n want: %v\ngot:  %v",
 					&hardDefaults.Options, tc.svc.Options.HardDefaults)
 			}
-			// Notify
+			// 	Notify.
 			if len(tc.svc.Notify) != 0 {
 				for i := range tc.svc.Notify {
 					if tc.svc.Notify[i].Main == nil {
@@ -382,7 +382,7 @@ func TestService_Init(t *testing.T) {
 					}
 				}
 			}
-			// Notifiers is not overridden if non-empty.
+			// 		Notifiers are not overridden if non-empty.
 			if len(hadNotify) != 0 && len(tc.svc.Notify) != len(hadNotify) {
 				t.Fatalf("Notify length changed\n want: %d (%v)\ngot:  %d (%v)",
 					len(hadNotify), hadNotify, len(tc.svc.Notify), util.SortedKeys(tc.svc.Notify))
@@ -397,7 +397,7 @@ func TestService_Init(t *testing.T) {
 					t.Errorf("Notify[%s] was nil", i)
 				}
 			}
-			// Command
+			// 	Command.
 			if len(tc.svc.Command) != 0 {
 				if tc.svc.CommandController == nil {
 					t.Errorf("CommandController is still nil with %v Commands present",
@@ -407,7 +407,7 @@ func TestService_Init(t *testing.T) {
 				t.Errorf("CommandController should be nil with %v Commands present",
 					tc.svc.Command)
 			}
-			// Command is not overridden if non-empty.
+			// 		Command is not overridden if non-empty.
 			if len(hadCommand) != 0 && len(tc.svc.Command) != len(hadCommand) {
 				t.Fatalf("Command length changed\n want: %d (%v)\ngot: %d (%v)",
 					len(hadCommand), hadCommand, len(tc.svc.Command), tc.svc.Command)
@@ -423,7 +423,7 @@ func TestService_Init(t *testing.T) {
 						i, wantCommand[i].String(), tc.svc.Command[i].String())
 				}
 			}
-			// WebHook
+			// 	WebHook.
 			if len(tc.svc.WebHook) != 0 {
 				for i := range tc.svc.WebHook {
 					if tc.svc.WebHook[i].Main == nil {
@@ -431,7 +431,7 @@ func TestService_Init(t *testing.T) {
 					}
 				}
 			}
-			// WebHook is not overridden if non-empty.
+			// 		WebHooks are not overridden if non-empty.
 			if len(hadWebHook) != 0 && len(tc.svc.WebHook) != len(hadWebHook) {
 				t.Fatalf("WebHook length changed\n want: %d (%v)\ngot: %d (%v)",
 					len(hadWebHook), hadWebHook, len(tc.svc.WebHook), util.SortedKeys(tc.svc.WebHook))
@@ -518,22 +518,22 @@ func TestService_InitMetrics_ResetMetrics_DeleteMetrics(t *testing.T) {
 			}
 
 			// metrics:
-			// 	latest_version_query_result_total
+			// 	latest_version_query_result_total.
 			latestVersionMetric := metric.LatestVersionIsDeployed.WithLabelValues(
 				service.ID)
-			// 	deployed_version_query_result_last
+			// 	deployed_version_query_result_last.
 			deployedVersionMetric := metric.DeployedVersionQueryResultLast.WithLabelValues(
 				service.ID)
-			// 	command_result_total
+			// 	command_result_total.
 			commandMetric := metric.CommandResultTotal.WithLabelValues(
 				testCommand.String(), "SUCCESS", service.ID)
-			// 	notify_result_total
+			// 	notify_result_total.
 			notifyMetric := metric.NotifyResultTotal.WithLabelValues(
 				testNotify.ID, "SUCCESS", service.ID, testNotify.GetType())
-			// 	webhook_result_total
+			// 	webhook_result_total.
 			webhookMetric := metric.WebHookResultTotal.WithLabelValues(
 				testWebHook.ID, "SUCCESS", service.ID)
-			// 	service_count_total
+			// 	service_count_total.
 			serviceCountTotal := metric.ServiceCountCurrent
 			initialServiceCountCurrent := testutil.ToFloat64(serviceCountTotal)
 
@@ -545,14 +545,14 @@ func TestService_InitMetrics_ResetMetrics_DeleteMetrics(t *testing.T) {
 			// THEN the metrics are created:
 			want := float64(3)
 			oldWant := want
-			// 	latest_version_is_deployed
+			// 	latest_version_is_deployed.
 			latestVersionMetric.Set(want)
 			got := testutil.ToFloat64(latestVersionMetric)
 			if got != want {
 				t.Errorf("Init, Expected latestVersionMetric to be %f, not %f",
 					want, got)
 			}
-			// 	deployed_version_query_result_last
+			// 	deployed_version_query_result_last.
 			if tc.nilDeployedVersion {
 				want = 0
 			} else {
@@ -564,7 +564,7 @@ func TestService_InitMetrics_ResetMetrics_DeleteMetrics(t *testing.T) {
 					want, got)
 			}
 			want = oldWant
-			// 	command_result_total
+			// 	command_result_total.
 			if tc.nilCommand {
 				want = 0
 			} else {
@@ -576,7 +576,7 @@ func TestService_InitMetrics_ResetMetrics_DeleteMetrics(t *testing.T) {
 					want, got)
 			}
 			want = oldWant
-			// 	notify_result_total
+			// 	notify_result_total.
 			if tc.nilNotify {
 				want = 0
 			} else {
@@ -587,7 +587,7 @@ func TestService_InitMetrics_ResetMetrics_DeleteMetrics(t *testing.T) {
 				t.Errorf("Init, Expected notifyMetric to be %f, not %f",
 					want, got)
 			}
-			// 	webhook_result_total
+			// 	webhook_result_total.
 			want = oldWant
 			if tc.nilWebHook {
 				want = 0
@@ -600,7 +600,7 @@ func TestService_InitMetrics_ResetMetrics_DeleteMetrics(t *testing.T) {
 					want, got)
 			}
 			want = oldWant
-			// 	service_count_total
+			// 	service_count_total.
 			got = testutil.ToFloat64(serviceCountTotal)
 			wantServiceCountCurrent := initialServiceCountCurrent + 1
 			if got != wantServiceCountCurrent {
@@ -614,55 +614,55 @@ func TestService_InitMetrics_ResetMetrics_DeleteMetrics(t *testing.T) {
 			service.deleteMetrics()
 
 			// metrics:
-			// 	latest_version_is_deployed
+			// 	latest_version_is_deployed.
 			latestVersionMetric = metric.LatestVersionIsDeployed.WithLabelValues(
 				service.ID)
-			// 	deployed_version_query_result_last
+			// 	deployed_version_query_result_last.
 			deployedVersionMetric = metric.DeployedVersionQueryResultLast.WithLabelValues(
 				service.ID)
-			// 	command_result_total
+			// 	command_result_total.
 			commandMetric = metric.CommandResultTotal.WithLabelValues(
 				testCommand.String(), "SUCCESS", service.ID)
-			// 	notify_result_total
+			// 	notify_result_total.
 			notifyMetric = metric.NotifyResultTotal.WithLabelValues(
 				testNotify.ID, "SUCCESS", service.ID, testNotify.GetType())
-			// 	webhook_result_total
+			// 	webhook_result_total.
 			webhookMetric = metric.WebHookResultTotal.WithLabelValues(
 				testWebHook.ID, "SUCCESS", service.ID)
 
 			// THEN the metrics are deleted:
 			want = 0
-			// 	latest_version_is_deployed
+			// 	latest_version_is_deployed.
 			got = testutil.ToFloat64(latestVersionMetric)
 			if got != want {
 				t.Errorf("Delete, Expected latestVersionMetric to be %f, not %f",
 					want, got)
 			}
-			// 	deployed_version_query_result_last
+			// 	deployed_version_query_result_last.
 			got = testutil.ToFloat64(deployedVersionMetric)
 			if got != want {
 				t.Errorf("Delete, Expected deployedVersionMetric to be %f, not %f",
 					want, got)
 			}
-			// 	command_result_total
+			// 	command_result_total.
 			got = testutil.ToFloat64(commandMetric)
 			if got != want {
 				t.Errorf("Delete, Expected commandMetric to be %f, not %f",
 					want, got)
 			}
-			// 	notify_result_total
+			// 	notify_result_total.
 			got = testutil.ToFloat64(notifyMetric)
 			if got != want {
 				t.Errorf("Delete, Expected notifyMetric to be %f, not %f",
 					want, got)
 			}
-			// 	webhook_result_total
+			// 	webhook_result_total.
 			got = testutil.ToFloat64(webhookMetric)
 			if got != want {
 				t.Errorf("Delete, Expected webhookMetric to be %f, not %f",
 					want, got)
 			}
-			// 	service_count_total
+			// 	service_count_total.
 			got = testutil.ToFloat64(serviceCountTotal)
 			// Reset to initial value.
 			if got != initialServiceCountCurrent {

--- a/service/latest_version/filter/help_test.go
+++ b/service/latest_version/filter/help_test.go
@@ -22,18 +22,17 @@ import (
 	"time"
 
 	"github.com/release-argus/Argus/command"
-	logutil "github.com/release-argus/Argus/util/log"
+	logtest "github.com/release-argus/Argus/test/log"
 )
 
 func TestMain(m *testing.M) {
-	// initialise jLog
-	logutil.Init("DEBUG", false)
-	logutil.Log.Testing = true
+	// Log.
+	logtest.InitLog()
 
-	// run other tests
+	// Run other tests.
 	exitCode := m.Run()
 
-	// exit
+	// Exit.
 	os.Exit(exitCode)
 }
 

--- a/service/latest_version/help_test.go
+++ b/service/latest_version/help_test.go
@@ -28,18 +28,17 @@ import (
 	opt "github.com/release-argus/Argus/service/option"
 	"github.com/release-argus/Argus/service/status"
 	"github.com/release-argus/Argus/test"
-	logutil "github.com/release-argus/Argus/util/log"
+	logtest "github.com/release-argus/Argus/test/log"
 )
 
 func TestMain(m *testing.M) {
-	// initialise jLog
-	logutil.Init("DEBUG", false)
-	logutil.Log.Testing = true
+	// Log.
+	logtest.InitLog()
 
-	// run other tests
+	// Run other tests.
 	exitCode := m.Run()
 
-	// exit
+	// Exit.
 	os.Exit(exitCode)
 }
 
@@ -51,18 +50,18 @@ func testLookup(lookupType string, failing bool) Lookup {
 		nil,
 		nil, nil)
 
-	// Hard defaults
+	// HardDefaults.
 	hardDefaults := &base.Defaults{}
 	hardDefaults.Default()
-	// Defaults
+	// Defaults.
 	defaults := &base.Defaults{}
-	// Options
+	// Options.
 	hardDefaultOptions := &opt.Defaults{}
 	hardDefaultOptions.Default()
 	options := opt.New(
 		nil, "5m", test.BoolPtr(false),
 		&opt.Defaults{}, hardDefaultOptions)
-	// Status
+	// Status.
 	announceChannel := make(chan []byte, 24)
 	saveChannel := make(chan bool, 5)
 	databaseChannel := make(chan dbtype.Message, 5)

--- a/service/latest_version/init_test.go
+++ b/service/latest_version/init_test.go
@@ -1,4 +1,4 @@
-// Copyright [2024] [Argus]
+// Copyright [2025] [Argus]
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import (
 )
 
 func TestLookup_Init(t *testing.T) {
-	// GIVEN a Lookup and vars for the Init
+	// GIVEN a Lookup and vars for the Init.
 	lookup := testLookup("github", false)
 	var defaults base.Defaults
 	var hardDefaults base.Defaults
@@ -34,29 +34,29 @@ func TestLookup_Init(t *testing.T) {
 	status := status.Status{ServiceID: test.StringPtr("test")}
 	var options opt.Options
 
-	// WHEN Init is called on it
+	// WHEN Init is called on it.
 	lookup.Init(
 		&options,
 		&status,
 		&defaults, &hardDefaults)
 
-	// THEN pointers to those vars are handed out to the Lookup
-	// defaults
+	// THEN pointers to those vars are handed out to the Lookup:
+	// 	Defaults.
 	if lookup.GetDefaults() != &defaults {
 		t.Errorf("Defaults were not handed to the Lookup correctly\n want: %v\ngot:  %v",
 			&defaults, lookup.GetDefaults())
 	}
-	// hardDefaults
+	// HardDefaults.
 	if lookup.GetHardDefaults() != &hardDefaults {
 		t.Errorf("HardDefaults were not handed to the Lookup correctly\n want: %v\ngot:  %v",
 			&hardDefaults, lookup.GetHardDefaults())
 	}
-	// status
+	// 	Status.
 	if lookup.GetStatus() != &status {
 		t.Errorf("Status was not handed to the Lookup correctly\n want: %v\ngot:  %v",
 			&status, lookup.GetStatus())
 	}
-	// options
+	// 	Options.
 	if lookup.GetOptions() != &options {
 		t.Errorf("Options were not handed to the Lookup correctly\n want: %v\ngot:  %v",
 			&options, lookup.GetOptions())

--- a/service/latest_version/types/github/help_test.go
+++ b/service/latest_version/types/github/help_test.go
@@ -28,10 +28,9 @@ import (
 	opt "github.com/release-argus/Argus/service/option"
 	"github.com/release-argus/Argus/service/status"
 	"github.com/release-argus/Argus/test"
-	logutil "github.com/release-argus/Argus/util/log"
+	logtest "github.com/release-argus/Argus/test/log"
 )
 
-// Unsure why Go tests give a different result than the compiled binary
 var initialEmptyListETag string
 var testBody = []byte(test.TrimJSON(`
 [
@@ -47,20 +46,19 @@ var testBody = []byte(test.TrimJSON(`
 var testBodyObject []github_types.Release
 
 func TestMain(m *testing.M) {
-	// initialise logutil.Log
-	logutil.Init("DEBUG", false)
-	logutil.Log.Testing = true
+	// Log.
+	logtest.InitLog()
 
 	SetEmptyListETag(os.Getenv("GITHUB_TOKEN"))
 	initialEmptyListETag = getEmptyListETag()
 
-	// unmarshal testBody
+	// Unmarshal testBody.
 	json.Unmarshal(testBody, &testBodyObject)
 
-	// run other tests
+	// Run other tests.
 	exitCode := m.Run()
 
-	// exit
+	// Exit.
 	os.Exit(exitCode)
 }
 
@@ -73,7 +71,7 @@ func newData(
 	if eTag == "" {
 		eTag = getEmptyListETag()
 	}
-	// Releases
+	// Releases.
 	var releasesDeref []github_types.Release
 	if releases != nil {
 		releasesDeref = *releases
@@ -85,19 +83,19 @@ func newData(
 }
 
 func testLookup(failing bool) *Lookup {
-	// Hard defaults
+	// HardDefaults.
 	hardDefaults := &base.Defaults{}
 	hardDefaults.AccessToken = os.Getenv("GITHUB_TOKEN")
 	hardDefaults.Default()
-	// Defaults
+	// Defaults.
 	defaults := &base.Defaults{}
-	// Options
+	// Options.
 	hardDefaultOptions := &opt.Defaults{}
 	hardDefaultOptions.Default()
 	options := opt.New(
 		nil, "", test.BoolPtr(true),
 		&opt.Defaults{}, hardDefaultOptions)
-	// Status
+	// Status.
 	announceChannel := make(chan []byte, 24)
 	saveChannel := make(chan bool, 5)
 	databaseChannel := make(chan dbtype.Message, 5)

--- a/service/latest_version/types/web/help_test.go
+++ b/service/latest_version/types/web/help_test.go
@@ -25,34 +25,33 @@ import (
 	opt "github.com/release-argus/Argus/service/option"
 	"github.com/release-argus/Argus/service/status"
 	"github.com/release-argus/Argus/test"
-	logutil "github.com/release-argus/Argus/util/log"
+	logtest "github.com/release-argus/Argus/test/log"
 )
 
 func TestMain(m *testing.M) {
-	// initialise logutil.Log
-	logutil.Init("DEBUG", false)
-	logutil.Log.Testing = true
+	// Log.
+	logtest.InitLog()
 
-	// run other tests
+	// Run other tests.
 	exitCode := m.Run()
 
-	// exit
+	// Exit.
 	os.Exit(exitCode)
 }
 
 func testLookup(failing bool) *Lookup {
-	// Hard defaults
+	// HardDefaults.
 	hardDefaults := &base.Defaults{}
 	hardDefaults.Default()
-	// Defaults
+	// Defaults.
 	defaults := &base.Defaults{}
-	// Options
+	// Options.
 	hardDefaults.Options = &opt.Defaults{}
 	hardDefaults.Options.Default()
 	options := opt.New(
 		nil, "", test.BoolPtr(true),
 		&opt.Defaults{}, hardDefaults.Options)
-	// Status
+	// Status.
 	announceChannel := make(chan []byte, 24)
 	saveChannel := make(chan bool, 5)
 	databaseChannel := make(chan dbtype.Message, 5)

--- a/test/log/log.go
+++ b/test/log/log.go
@@ -12,29 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build unit
+//go:build unit || integration
 
-// Package base provides the base struct for latest_version lookups.
-package base
+package logtest
 
 import (
 	"os"
-	"testing"
+	"sync"
 
-	logtest "github.com/release-argus/Argus/test/log"
+	logutil "github.com/release-argus/Argus/util/log"
 )
 
-type testLookup struct {
-	Lookup `yaml:",inline" json:",inline"` // Base struct for a Lookup.
-}
+var once sync.Once
 
-func TestMain(m *testing.M) {
-	// Log.
-	logtest.InitLog()
+func InitLog() {
+	once.Do(func() {
+		// Set the environment variable to "DEBUG" to stop .Load() resetting it.
+		logLevel := "DEBUG"
+		os.Setenv("ARGUS_LOG_LEVEL", logLevel)
 
-	// Run other tests.
-	exitCode := m.Run()
-
-	// Exit.
-	os.Exit(exitCode)
+		logutil.Init(logLevel, false)
+		logutil.Log.Testing = true
+	})
 }

--- a/test/log/log_test.go
+++ b/test/log/log_test.go
@@ -1,0 +1,50 @@
+// Copyright [2025] [Argus]
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build unit
+
+package logtest
+
+import (
+	"os"
+	"testing"
+
+	logutil "github.com/release-argus/Argus/util/log"
+)
+
+func TestInitLog(t *testing.T) {
+	// GIVEN the environment variable is not set.
+	os.Unsetenv("ARGUS_LOG_LEVEL")
+
+	// WHEN InitLog is called.
+	InitLog()
+
+	// THEN the environment variable should be set to "DEBUG".
+	if got := os.Getenv("ARGUS_LOG_LEVEL"); got != "DEBUG" {
+		t.Errorf("expected ARGUS_LOG_LEVEL to be 'DEBUG', got '%s'",
+			got)
+	}
+	// AND the log level should be set to DEBUG.
+	hadLogLevel := logutil.Log.Level
+	logutil.Log.SetLevel("DEBUG")
+	debugLogLevel := logutil.Log.Level
+	if hadLogLevel != debugLogLevel {
+		t.Errorf("expected log level to be DEBUG, got %d (want %d)",
+			debugLogLevel, hadLogLevel)
+	}
+	// AND the log should be in testing mode.
+	if !logutil.Log.Testing {
+		t.Errorf("expected log to be in testing mode")
+	}
+}

--- a/testing/help_test.go
+++ b/testing/help_test.go
@@ -20,17 +20,16 @@ import (
 	"os"
 	"testing"
 
-	logutil "github.com/release-argus/Argus/util/log"
+	logtest "github.com/release-argus/Argus/test/log"
 )
 
 func TestMain(m *testing.M) {
-	// initialise jLog
-	logutil.Init("DEBUG", false)
-	logutil.Log.Testing = true
+	// Log.
+	logtest.InitLog()
 
-	// run other tests
+	// Run other tests.
 	exitCode := m.Run()
 
-	// exit
+	// Exit.
 	os.Exit(exitCode)
 }

--- a/util/log/log.go
+++ b/util/log/log.go
@@ -84,6 +84,8 @@ func NewJLog(level string, timestamps bool) *JLog {
 func (l *JLog) SetLevel(level string) {
 	l.mutex.Lock()
 	defer l.mutex.Unlock()
+
+	// New log level.
 	level = strings.ToUpper(level)
 	value := levelMap[level]
 
@@ -92,15 +94,21 @@ func (l *JLog) SetLevel(level string) {
 			level),
 			LogFrom{}, true)
 	}
-
-	l.Level = value
+	// Set the log level if it has changed.
+	if value != l.Level {
+		l.Level = value
+	}
 }
 
 // SetTimestamps on the logs.
 func (l *JLog) SetTimestamps(enable bool) {
 	l.mutex.Lock()
 	defer l.mutex.Unlock()
-	l.Timestamps = enable
+
+	// Set the timestamps flag if it has changed.
+	if enable != l.Timestamps {
+		l.Timestamps = enable
+	}
 }
 
 // String produces the string representation of the LogFrom.

--- a/web/api/v1/help_test.go
+++ b/web/api/v1/help_test.go
@@ -33,8 +33,8 @@ import (
 	latestver "github.com/release-argus/Argus/service/latest_version"
 	opt "github.com/release-argus/Argus/service/option"
 	"github.com/release-argus/Argus/test"
+	logtest "github.com/release-argus/Argus/test/log"
 	"github.com/release-argus/Argus/util"
-	logutil "github.com/release-argus/Argus/util/log"
 	"github.com/release-argus/Argus/webhook"
 )
 
@@ -45,9 +45,9 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	// initialise jLog
-	logutil.Init("DEBUG", false)
-	logutil.Log.Testing = true
+	// Log.
+	logtest.InitLog()
+
 	flags := make(map[string]bool)
 	path := "TestWebAPIv1Main.yml"
 	testYAML_Argus(path)
@@ -55,14 +55,14 @@ func TestMain(m *testing.M) {
 	config.Load(path, &flags)
 	os.Remove(path)
 
-	// Marshal the secret value '<secret>' -> '\u003csecret\u003e'
+	// Marshal the secret value '<secret>' -> '\u003csecret\u003e'.
 	secretValueMarshalledBytes, _ := json.Marshal(util.SecretValue)
 	secretValueMarshalled = string(secretValueMarshalledBytes)
 
-	// run other tests
+	// Run other tests.
 	exitCode := m.Run()
 
-	// exit
+	// Exit.
 	os.Exit(exitCode)
 }
 
@@ -143,7 +143,7 @@ func testService(id string, semVer bool) *service.Service {
 		DeployedVersionLookup: dv,
 		Options:               *options}
 
-	// Hard defaults
+	// HardDefaults.
 	serviceHardDefaults := service.Defaults{}
 	serviceHardDefaults.Default()
 	shoutrrrHardDefaults := shoutrrr.SliceDefaults{}
@@ -151,17 +151,17 @@ func testService(id string, semVer bool) *service.Service {
 	webhookHardDefaults := webhook.Defaults{}
 	webhookHardDefaults.Default()
 
-	// Defaults
+	// Defaults.
 	serviceDefaults := service.Defaults{}
 	serviceDefaults.Init()
 
-	// Init with defaults/hardDefaults
+	// Init with defaults/hardDefaults.
 	svc.Init(
 		&serviceDefaults, &serviceHardDefaults,
 		&shoutrrr.SliceDefaults{}, &shoutrrr.SliceDefaults{}, &shoutrrrHardDefaults,
 		&webhook.SliceDefaults{}, &webhook.Defaults{}, &webhookHardDefaults)
 
-	// Status channels
+	// Status channels.
 	svc.Status.AnnounceChannel = &announceChannel
 	svc.Status.DatabaseChannel = &databaseChannel
 

--- a/web/api/v1/http_test.go
+++ b/web/api/v1/http_test.go
@@ -34,19 +34,19 @@ import (
 )
 
 func TestHTTP_Version(t *testing.T) {
-	// GIVEN an API and the Version,BuildDate and GoVersion vars defined
+	// GIVEN an API and the Version,BuildDate and GoVersion vars defined.
 	api := API{}
 	util.Version = "1.2.3"
 	util.BuildDate = "2022-01-01T01:01:01Z"
 
-	// WHEN a HTTP request is made to the httpVersion handler
+	// WHEN a HTTP request is made to the httpVersion handler.
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/version", nil)
 	w := httptest.NewRecorder()
 	api.httpVersion(w, req)
 	res := w.Result()
 	t.Cleanup(func() { res.Body.Close() })
 
-	// THEN the version is returned in JSON format
+	// THEN the version is returned in JSON format.
 	data, err := io.ReadAll(res.Body)
 	if err != nil {
 		t.Errorf("expected error to be nil got %v",
@@ -66,7 +66,7 @@ func TestHTTP_Version(t *testing.T) {
 }
 
 func TestHTTP_BasicAuth(t *testing.T) {
-	// GIVEN an API with/without Basic Auth credentials
+	// GIVEN an API with/without Basic Auth credentials.
 	tests := map[string]struct {
 		basicAuth *config.WebSettingsBasicAuth
 		fail      bool
@@ -95,7 +95,7 @@ func TestHTTP_BasicAuth(t *testing.T) {
 
 			cfg := config.Config{}
 			cfg.Settings.Web.BasicAuth = tc.basicAuth
-			// Hash the username/password
+			// Hash the username/password.
 			if cfg.Settings.Web.BasicAuth != nil {
 				cfg.Settings.Web.BasicAuth.CheckValues()
 			}
@@ -106,7 +106,7 @@ func TestHTTP_BasicAuth(t *testing.T) {
 			ts := httptest.NewServer(api.BaseRouter)
 			t.Cleanup(func() { ts.Close() })
 
-			// WHEN a HTTP request is made to this router
+			// WHEN a HTTP request is made to this router.
 			client := http.Client{}
 			req, err := http.NewRequest(http.MethodGet, ts.URL+"/test", nil)
 			if err != nil {
@@ -123,7 +123,7 @@ func TestHTTP_BasicAuth(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			// THEN the request passes only when expected
+			// THEN the request passes only when expected.
 			got := resp.StatusCode
 			want := 200
 			if tc.fail {
@@ -138,7 +138,7 @@ func TestHTTP_BasicAuth(t *testing.T) {
 }
 
 func TestHTTP_SetupRoutesFavicon(t *testing.T) {
-	// GIVEN an API with/without favicon overrides
+	// GIVEN an API with/without favicon overrides.
 	tests := map[string]struct {
 		favicon        *config.FaviconSettings
 		urlPNG, urlSVG string
@@ -170,7 +170,7 @@ func TestHTTP_SetupRoutesFavicon(t *testing.T) {
 			t.Cleanup(func() { ts.Close() })
 			client := http.Client{}
 
-			// WHEN a HTTP request is made to this router (apple-touch-icon.png)
+			// WHEN a HTTP request is made to this router (apple-touch-icon.png).
 			req, err := http.NewRequest(http.MethodGet, ts.URL+"/apple-touch-icon.png", nil)
 			if err != nil {
 				t.Fatal(err)
@@ -180,7 +180,7 @@ func TestHTTP_SetupRoutesFavicon(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			// THEN the status code is as expected
+			// THEN the status code is as expected.
 			wantStatus := http.StatusNotFound
 			if tc.urlPNG != "" {
 				wantStatus = http.StatusOK
@@ -194,7 +194,7 @@ func TestHTTP_SetupRoutesFavicon(t *testing.T) {
 					tc.urlPNG, resp.Request.URL.String())
 			}
 
-			// WHEN a HTTP request is made to this router (favicon.svg)
+			// WHEN a HTTP request is made to this router (favicon.svg).
 			req, err = http.NewRequest(http.MethodGet, ts.URL+"/favicon.svg", nil)
 			if err != nil {
 				t.Fatal(err)
@@ -204,7 +204,7 @@ func TestHTTP_SetupRoutesFavicon(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			// THEN the status code is as expected
+			// THEN the status code is as expected.
 			wantStatus = http.StatusNotFound
 			if tc.urlSVG != "" {
 				wantStatus = http.StatusOK
@@ -222,7 +222,7 @@ func TestHTTP_SetupRoutesFavicon(t *testing.T) {
 }
 
 func TestHTTP_DisableRoutes(t *testing.T) {
-	// GIVEN an API and a bunch of routes
+	// GIVEN an API and a bunch of routes.
 	tests := map[string]struct {
 		method, path       string
 		replaceLastPathDir string
@@ -266,7 +266,7 @@ func TestHTTP_DisableRoutes(t *testing.T) {
 			path:       "flags",
 			wantStatus: http.StatusOK,
 			wantBody: `{
-				"log.level":"INFO",
+				"log.level":"DEBUG",
 				"log.timestamps":false,
 				"data.database-file":"[^"]+",
 				"web.listen-host":"[\d.]+",
@@ -401,7 +401,7 @@ func TestHTTP_DisableRoutes(t *testing.T) {
 	}
 	disableCombinations := test.Combinations(util.SortedKeys(tests))
 
-	// Split tests into groups
+	// Split tests into groups.
 	groupSize := max(1, len(disableCombinations)/runtime.NumCPU())
 	numGroups := len(disableCombinations) / groupSize
 	for i := 0; i < numGroups; i++ {
@@ -412,7 +412,7 @@ func TestHTTP_DisableRoutes(t *testing.T) {
 		t.Run(fmt.Sprintf("Group %d", i+1), func(t *testing.T) {
 			t.Parallel()
 			for j, disabledRoutes := range group {
-				// Insane number of tests, so have to skip some
+				// Insane number of tests, so have to skip some.
 				if j%((len(tests)+1)*10) != 0 {
 					continue
 				}
@@ -420,7 +420,7 @@ func TestHTTP_DisableRoutes(t *testing.T) {
 
 					cfg := config_test.BareConfig(false)
 					cfg.Settings.Web.DisabledRoutes = disabledRoutes
-					// Give every other test a route prefix
+					// Give every other test a route prefix.
 					routePrefix := ""
 					if j%2 == 0 {
 						routePrefix = "/test"
@@ -433,7 +433,7 @@ func TestHTTP_DisableRoutes(t *testing.T) {
 					t.Cleanup(func() { ts.Close() })
 					client := http.Client{}
 
-					// Test each route for this set of disabled routes
+					// Test each route for this set of disabled routes.
 					for name, tc := range tests {
 						if !strings.HasPrefix(name, "-") && util.Contains(disabledRoutes, name) {
 							tc.wantStatus = http.StatusNotFound
@@ -450,7 +450,7 @@ func TestHTTP_DisableRoutes(t *testing.T) {
 						}
 						url := ts.URL + path
 
-						// WHEN a HTTP request is made to this router
+						// WHEN a HTTP request is made to this router.
 						req, err := http.NewRequest(tc.method, url, nil)
 						if err != nil {
 							t.Fatal(err)
@@ -460,7 +460,7 @@ func TestHTTP_DisableRoutes(t *testing.T) {
 							t.Fatal(err)
 						}
 
-						// Read the response body
+						// Read the response body.
 						body, err := io.ReadAll(resp.Body)
 						if err != nil {
 							t.Fatal(err)
@@ -468,13 +468,13 @@ func TestHTTP_DisableRoutes(t *testing.T) {
 						resp.Body.Close()
 
 						fail := false
-						// THEN the status code is as expected
+						// THEN the status code is as expected.
 						if resp.StatusCode != tc.wantStatus {
 							t.Errorf("%s - Expected a %d, not a %d",
 								path, tc.wantStatus, resp.StatusCode)
 							fail = true
 						}
-						// AND the body is as expected
+						// AND the body is as expected.
 						if !util.RegexCheck(tc.wantBody, string(body)) {
 							t.Errorf("%s - Expected a body of\n%s\nnot\n%s",
 								path, tc.wantBody, string(body))
@@ -492,7 +492,7 @@ func TestHTTP_DisableRoutes(t *testing.T) {
 }
 
 func TestHTTP_SetupRoutesNodeJS(t *testing.T) {
-	// GIVEN an API with NodeJS routes
+	// GIVEN an API with NodeJS routes.
 	tests := map[string]struct {
 		route       string
 		wantStatus  int
@@ -533,7 +533,7 @@ func TestHTTP_SetupRoutesNodeJS(t *testing.T) {
 			t.Cleanup(func() { ts.Close() })
 			client := http.Client{}
 
-			// WHEN a HTTP request is made to this router
+			// WHEN a HTTP request is made to this router.
 			req, err := http.NewRequest(http.MethodGet, ts.URL+tc.route, nil)
 			if err != nil {
 				t.Fatal(err)
@@ -543,12 +543,12 @@ func TestHTTP_SetupRoutesNodeJS(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			// THEN the status code is as expected
+			// THEN the status code is as expected.
 			if resp.StatusCode != tc.wantStatus {
 				t.Errorf("Expected status %d, got %d", tc.wantStatus, resp.StatusCode)
 			}
 
-			// AND the content type is as expected
+			// AND the content type is as expected.
 			if tc.wantContent != "" {
 				contentType := resp.Header.Get("Content-Type")
 				if !strings.Contains(contentType, tc.wantContent) {

--- a/web/api/v1/http_test.go
+++ b/web/api/v1/http_test.go
@@ -30,7 +30,6 @@ import (
 	config_test "github.com/release-argus/Argus/config/test"
 	"github.com/release-argus/Argus/test"
 	"github.com/release-argus/Argus/util"
-	logutil "github.com/release-argus/Argus/util/log"
 	apitype "github.com/release-argus/Argus/web/api/types"
 )
 
@@ -400,8 +399,6 @@ func TestHTTP_DisableRoutes(t *testing.T) {
 			}`,
 		},
 	}
-	logutil.Init("WARN", false)
-	logutil.Log.Testing = true
 	disableCombinations := test.Combinations(util.SortedKeys(tests))
 
 	// Split tests into groups

--- a/web/ui/package-lock.json
+++ b/web/ui/package-lock.json
@@ -1646,9 +1646,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001695",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001695.tgz",
-      "integrity": "sha512-vHyLade6wTgI2u1ec3WQBxv+2BrTERV28UXQu9LO6lZ9pYeMk34vjXFLOxo1A4UBA8XTL4njRQZdno/yYaSmWw==",
+      "version": "1.0.30001698",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001698.tgz",
+      "integrity": "sha512-xJ3km2oiG/MbNU8G6zIq6XRZ6HtAOVXsbOrP/blGazi52kc5Yy7b6sDA5O+FbROzRrV7BSTllLHuNvmawYUJjw==",
       "dev": true,
       "funding": [
         {

--- a/webhook/help_test.go
+++ b/webhook/help_test.go
@@ -23,18 +23,17 @@ import (
 
 	"github.com/release-argus/Argus/service/status"
 	"github.com/release-argus/Argus/test"
-	logutil "github.com/release-argus/Argus/util/log"
+	logtest "github.com/release-argus/Argus/test/log"
 )
 
 func TestMain(m *testing.M) {
-	// initialise jLog
-	logutil.Init("DEBUG", false)
-	logutil.Log.Testing = true
+	// Log.
+	logtest.InitLog()
 
-	// run other tests
+	// Run other tests.
 	exitCode := m.Run()
 
-	// exit
+	// Exit.
 	os.Exit(exitCode)
 }
 


### PR DESCRIPTION
Wasn't initialising the logger before the first possible log.

Builds on #528. (Was keeping the log level at `ERROR` until after `config.Load`, meaning the Debug logs of services being initialised were skipped)
