### PR TITLE
fix(ui): handle `manual` type deployed_version on new service

### DIFF
--- a/web/ui/react-app/src/components/approvals/service.tsx
+++ b/web/ui/react-app/src/components/approvals/service.tsx
@@ -57,7 +57,7 @@ const Service: FC<Props> = ({ service, editable = false }) => {
 
 	return (
 		<Card key={service.id} bg="secondary" className={'service shadow'}>
-			<Card.Title className="service-title" key={service.id + '-title'}>
+			<Card.Title className="service-title" key={`${service.id}-title`}>
 				<a
 					href={service.url}
 					target="_blank"

--- a/web/ui/react-app/src/components/generic/boolean-with-default.tsx
+++ b/web/ui/react-app/src/components/generic/boolean-with-default.tsx
@@ -62,11 +62,11 @@ const BooleanWithDefault: FC<Props> = ({
 		>
 			<>
 				{label && (
-					<FormLabel id={name + '-label'} style={{ float: 'left' }}>
+					<FormLabel id={`${name}-label`} style={{ float: 'left' }}>
 						{label}
 					</FormLabel>
 				)}
-				{tooltip && <HelpTooltip id={name + '-tooltip'} tooltip={tooltip} />}
+				{tooltip && <HelpTooltip id={`${name}-tooltip`} tooltip={tooltip} />}
 			</>
 
 			<div
@@ -85,8 +85,8 @@ const BooleanWithDefault: FC<Props> = ({
 						return (
 							<>
 								<ButtonGroup
-									aria-labelledby={name + '-label'}
-									aria-describedby={tooltip && name + '-tooltip'}
+									aria-labelledby={`${name}-label`}
+									aria-describedby={tooltip && `${name}-tooltip`}
 								>
 									{options.map((option) => (
 										<Button

--- a/web/ui/react-app/src/components/generic/form-colour.tsx
+++ b/web/ui/react-app/src/components/generic/form-colour.tsx
@@ -102,8 +102,8 @@ const FormColour: FC<Props> = ({
 						<FormControl
 							id={name}
 							aria-describedby={cx(
-								error && name + '-error',
-								tooltip && name + '-tooltip',
+								error && `${name}-error`,
+								tooltip && `${name}-tooltip`,
 							)}
 							style={{ width: '25%' }}
 							type="text"
@@ -133,7 +133,7 @@ const FormColour: FC<Props> = ({
 				</div>
 			</FormGroup>
 			{error && (
-				<small id={name + '-error'} className="error-msg" role="alert">
+				<small id={`${name}-error`} className="error-msg" role="alert">
 					{error['message'] || 'err'}
 				</small>
 			)}

--- a/web/ui/react-app/src/components/generic/form-select-creatable-sortable.tsx
+++ b/web/ui/react-app/src/components/generic/form-select-creatable-sortable.tsx
@@ -243,8 +243,8 @@ const FormSelectCreatableSortable: FC<FormSelectCreatableSortableProps> = ({
 									id={name}
 									aria-label={`Select options for ${label}`}
 									aria-describedby={cx(
-										error && name + '-error',
-										tooltip && name + '-tooltip',
+										error && `${name}-error`,
+										tooltip && `${name}-tooltip`,
 									)}
 									className="form-select-creatable"
 									options={creatableOptions}
@@ -286,7 +286,7 @@ const FormSelectCreatableSortable: FC<FormSelectCreatableSortableProps> = ({
 					}}
 				/>
 				{error && (
-					<small id={name + '-error'} className="error-msg" role="alert">
+					<small id={`${name}-error`} className="error-msg" role="alert">
 						{error['message'] || 'err'}
 					</small>
 				)}

--- a/web/ui/react-app/src/components/generic/form-select-creatable.tsx
+++ b/web/ui/react-app/src/components/generic/form-select-creatable.tsx
@@ -207,8 +207,8 @@ const FormSelectCreatable: FC<FormSelectCreatableProps> = ({
 							id={name}
 							aria-label={`Select option${isMulti ? 's' : ''} for ${label}`}
 							aria-describedby={cx(
-								error && name + '-error',
-								tooltip && name + '-tooltip',
+								error && `${name}-error`,
+								tooltip && `${name}-tooltip`,
 							)}
 							className="form-select-creatable"
 							options={creatableOptions ?? []}
@@ -248,7 +248,7 @@ const FormSelectCreatable: FC<FormSelectCreatableProps> = ({
 					}}
 				/>
 				{error && (
-					<small id={name + '-error'} className="error-msg" role="alert">
+					<small id={`${name}-error`} className="error-msg" role="alert">
 						{error['message'] || 'err'}
 					</small>
 				)}

--- a/web/ui/react-app/src/components/generic/form-select.tsx
+++ b/web/ui/react-app/src/components/generic/form-select.tsx
@@ -144,8 +144,8 @@ const FormSelect: FC<FormSelectProps> = ({
 							id={name}
 							aria-label={`Select option${isMulti ? 's' : ''} for ${label}`}
 							aria-describedby={cx(
-								error && name + '-error',
-								tooltip && name + '-tooltip',
+								error && `${name}-error`,
+								tooltip && `${name}-tooltip`,
 							)}
 							options={options}
 							value={
@@ -190,7 +190,7 @@ const FormSelect: FC<FormSelectProps> = ({
 					}}
 				/>
 				{error && (
-					<small id={name + '-error'} className="error-msg" role="alert">
+					<small id={`${name}-error`} className="error-msg" role="alert">
 						{error['message'] || 'err'}
 					</small>
 				)}

--- a/web/ui/react-app/src/components/generic/form-text-area.tsx
+++ b/web/ui/react-app/src/components/generic/form-text-area.tsx
@@ -119,8 +119,8 @@ const FormTextArea: FC<FormTextAreaProps> = ({
 				<FormControl
 					id={name}
 					aria-describedby={cx(
-						error && name + '-error',
-						tooltip && name + '-tooltip',
+						error && `${name}-error`,
+						tooltip && `${name}-tooltip`,
 					)}
 					type={'textarea'}
 					as="textarea"
@@ -142,7 +142,7 @@ const FormTextArea: FC<FormTextAreaProps> = ({
 					isInvalid={!!error}
 				/>
 				{error && (
-					<small id={name + '-error'} className="error-msg" role="alert">
+					<small id={`${name}-error`} className="error-msg" role="alert">
 						{error['message'] || 'err'}
 					</small>
 				)}

--- a/web/ui/react-app/src/components/generic/form-text-with-button.tsx
+++ b/web/ui/react-app/src/components/generic/form-text-with-button.tsx
@@ -1,0 +1,223 @@
+import {
+	Button,
+	Col,
+	FormControl,
+	FormGroup,
+	InputGroup,
+} from 'react-bootstrap';
+import { requiredTest, urlTest } from './form-validate';
+import { useFormContext, useWatch } from 'react-hook-form';
+
+import { FC } from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import FormLabel from './form-label';
+import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
+import { Position } from 'types/config';
+import { TooltipWithAriaProps } from './tooltip';
+import cx from 'classnames';
+import { formPadding } from './form-shared';
+import { useError } from 'hooks/errors';
+
+interface Props {
+	name: string;
+	required?: boolean | string;
+
+	col_xs?: number;
+	col_sm?: number;
+	col_md?: number;
+	col_lg?: number;
+
+	label?: string;
+	smallLabel?: boolean;
+
+	type?: 'text' | 'url';
+	isURL?: boolean;
+	validationFunc?: (value: string) => boolean | string;
+	defaultVal?: string;
+	placeholder?: string;
+
+	buttonIcon: IconDefinition;
+	buttonAriaLabel: string;
+	buttonVariant?: string;
+	buttonOnClick?: (value: string) => void;
+	buttonHref?: (value: string) => string;
+	showButtonCondition?: (value: string, hasError: boolean) => boolean;
+
+	positionXS?: Position;
+	positionSM?: Position;
+	positionMD?: Position;
+	positionLG?: Position;
+}
+
+type FormTextWithButtonProps = TooltipWithAriaProps & Props;
+
+/**
+ * A form text input item.
+ *
+ * @param name - The name of the form item.
+ * @param className - Additional classes for the form item.
+ * @param registerParams - Additional parameters for the form item.
+ * @param required - Whether the form item is required.
+ * @param unique - Whether the form item should be unique.
+ *
+ * @param col_xs - The number of columns the item takes up on XS+ screens.
+ * @param col_sm - The number of columns the item takes up on SM+ screens.
+ * @param col_md - The number of columns the item takes up on MD+ screens.
+ * @param col_lg - The number of columns the item takes up on LG+ screens.
+ *
+ * @param label - The label of the form item.
+ * @param smallLabel - Whether the label should be small.
+ * @param tooltip - The tooltip of the form item.
+ * @param tooltipAriaLabel - The aria label for the tooltip (Defaults to the tooltip).
+ *
+ * @param type - The type of the form item.
+ * @param isURL - Whether the form item should be a URL.
+ * @param validationFunc - The validation function for the form item.
+ * @param defaultVal - The default value of the form item.
+ * @param placeholder - The placeholder of the form item.
+ *
+ * @param buttonIcon - The icon for the button.
+ * @param buttonAriaLabel - Aria Label for the button.
+ * @param buttonVariant - Variant for the button.
+ * @param buttonOnClick - Function to run when the button is clicked.
+ * @param buttonHref - Hyperlink to navigate to when the button is clicked.
+ * @param showButtonCondition - Condition behind whether to render the button in the UI.
+ *
+ * @param positionXS - The position of the form item on XS+ screens.
+ * @param positionSM - The position of the form item on SM+ screens.
+ * @param positionMD - The position of the form item on MD+ screens.
+ * @param positionLG - The position of the form item on LG+ screens.
+ * @returns A form text input item at name with a label and tooltip.
+ */
+const FormTextWithButton: FC<FormTextWithButtonProps> = ({
+	name,
+	required = false,
+
+	col_xs = 12,
+	col_sm = 6,
+	col_md,
+	col_lg,
+
+	label,
+	smallLabel,
+	tooltip,
+	tooltipAriaLabel,
+
+	type = 'text',
+	isURL,
+	validationFunc,
+	defaultVal,
+	placeholder,
+
+	buttonIcon,
+	buttonAriaLabel,
+	buttonVariant = 'secondary',
+	buttonOnClick,
+	buttonHref,
+	showButtonCondition = (value, hasError) => value && !hasError,
+
+	positionXS = 'left',
+	positionSM,
+	positionMD,
+	positionLG,
+}) => {
+	const { register, setError, clearErrors } = useFormContext();
+	const value = useWatch({ name });
+	const error = useError(name, !!required || isURL);
+
+	const padding = formPadding({
+		col_xs,
+		col_sm,
+		col_md,
+		col_lg,
+		positionXS,
+		positionSM,
+		positionMD,
+		positionLG,
+	});
+
+	const getTooltipProps = () => {
+		if (!tooltip) return {};
+		if (typeof tooltip === 'string') return { tooltip, tooltipAriaLabel };
+		return { tooltip, tooltipAriaLabel };
+	};
+
+	const ButtonWrapper = ({ children }: { children: React.ReactNode }) =>
+		buttonHref ? (
+			<a href={buttonHref(value)} target="_blank" rel="noopener noreferrer">
+				{children}
+			</a>
+		) : (
+			<>{children}</>
+		);
+
+	return (
+		<Col
+			xs={col_xs}
+			sm={col_sm}
+			md={col_md}
+			lg={col_lg}
+			className={cx(padding, 'pt-1 pb-1', 'col-form')}
+		>
+			<FormGroup>
+				{label && (
+					<FormLabel
+						htmlFor={name}
+						text={label}
+						{...getTooltipProps()}
+						required={required !== false}
+						small={!!smallLabel}
+					/>
+				)}
+				<InputGroup className="me-3">
+					<FormControl
+						id={name}
+						aria-label={`Value field for ${label}`}
+						aria-describedby={cx(
+							error && `${name}-error`,
+							tooltip && `${name}-tooltip`,
+						)}
+						type={type}
+						placeholder={defaultVal || placeholder}
+						autoFocus={false}
+						{...register(name, {
+							validate: {
+								required: (value) =>
+									requiredTest(
+										value || defaultVal || '',
+										name,
+										setError,
+										clearErrors,
+										required,
+									),
+								isURL: (value) => urlTest(value || defaultVal || '', isURL),
+								validationFunc: (value) =>
+									!validationFunc || validationFunc(value || defaultVal || ''),
+							},
+						})}
+						isInvalid={!!error}
+					/>
+					{showButtonCondition(value, !!error) && (
+						<ButtonWrapper>
+							<Button
+								aria-label={buttonAriaLabel}
+								variant={buttonVariant}
+								className="curved-right-only"
+								onClick={() => buttonOnClick?.(value)}
+							>
+								<FontAwesomeIcon icon={buttonIcon} />
+							</Button>
+						</ButtonWrapper>
+					)}
+				</InputGroup>
+				{error && (
+					<small id={`${name}-error`} className="error-msg" role="alert">
+						{error['message'] || 'err'}
+					</small>
+				)}
+			</FormGroup>
+		</Col>
+	);
+};
+
+export default FormTextWithButton;

--- a/web/ui/react-app/src/components/generic/form-text-with-preview.tsx
+++ b/web/ui/react-app/src/components/generic/form-text-with-preview.tsx
@@ -62,7 +62,7 @@ const FormTextWithPreview: FC<Props> = ({
 	}, [formValue]);
 
 	return (
-		<Col xs={12} sm={12} className={'pt-1 pb-1 col-form'}>
+		<Col xs={12} sm={12} className={cx('py-1', 'col-form')}>
 			<FormGroup>
 				<FormLabel htmlFor={name} text={label} tooltip={tooltip} />
 				<div style={{ display: 'flex', alignItems: 'center' }}>
@@ -70,8 +70,8 @@ const FormTextWithPreview: FC<Props> = ({
 						id={name}
 						aria-label={`Value field for ${label}`}
 						aria-describedby={cx(
-							error && name + '-error',
-							tooltip && name + '-tooltip',
+							error && `${name}-error`,
+							tooltip && `${name}-tooltip`,
 						)}
 						type="text"
 						value={formValue}
@@ -104,7 +104,7 @@ const FormTextWithPreview: FC<Props> = ({
 				</div>
 			</FormGroup>
 			{error && (
-				<small id={name + '-error'} className="error-msg" role="alert">
+				<small id={`${name}-error`} className="error-msg" role="alert">
 					{error['message'] || 'err'}
 				</small>
 			)}

--- a/web/ui/react-app/src/components/generic/form-text.tsx
+++ b/web/ui/react-app/src/components/generic/form-text.tsx
@@ -157,7 +157,7 @@ const FormText: FC<FormTextProps> = ({
 				<FormControl
 					id={name}
 					aria-label={`Value field for ${label}`}
-					aria-describedby={cx(error && name + '-error')}
+					aria-describedby={cx(error && `${name}-error`)}
 					type={type}
 					placeholder={defaultVal || placeholder}
 					autoFocus={false}
@@ -185,7 +185,7 @@ const FormText: FC<FormTextProps> = ({
 					isInvalid={!!error}
 				/>
 				{error && (
-					<small id={name + '-error'} className="error-msg" role="alert">
+					<small id={`${name}-error`} className="error-msg" role="alert">
 						{error['message'] || 'err'}
 					</small>
 				)}

--- a/web/ui/react-app/src/components/generic/form.tsx
+++ b/web/ui/react-app/src/components/generic/form.tsx
@@ -9,6 +9,7 @@ import FormSelectCreatable from './form-select-creatable';
 import FormSelectCreatableSortable from './form-select-creatable-sortable';
 import FormText from './form-text';
 import FormTextArea from './form-text-area';
+import FormTextWithButton from './form-text-with-button';
 import FormTextWithPreview from './form-text-with-preview';
 
 export {
@@ -23,5 +24,6 @@ export {
 	FormSelectCreatableSortable,
 	FormText,
 	FormTextArea,
+	FormTextWithButton,
 	FormTextWithPreview,
 };

--- a/web/ui/react-app/src/components/modals/action-release/item.tsx
+++ b/web/ui/react-app/src/components/modals/action-release/item.tsx
@@ -106,7 +106,7 @@ export const Item: FC<Props> = ({
 
 	return (
 		<Card bg="secondary" className={'no-margin service'}>
-			<Card.Title className="modal-item-title" key={title + '-title'}>
+			<Card.Title className="modal-item-title" key={`${title}-title`}>
 				<Container fluid style={{ paddingLeft: '0px' }}>
 					{title}
 				</Container>
@@ -116,7 +116,7 @@ export const Item: FC<Props> = ({
 						placement="top"
 						delay={{ show: 500, hide: 500 }}
 						overlay={
-							<Tooltip id={id + '-resend-date'}>
+							<Tooltip id={`${id}-resend-date`}>
 								{`Can resend ${formatRelative(
 									new Date(next_runnable),
 									new Date(),
@@ -149,7 +149,7 @@ export const Item: FC<Props> = ({
 						placement="top"
 						delay={{ show: 500, hide: 500 }}
 						overlay={
-							<Tooltip id={id + '-result'}>
+							<Tooltip id={`${id}-result`}>
 								{failed === true ? 'Failed' : 'Successful'}
 							</Tooltip>
 						}
@@ -181,7 +181,7 @@ export const Item: FC<Props> = ({
 						placement="top"
 						delay={{ show: 500, hide: 500 }}
 						overlay={
-							<Tooltip id={id + '-send'}>
+							<Tooltip id={`${id}-send`}>
 								{modalType === 'RESEND' || failed !== undefined
 									? 'Retry'
 									: 'Send'}
@@ -190,9 +190,9 @@ export const Item: FC<Props> = ({
 					>
 						<Button
 							aria-describedby={cx(
-								id + '-send',
-								!sendable && !sending && id + '-resend-date',
-								!sending && failed !== undefined && id + '-result',
+								`${id}-send`,
+								!sendable && !sending && `${id}-resend-date`,
+								!sending && failed !== undefined && `${id}-result`,
 							)}
 							variant="secondary"
 							size="sm"

--- a/web/ui/react-app/src/components/modals/service-edit/dashboard.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/dashboard.tsx
@@ -1,7 +1,7 @@
 import { FC, memo, useMemo } from 'react';
 import {
 	FormSelectCreatableSortable,
-	FormText,
+	FormTextWithButton,
 	FormTextWithPreview,
 } from 'components/generic/form';
 
@@ -9,6 +9,7 @@ import { Accordion } from 'react-bootstrap';
 import { BooleanWithDefault } from 'components/generic';
 import { ServiceDashboardOptionsType } from 'types/config';
 import { createOption } from 'components/generic/form-select-shared';
+import { faLink } from '@fortawesome/free-solid-svg-icons';
 import { firstNonDefault } from 'utils';
 import { useWebSocket } from 'contexts/websocket';
 
@@ -74,7 +75,7 @@ const EditServiceDashboard: FC<Props> = ({
 					tooltip="e.g. https://example.com/icon.png"
 					defaultVal={convertedDefaults.icon}
 				/>
-				<FormText
+				<FormTextWithButton
 					key="icon_link_to"
 					name="dashboard.icon_link_to"
 					col_sm={12}
@@ -82,8 +83,11 @@ const EditServiceDashboard: FC<Props> = ({
 					tooltip="Where the Icon will redirect when clicked"
 					defaultVal={convertedDefaults.icon_link_to}
 					isURL
+					buttonIcon={faLink}
+					buttonAriaLabel="Open icon link"
+					buttonHref={(value) => value}
 				/>
-				<FormText
+				<FormTextWithButton
 					key="web_url"
 					name="dashboard.web_url"
 					col_sm={12}
@@ -91,6 +95,9 @@ const EditServiceDashboard: FC<Props> = ({
 					tooltip="Where the 'Service name' will redirect when clicked"
 					defaultVal={convertedDefaults.web_url}
 					isURL
+					buttonIcon={faLink}
+					buttonAriaLabel="Open web URL"
+					buttonHref={(value) => value}
 				/>
 				<FormSelectCreatableSortable
 					name="dashboard.tags"

--- a/web/ui/react-app/src/components/modals/service-edit/deployed-version-manual.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/deployed-version-manual.tsx
@@ -137,7 +137,7 @@ const DeployedVersionManual: FC<DeployedVersionManualProps> = ({
 						<FormControl
 							id={name}
 							aria-label="Version string"
-							aria-describedby={cx(errorMessage && name + '-error')}
+							aria-describedby={cx(errorMessage && `${name}-error`)}
 							type="text"
 							defaultValue={value}
 							isInvalid={!!errorMessage}

--- a/web/ui/react-app/src/components/modals/service-edit/deployed-version-manual.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/deployed-version-manual.tsx
@@ -10,6 +10,7 @@ import { FC, memo, useState } from 'react';
 import { NonNullable, ServiceOptionsType } from 'types/config';
 import { beautifyGoErrors, fetchVersionJSON } from 'utils';
 import { faSave, faSpinner } from '@fortawesome/free-solid-svg-icons';
+import { useFormContext, useWatch } from 'react-hook-form';
 
 import { DeployedVersionLookupEditType } from 'types/service-edit';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -20,7 +21,6 @@ import cx from 'classnames';
 import { formPadding } from 'components/generic/form-shared';
 import { useQuery } from '@tanstack/react-query';
 import useValuesRefetch from 'hooks/values-refetch';
-import { useWatch } from 'react-hook-form';
 import { useWebSocket } from 'contexts/websocket';
 
 interface Props {
@@ -45,13 +45,14 @@ const DeployedVersionManual: FC<DeployedVersionManualProps> = ({
 	original_options,
 }) => {
 	const name = 'deployed_version.version';
+	const { register } = useFormContext();
 	const [lastFetched, setLastFetched] = useState(0);
 	const value: string = useWatch({ name: name });
 	const { data: semanticVersioning, refetchData: refetchSemanticVersioning } =
 		useValuesRefetch('options.semantic_versioning');
 	const { monitorData } = useWebSocket();
-	let status = monitorData.service[serviceID]
-		.status as NonNullable<StatusSummaryType>;
+	const status = (monitorData.service[serviceID]?.status ??
+		{}) as NonNullable<StatusSummaryType>;
 
 	const canSave =
 		original?.type === 'manual' && value !== status.deployed_version;
@@ -137,8 +138,10 @@ const DeployedVersionManual: FC<DeployedVersionManualProps> = ({
 							id={name}
 							aria-label="Version string"
 							aria-describedby={cx(errorMessage && name + '-error')}
+							type="text"
 							defaultValue={value}
 							isInvalid={!!errorMessage}
+							{...register(name)}
 						/>
 						{canSave && value && (
 							<Button

--- a/web/ui/react-app/src/components/modals/service-edit/version-with-link.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/version-with-link.tsx
@@ -1,26 +1,9 @@
-import {
-	Button,
-	Col,
-	FormControl,
-	FormGroup,
-	InputGroup,
-} from 'react-bootstrap';
-import { FC, useState } from 'react';
-import {
-	repoTest,
-	requiredTest,
-	urlTest,
-} from 'components/generic/form-validate';
-import { useFormContext, useWatch } from 'react-hook-form';
-
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { FormLabel } from 'components/generic/form';
+import { FC } from 'react';
+import FormTextWithButton from 'components/generic/form-text-with-button';
 import { Position } from 'types/config';
 import { TooltipWithAriaProps } from 'components/generic/tooltip';
-import cx from 'classnames';
 import { faLink } from '@fortawesome/free-solid-svg-icons';
-import { formPadding } from 'components/generic/form-shared';
-import { useError } from 'hooks/errors';
+import { repoTest } from 'components/generic/form-validate';
 
 interface Props {
 	name: string;
@@ -31,6 +14,7 @@ interface Props {
 	col_sm?: number;
 	col_md?: number;
 	col_lg?: number;
+
 	positionXS?: Position;
 	positionSM?: Position;
 	positionMD?: Position;
@@ -45,11 +29,14 @@ type VersionWithLinkProps = TooltipWithAriaProps & Props;
  * @param name - The name of the field in the form.
  * @param type - The type of version field.
  * @param required - Whether the field is required.
+ *
  * @param col_xs - The amount of columns the item takes up on XS+ screens.
  * @param col_sm - The amount of columns the item takes up on SM+ screens.
  * @param col_md - The amount of columns the item takes up on MD+ screens.
  * @param col_lg - The amount of columns the item takes up on LG+ screens.
+ *
  * @param tooltip - The tooltip for the field.
+ *
  * @param positionXS - The position of the field on XS+ screens.
  * @param positionSM - The position of the field on SM+ screens.
  * @param positionMD - The position of the field on MD+ screens.
@@ -62,99 +49,43 @@ const VersionWithLink: FC<VersionWithLinkProps> = ({
 	required,
 	col_xs = 12,
 	col_sm = 6,
-	col_md,
-	col_lg,
-	tooltip,
-	tooltipAriaLabel,
 	positionXS = 'left',
-	positionSM,
-	positionMD,
-	positionLG,
+	...props
 }) => {
-	const { register, setError, clearErrors } = useFormContext();
-	const value: string = useWatch({ name: name });
-	const error = useError(name, true);
-
-	const [isUnfocused, setIsUnfocused] = useState(true);
-	const handleFocus = () => setIsUnfocused(false);
-	const handleBlur = () => setIsUnfocused(true);
-
-	const link = (type: 'github' | 'url') =>
-		type === 'github' ? `https://github.com/${value}` : value;
-	const padding = formPadding({
-		col_xs,
-		col_sm,
-		col_md,
-		col_lg,
-		positionXS,
-		positionSM,
-		positionMD,
-		positionLG,
-	});
-
-	const getTooltipProps = () => {
-		if (!tooltip) return {};
-		if (typeof tooltip === 'string') return { tooltip, tooltipAriaLabel };
-		return { tooltip, tooltipAriaLabel };
+	const typeConfig = {
+		github: {
+			label: 'Repository',
+			getLink: (value: string) => `https://github.com/${value}`,
+			buttonAriaLabel: 'Open GitHub repository',
+			validationFunc: (value: string) => repoTest(value, true),
+			isURL: false,
+		},
+		url: {
+			label: 'URL',
+			getLink: (value: string) => value,
+			buttonAriaLabel: 'Open URL',
+			validationFunc: undefined,
+			isURL: true,
+		},
 	};
 
+	const config = typeConfig[type];
+
 	return (
-		<Col
-			xs={col_xs}
-			sm={col_sm}
-			md={col_md}
-			lg={col_lg}
-			className={`${padding} pt-1 pb-1 col-form`}
-		>
-			<FormGroup>
-				<FormLabel
-					htmlFor={name}
-					text={type === 'github' ? 'Repository' : 'URL'}
-					{...getTooltipProps()}
-					required={required}
-				/>
-				<InputGroup className="me-3">
-					<FormControl
-						id={name}
-						aria-label={type === 'github' ? 'GitHub repository' : 'URL'}
-						aria-describedby={cx(
-							error && name + '-error',
-							tooltip && name + '-tooltip',
-						)}
-						defaultValue={value}
-						onFocus={handleFocus}
-						{...register(name, {
-							validate: {
-								required: (value) =>
-									requiredTest(value, name, setError, clearErrors, required),
-								isType: (value) =>
-									type === 'url' ? urlTest(value, true) : repoTest(value, true),
-							},
-							onBlur: handleBlur,
-						})}
-						isInvalid={!!error}
-					/>
-					{isUnfocused && value && !error && (
-						<a href={link(type)} target="_blank">
-							<Button
-								aria-label={
-									type === 'github' ? 'Open GitHub repository' : 'Open URL'
-								}
-								variant="secondary"
-								className="curved-right-only"
-							>
-								<FontAwesomeIcon icon={faLink} />
-							</Button>
-						</a>
-					)}
-				</InputGroup>
-				{error && (
-					<small id={name + '-error'} className="error-msg" role="alert">
-						{error['message'] || 'err'}
-					</small>
-				)}
-			</FormGroup>
-		</Col>
+		<FormTextWithButton
+			name={name}
+			required={required}
+			col_sm={col_sm}
+			label={config.label}
+			type="text"
+			isURL={config.isURL}
+			validationFunc={config.validationFunc}
+			positionXS={positionXS}
+			buttonIcon={faLink}
+			buttonAriaLabel={config.buttonAriaLabel}
+			buttonHref={config.getLink}
+			{...props}
+		/>
 	);
 };
 


### PR DESCRIPTION
fix(ui): improve deployed_version manual type input handling

- Add missing react-hook-form registration for version input
- Safely handle undefined service status in monitorData (new service)

Creating a new service and giving it a `manual` deployed_version caused an 'Uncaught TypeError'

---
feat(ui): add links to icon_url/web_url and visible lv/dv links on focus

- Create `FormTextWithButton` component for text fields with buttons
- Use this component for lv/dv `url` fields to keep links visible on focus
- Use this component to `icon_url` and `web_url` fields in dashboard