### PR TITLE
fix(ui): show error on first version refresh failure

### DIFF
--- a/service/init.go
+++ b/service/init.go
@@ -57,6 +57,14 @@ func (s *Service) Init(
 	rootWebHookConfig *webhook.SliceDefaults,
 	webhookDefaults, webhookHardDefaults *webhook.Defaults,
 ) {
+	// Service.
+	s.Defaults = defaults
+	s.HardDefaults = hardDefaults
+	// Default Name to ID.
+	if s.Name == "" {
+		s.Name = s.ID
+	}
+
 	// Status.
 	var serviceURL string
 	if s.LatestVersion != nil {
@@ -66,10 +74,6 @@ func (s *Service) Init(
 		len(s.Notify), len(s.Command), len(s.WebHook),
 		s.ID, s.Name, serviceURL,
 		&s.Dashboard)
-
-	// Service.
-	s.Defaults = defaults
-	s.HardDefaults = hardDefaults
 
 	// Dashboard.
 	s.Dashboard.Defaults = &s.Defaults.Dashboard

--- a/service/types.go
+++ b/service/types.go
@@ -87,10 +87,6 @@ func (s *Slice) giveIDs() {
 		}
 
 		service.ID = id
-		// Default Name to ID.
-		if service.Name == "" {
-			service.Name = id
-		}
 	}
 }
 

--- a/service/types_test.go
+++ b/service/types_test.go
@@ -423,10 +423,6 @@ func TestSlice_giveIDs(t *testing.T) {
 					t.Errorf("%s\nservice %q, ID mismatch\nwant: %q\ngot:  %q",
 						packageName, id, service.ID, got.ID)
 				}
-				if got.Name != service.Name {
-					t.Errorf("%s\nservice %q, Name mismatch\nwant: %q\ngot:  %q",
-						packageName, id, got.Name, service.Name)
-				}
 			}
 		})
 	}

--- a/web/ui/react-app/src/hooks/errors.tsx
+++ b/web/ui/react-app/src/hooks/errors.tsx
@@ -2,12 +2,13 @@ import { FieldError, useFormState } from 'react-hook-form';
 import { extractErrors, getNestedError } from 'utils';
 
 import { StringStringMap } from 'types/config';
+import { useMemo } from 'react';
 
 /**
  * Tracks an error of a field in a form.
  *
- * @param name - The name of the field in the form.
- * @param wanted - Whether the error is returned.
+ * @param name - Form field name.
+ * @param wanted - Whether to return the error.
  * @returns The error of the field.
  */
 export const useError = (
@@ -15,22 +16,26 @@ export const useError = (
 	wanted?: boolean,
 ): FieldError | undefined => {
 	const { errors } = useFormState({ name: name, exact: true });
-	if (!wanted) return undefined;
-	return getNestedError(errors, name);
+	return wanted ? getNestedError(errors, name) : undefined
 };
 
 /**
  * Tracks all errors under a field in a form.
  *
- * @param name - The name of the field in the form.
- * @param wanted - Whether the errors are returned.
+ * @param name - Form field name.
+ * @param wanted - Whether to return the error.
  * @returns The errors under the field.
  */
 export const useErrors = (
 	name: string,
 	wanted?: boolean,
 ): StringStringMap | undefined => {
-	const { errors } = useFormState({ name: name, exact: true });
-	if (!wanted) return undefined;
-	return extractErrors(errors, name);
+	const { errors } = useFormState({ name: name });
+
+	const extracted = useMemo(() => {
+		if (!wanted) return undefined;
+		return extractErrors(errors, name);
+	}, [JSON.stringify(errors), name, wanted]);
+
+	return extracted;
 };


### PR DESCRIPTION
Version refreshes were having issues with `useQuery` query keys and so the error wasn't showing on the first fetch. This move to `useMutation` removes query keys shows the errors on the first fetch and makes more sense for the role of the component.

Also noticed in #573 that `service_name` was not being defaulted to `service_id` after creating/editing a service in the web ui.