### PR TITLE
feat(latest_version): add pagination to GitHub release fetching

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "standard-version": "^9.5.0"
   },
   "dependencies": {
-    "@commitlint/cli": "^19.8.0",
-    "@commitlint/config-conventional": "^19.8.0"
+    "@commitlint/cli": "^19.8.1",
+    "@commitlint/config-conventional": "^19.8.1"
   }
 }

--- a/service/deployed_version/refresh.go
+++ b/service/deployed_version/refresh.go
@@ -83,7 +83,7 @@ func Refresh(
 	// Query the lookup.
 	err := newLookup.Query(!usingOverrides, logFrom)
 	if err != nil {
-		return "", err //nolint: wrapcheck
+		return "", err //nolint:wrapcheck
 	}
 
 	return newLookup.GetStatus().DeployedVersion(), nil

--- a/service/deployed_version/types/web/query.go
+++ b/service/deployed_version/types/web/query.go
@@ -80,7 +80,7 @@ func (l *Lookup) query(writeToDB bool, logFrom logutil.LogFrom) error {
 
 	// Set the deployed version if it has changed.
 	if previousVersion := l.Status.DeployedVersion(); version != previousVersion {
-		l.HandleNewVersion(version, "", writeToDB, logFrom) //nolint: wrapcheck
+		l.HandleNewVersion(version, "", writeToDB, logFrom) //nolint:wrapcheck
 	}
 
 	return nil
@@ -149,7 +149,7 @@ func (l *Lookup) httpRequest(logFrom logutil.LogFrom) ([]byte, error) {
 	// Return the body.
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 10<<20)) // Limit to 10 MB.
 	logutil.Log.Error(err, logFrom, err != nil)
-	return body, err //nolint: wrapcheck
+	return body, err //nolint:wrapcheck
 }
 
 // getVersion returns the latest version from `body` that matches the URLCommands, and Regex requirements.

--- a/service/latest_version/refresh.go
+++ b/service/latest_version/refresh.go
@@ -76,7 +76,7 @@ func Refresh(
 	// Query the lookup.
 	_, err := newLookup.Query(!usingOverrides, logFrom)
 	if err != nil {
-		return "", false, err //nolint: wrapcheck
+		return "", false, err //nolint:wrapcheck
 	}
 
 	version := newLookup.GetStatus().LatestVersion()

--- a/service/latest_version/types/github/gets.go
+++ b/service/latest_version/types/github/gets.go
@@ -31,7 +31,7 @@ func (l *Lookup) accessToken() string {
 }
 
 // url will return a GitHub API URL for the repository.
-func (l *Lookup) url() string {
+func (l *Lookup) url(page int) string {
 	url := util.EvalEnvVars(l.URL)
 	// Convert "owner/repo" to the API path.
 	if strings.Count(url, "/") == 1 {
@@ -41,7 +41,20 @@ func (l *Lookup) url() string {
 		}
 		url = fmt.Sprintf("https://api.github.com/repos/%s/%s",
 			url, apiTarget)
+
+		// Query params
+		params := make([]string, 0, 2)
+		if page > 1 {
+			params = append(params, fmt.Sprintf("page=%d", page))
+		}
+		if perPage := l.data.PerPage(); perPage != 0 {
+			params = append(params, fmt.Sprintf("per_page=%d", perPage))
+		}
+		if len(params) > 0 {
+			url += "?" + strings.Join(params, "&")
+		}
 	}
+
 	return url
 }
 

--- a/service/latest_version/types/github/gets_test.go
+++ b/service/latest_version/types/github/gets_test.go
@@ -73,6 +73,8 @@ func TestURL(t *testing.T) {
 	tests := map[string]struct {
 		url         string
 		tagFallback bool
+		page        int
+		perPage     int
 		want        string
 	}{
 		"Repo": {
@@ -88,6 +90,40 @@ func TestURL(t *testing.T) {
 			url:  "https://api.github.com/repos/release-argus/Argus",
 			want: "https://api.github.com/repos/release-argus/Argus",
 		},
+		"Repo with page 1": {
+			url:  "release-argus/Argus",
+			page: 1,
+			want: "https://api.github.com/repos/release-argus/Argus/releases",
+		},
+		"Repo with page >1": {
+			url:  "release-argus/Argus",
+			page: 2,
+			want: "https://api.github.com/repos/release-argus/Argus/releases?page=2",
+		},
+		"Repo with per_page": {
+			url:     "release-argus/Argus",
+			perPage: 2,
+			want:    fmt.Sprintf("https://api.github.com/repos/release-argus/Argus/releases?per_page=%d", 2*defaultPerPage),
+		},
+		"Repo with page >1 and per_page": {
+			url:     "release-argus/Argus",
+			page:    2,
+			perPage: 4,
+			want:    fmt.Sprintf("https://api.github.com/repos/release-argus/Argus/releases?page=2&per_page=%d", 4*defaultPerPage),
+		},
+		"Repo with tag fallback and page >1": {
+			url:         "release-argus/Argus",
+			tagFallback: true,
+			page:        3,
+			want:        "https://api.github.com/repos/release-argus/Argus/tags?page=3",
+		},
+		"Repo with tag fallback, page >1, and per_page": {
+			url:         "release-argus/Argus",
+			tagFallback: true,
+			page:        3,
+			perPage:     7,
+			want:        fmt.Sprintf("https://api.github.com/repos/release-argus/Argus/tags?page=3&per_page=%d", 7*defaultPerPage),
+		},
 	}
 
 	for name, tc := range tests {
@@ -99,9 +135,10 @@ func TestURL(t *testing.T) {
 			if tc.tagFallback {
 				lookup.GetGitHubData().SetTagFallback()
 			}
+			lookup.data.SetPerPage(tc.perPage)
 
-			// WHEN url is called.
-			got := lookup.url()
+			// WHEN url is called with the page argument.
+			got := lookup.url(tc.page)
 
 			// THEN the expected value is returned.
 			if got != tc.want {

--- a/service/latest_version/types/github/githubdata_test.go
+++ b/service/latest_version/types/github/githubdata_test.go
@@ -18,6 +18,7 @@
 package github
 
 import (
+	"math/rand"
 	"os"
 	"sync"
 	"testing"
@@ -256,6 +257,33 @@ func TestData_ETag(t *testing.T) {
 	if got != want {
 		t.Errorf("%s\nwant: %q\ngot:  %q",
 			packageName, want, got)
+	}
+}
+
+func TestData_PerPage(t *testing.T) {
+	for range 10 {
+		// GIVEN a Data instance.
+		data := &Data{}
+
+		// WHEN SetPerPage is called with a new value.
+		foundOnPage := rand.Intn(10) + 1
+		data.SetPerPage(foundOnPage)
+
+		// THEN the PerPage field is updated correctly.
+		want := foundOnPage * defaultPerPage
+		if got := data.PerPage(); got != want {
+			t.Errorf("%s\nfailed to update PerPage\nwant: %d\ngot:  %d",
+				packageName, want, got)
+		}
+
+		// WHEN ResetPerPage is called.
+		data.ResetPerPage()
+
+		// THEN the PerPage field is reset to 0.
+		if got := data.PerPage(); got != 0 {
+			t.Errorf("%s\nfailed to reset PerPage\nwant: %d\ngot:  %d",
+				packageName, 0, got)
+		}
 	}
 }
 

--- a/service/latest_version/types/web/query.go
+++ b/service/latest_version/types/web/query.go
@@ -63,11 +63,11 @@ func (l *Lookup) query(logFrom logutil.LogFrom) (bool, error) {
 		// Verify Semantic Versioning (if enabled).
 		if l.Options.GetSemanticVersioning() {
 			if err := l.VerifySemanticVersioning(version, previousVersion, logFrom); err != nil {
-				return false, err //nolint: wrapcheck
+				return false, err //nolint:wrapcheck
 			}
 		}
 
-		return l.HandleNewVersion(version, "", logFrom) //nolint: wrapcheck
+		return l.HandleNewVersion(version, "", logFrom) //nolint:wrapcheck
 	}
 
 	// Announce `LastQueried`.
@@ -116,7 +116,7 @@ func (l *Lookup) httpRequest(logFrom logutil.LogFrom) ([]byte, error) {
 	defer resp.Body.Close()
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 10<<20)) // Limit to 10 MB.
 	logutil.Log.Error(err, logFrom, err != nil)
-	return body, err //nolint: wrapcheck
+	return body, err //nolint:wrapcheck
 }
 
 // getVersion returns the latest version from `body` that matches the URLCommands, and Regex requirements.
@@ -152,17 +152,17 @@ func (l *Lookup) versionMeetsRequirements(version, body string, logFrom logutil.
 	// Check all `Require` filters for this version.
 	// Version RegEx.
 	if err := l.Require.RegexCheckVersion(version, logFrom); err != nil {
-		return err //nolint: wrapcheck
+		return err //nolint:wrapcheck
 	}
 
 	// Content RegEx (on response body).
 	if err := l.Require.RegexCheckContent(version, body, logFrom); err != nil {
-		return err //nolint: wrapcheck
+		return err //nolint:wrapcheck
 	}
 
 	// If the Command didn't return successfully.
 	if err := l.Require.ExecCommand(logFrom); err != nil {
-		return err //nolint: wrapcheck
+		return err //nolint:wrapcheck
 	}
 
 	// If the Docker tag doesn't exist.

--- a/web/ui/package-lock.json
+++ b/web/ui/package-lock.json
@@ -1408,9 +1408,9 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.74.9",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.74.9.tgz",
-      "integrity": "sha512-qmjXpWyigDw4SfqdSBy24FzRvpBPXlaSbl92N77lcrL+yvVQLQkf0T6bQNbTxl9IEB/SvVFhhVZoIlQvFnNuuw==",
+      "version": "5.75.7",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.75.7.tgz",
+      "integrity": "sha512-4BHu0qnxUHOSnTn3ow9fIoBKTelh0GY08yn1IO9cxjBTsGvnxz1ut42CHZqUE3Vl/8FAjcHsj8RNJMoXvjgHEA==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -1429,12 +1429,12 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.74.11",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.74.11.tgz",
-      "integrity": "sha512-FFhn9ZiYRUOsxLAWZYxVfQTpVE7UWRaAeHJIWVDHKlmZZGc16rMHW9KrFZ8peC4hA71QUf/shJD8dPSMqDnRmA==",
+      "version": "5.75.7",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.75.7.tgz",
+      "integrity": "sha512-JYcH1g5pNjKXNQcvvnCU/PueaYg05uKBDHlWIyApspv7r5C0BM12n6ysa2QF2T+1tlPnNXOob8vr8o96Nx0GxQ==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.74.9"
+        "@tanstack/query-core": "5.75.7"
       },
       "funding": {
         "type": "github",
@@ -1445,9 +1445,9 @@
       }
     },
     "node_modules/@tanstack/react-query-devtools": {
-      "version": "5.74.11",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.74.11.tgz",
-      "integrity": "sha512-vx8MzH4WUUk4ZW8uHq7T45XNDgePF5ecRoa7haWJZxDMQyAHM80GGMhEW/yRz6TeyS9UlfTUz2OLPvgGRvvVOA==",
+      "version": "5.75.7",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.75.7.tgz",
+      "integrity": "sha512-VUzHvxcUAz7oSeX/TlVyDgNxajLAF+b12Z3OfSxCrAdWynELfWohwzCn1iT2NEjnGTb3X3ryzQxeWuWMyMwCmQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1458,7 +1458,7 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
-        "@tanstack/react-query": "^5.74.11",
+        "@tanstack/react-query": "^5.75.7",
         "react": "^18 || ^19"
       }
     },
@@ -1520,9 +1520,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.15.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.3.tgz",
-      "integrity": "sha512-lX7HFZeHf4QG/J7tBZqrCAXwz9J5RD56Y6MpP0eJkka8p+K0RY/yBTW7CYFJ4VGCclxqOLKmiGP5juQc6MKgcw==",
+      "version": "22.15.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.17.tgz",
+      "integrity": "sha512-wIX2aSZL5FE+MR0JlvF87BNVrtFWf6AE6rxSE9X7OwnVvoyCQjpzSRJ+M87se/4QCkCiebQAqrJ0y6fwIyi7nw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1542,9 +1542,9 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "19.1.2",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.2.tgz",
-      "integrity": "sha512-oxLPMytKchWGbnQM9O7D67uPa9paTNxO7jVoNMXgkkErULBPhPARCfkKL9ytcIJJRGjbsVwW4ugJzyFFvm/Tiw==",
+      "version": "19.1.3",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.3.tgz",
+      "integrity": "sha512-dLWQ+Z0CkIvK1J8+wrDPwGxEYFA4RAyHoZPxHVGspYmFVnwGSNT24cGIhFJrtfRnWVuW8X7NO52gCXmhkVUWGQ==",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -1628,9 +1628,9 @@
       }
     },
     "node_modules/bootstrap": {
-      "version": "5.3.5",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.5.tgz",
-      "integrity": "sha512-ct1CHKtiobRimyGzmsSldEtM03E8fcEX4Tb3dGXz1V8faRwM50+vfHwTzOxB3IlKO7m+9vTH3s/3C6T2EAPeTA==",
+      "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.6.tgz",
+      "integrity": "sha512-jX0GAcRzvdwISuvArXn3m7KZscWWFAf1MKBcnzaN02qWMb3jpMoUX4/qgeiGzqyIb4ojulRzs89UCUmGcFSzTA==",
       "funding": [
         {
           "type": "github",
@@ -1697,9 +1697,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001716",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001716.tgz",
-      "integrity": "sha512-49/c1+x3Kwz7ZIWt+4DvK3aMJy9oYXXG6/97JKsnjdCk/6n9vVyWL8NAwVt95Lwt9eigI10Hl782kDfZUUlRXw==",
+      "version": "1.0.30001717",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001717.tgz",
+      "integrity": "sha512-auPpttCq6BDEG8ZAuHJIplGw6GODhjw+/11e7IjpnYCxZcW/ONgPs0KVBJ0d1bY3e2+7PRe5RCLyP+PfwVgkYw==",
       "dev": true,
       "funding": [
         {
@@ -2300,9 +2300,9 @@
       }
     },
     "node_modules/react-hook-form": {
-      "version": "7.56.1",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.56.1.tgz",
-      "integrity": "sha512-qWAVokhSpshhcEuQDSANHx3jiAEFzu2HAaaQIzi/r9FNPm1ioAvuJSD4EuZzWd7Al7nTRKcKPnBKO7sRn+zavQ==",
+      "version": "7.56.3",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.56.3.tgz",
+      "integrity": "sha512-IK18V6GVbab4TAo1/cz3kqajxbDPGofdF0w7VHdCo0Nt8PrPlOZcuuDq9YYIV1BtjcX78x0XsldbQRQnQXWXmw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -2335,14 +2335,13 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.5.3.tgz",
-      "integrity": "sha512-3iUDM4/fZCQ89SXlDa+Ph3MevBrozBAI655OAfWQlTm9nBR0IKlrmNwFow5lPHttbwvITZfkeeeZFP6zt3F7pw==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.6.0.tgz",
+      "integrity": "sha512-GGufuHIVCJDbnIAXP3P9Sxzq3UUsddG3rrI3ut1q6m0FI6vxVBF3JoPQ38+W/blslLH4a5Yutp8drkEpXoddGQ==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0",
-        "turbo-stream": "2.4.0"
+        "set-cookie-parser": "^2.6.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -2358,12 +2357,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.5.3.tgz",
-      "integrity": "sha512-cK0jSaTyW4jV9SRKAItMIQfWZ/D6WEZafgHuuCb9g+SjhLolY78qc+De4w/Cz9ybjvLzShAmaIMEXt8iF1Cm+A==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.6.0.tgz",
+      "integrity": "sha512-DYgm6RDEuKdopSyGOWZGtDfSm7Aofb8CCzgkliTjtu/eDuB0gcsv6qdFhhi8HdtmA+KHkt5MfZ5K2PdzjugYsA==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.5.3"
+        "react-router": "7.6.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -2638,12 +2637,6 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
-    "node_modules/turbo-stream": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.4.0.tgz",
-      "integrity": "sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==",
-      "license": "ISC"
-    },
     "node_modules/typescript": {
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
@@ -2725,9 +2718,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.3.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.4.tgz",
-      "integrity": "sha512-BiReIiMS2fyFqbqNT/Qqt4CVITDU9M9vE+DKcVAsB+ZV0wvTKd+3hMbkpxz1b+NmEDMegpVbisKiAZOnvO92Sw==",
+      "version": "6.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
+      "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2855,27 +2848,27 @@
         "@fortawesome/free-brands-svg-icons": "^6.7.2",
         "@fortawesome/free-solid-svg-icons": "^6.7.2",
         "@fortawesome/react-fontawesome": "^0.2.2",
-        "@tanstack/react-query": "^5.74.11",
-        "bootstrap": "^5.3.5",
+        "@tanstack/react-query": "^5.75.7",
+        "bootstrap": "^5.3.6",
         "date-fns": "^4.1.0",
         "react": "^19.1.0",
         "react-bootstrap": "^2.10.9",
         "react-dom": "^19.1.0",
-        "react-hook-form": "^7.56.1",
-        "react-router-dom": "^7.5.3",
+        "react-hook-form": "^7.56.3",
+        "react-router-dom": "^7.6.0",
         "react-select": "^5.10.1",
         "reconnecting-websocket": "^4.4.0",
         "yaml": "^2.7.1"
       },
       "devDependencies": {
-        "@tanstack/react-query-devtools": "^5.74.11",
+        "@tanstack/react-query-devtools": "^5.75.7",
         "@types/bootstrap": "^5.2.10",
-        "@types/node": "^22.15.3",
-        "@types/react": "^19.1.2",
+        "@types/node": "^22.15.17",
+        "@types/react": "^19.1.3",
         "@types/react-dom": "^19.1.3",
         "@vitejs/plugin-react": "^4.4.1",
         "typescript": "^5.8.3",
-        "vite": "^6.3.4",
+        "vite": "^6.3.5",
         "vite-tsconfig-paths": "^5.1.4"
       }
     },

--- a/web/ui/react-app/package.json
+++ b/web/ui/react-app/package.json
@@ -12,14 +12,14 @@
     "@fortawesome/free-brands-svg-icons": "^6.7.2",
     "@fortawesome/free-solid-svg-icons": "^6.7.2",
     "@fortawesome/react-fontawesome": "^0.2.2",
-    "@tanstack/react-query": "^5.74.11",
-    "bootstrap": "^5.3.5",
+    "@tanstack/react-query": "^5.75.7",
+    "bootstrap": "^5.3.6",
     "date-fns": "^4.1.0",
     "react": "^19.1.0",
     "react-bootstrap": "^2.10.9",
     "react-dom": "^19.1.0",
-    "react-hook-form": "^7.56.1",
-    "react-router-dom": "^7.5.3",
+    "react-hook-form": "^7.56.3",
+    "react-router-dom": "^7.6.0",
     "react-select": "^5.10.1",
     "reconnecting-websocket": "^4.4.0",
     "yaml": "^2.7.1"
@@ -49,14 +49,14 @@
     ]
   },
   "devDependencies": {
-    "@tanstack/react-query-devtools": "^5.74.11",
+    "@tanstack/react-query-devtools": "^5.75.7",
     "@types/bootstrap": "^5.2.10",
-    "@types/node": "^22.15.3",
-    "@types/react": "^19.1.2",
+    "@types/node": "^22.15.17",
+    "@types/react": "^19.1.3",
     "@types/react-dom": "^19.1.3",
     "@vitejs/plugin-react": "^4.4.1",
     "typescript": "^5.8.3",
-    "vite": "^6.3.4",
+    "vite": "^6.3.5",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/web/ui/react-app/src/components/modals/service-edit/version-with-refresh.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/version-with-refresh.tsx
@@ -47,7 +47,7 @@ const VersionWithRefresh: FC<Props> = ({
 }) => {
 	const [lastFetched, setLastFetched] = useState(0);
 	const { monitorData } = useWebSocket();
-	const { setError, setValue, trigger } = useFormContext();
+	const { clearErrors, setError, setValue, trigger } = useFormContext();
 	const dataTarget = vType === 0 ? 'latest_version' : 'deployed_version';
 	const convertedOriginal = useMemo(() => {
 		if (original === null) return {};
@@ -123,6 +123,7 @@ const VersionWithRefresh: FC<Props> = ({
 	useEffect(() => {
 		if (versionData.version !== '') {
 			setValue(`${dataTarget}.version`, versionData.version);
+			clearErrors(`${dataTarget}.version`)
 		}
 	}, [versionData.version, dataTarget]);
 

--- a/web/ui/react-app/src/components/modals/service-edit/version-with-refresh.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/version-with-refresh.tsx
@@ -73,6 +73,15 @@ const VersionWithRefresh: FC<Props> = ({
 	const { data: semanticVersioning, refetchData: refetchSemanticVersioning } =
 		useValuesRefetch<boolean>('options.semantic_versioning');
 
+	const queryParams = useMemo(
+		() => ({
+			params: removeEmptyValues(data ?? {}),
+			semantic_versioning: semanticVersioning,
+			original_data: removeEmptyValues(original ?? []),
+		}),
+		[data, semanticVersioning, original]
+	);
+
 	const {
 		data: versionData,
 		isFetching,
@@ -82,11 +91,7 @@ const VersionWithRefresh: FC<Props> = ({
 			'version/refresh',
 			dataTarget,
 			{ id: serviceID },
-			{
-				params: removeEmptyValues(data ?? {}),
-				semantic_versioning: semanticVersioning,
-				original_data: removeEmptyValues(original ?? []),
-			},
+			queryParams,
 		],
 		queryFn: () =>
 			fetchVersionJSON({

--- a/web/ui/react-app/src/utils/remove-empty-values.tsx
+++ b/web/ui/react-app/src/utils/remove-empty-values.tsx
@@ -9,9 +9,17 @@ import { isEmptyArray, isEmptyObject } from './is-empty';
 
 import isEmptyOrNull from './is-empty-or-null';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const removeEmptyValues = (obj: { [x: string]: any }) => {
+const removeEmptyValues = (
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	obj: { [x: string]: any },
+	excludeKeys: string[] = [],
+) => {
 	for (const key in obj) {
+		if (excludeKeys.find((k) => k === key)) {
+			delete obj[key];
+			continue
+		}
+
 		// [] Array.
 		if (Array.isArray(obj[key])) {
 			// Empty array - remove.
@@ -21,8 +29,11 @@ const removeEmptyValues = (obj: { [x: string]: any }) => {
 			typeof obj[key] === 'object' &&
 			!['notify', 'webhook'].includes(key) // Not notify/webhook as they may be empty to reference globals.
 		) {
+			const childExcludeKeys = excludeKeys
+				.filter((k) => k.startsWith(`${key}.`))
+				.map((k) => k.substring(key.length + 1));
 			// Check object.
-			removeEmptyValues(obj[key]);
+			removeEmptyValues(obj[key], childExcludeKeys);
 			// Empty object - remove.
 			if (isEmptyObject(obj[key])) {
 				delete obj[key];
@@ -30,7 +41,7 @@ const removeEmptyValues = (obj: { [x: string]: any }) => {
 			// "" Empty/undefined string - remove.
 		} else if (isEmptyOrNull(obj[key])) delete obj[key];
 	}
-	return obj;
+	return JSON.parse(JSON.stringify(obj));
 };
 
 export default removeEmptyValues;


### PR DESCRIPTION
feat(latest_version): add pagination to GitHub release fetching - fixes #570 
- Enables fetching older releases, such as stable versions that appear on
later pages due to newer pre-releases being listed first.

fix(version-refresh): omit version from query keys
- Including the version in the query keys caused the initial refresh to be
skipped as the key changed after the version was fetched. Omitting the
version ensures the key remains consistent after the fetch.

fix(version-refresh): clear version errors after fetch