### PR TITLE
feat(latest-version): url, sort versions when semantic_versioning enabled

### DIFF
--- a/service/deployed_version/types/manual/query.go
+++ b/service/deployed_version/types/manual/query.go
@@ -28,12 +28,12 @@ func (l *Lookup) Track() {
 }
 
 // Query queries the source
-// and returns whether a new release was found and updates LatestVersion if so.
+// and returns whether a new release was found, updating LatestVersion if so.
 //
 // Parameters:
 //
-//	_metrics: ignored
-func (l *Lookup) Query(_metrics bool, logFrom logutil.LogFrom) error {
+//	metrics: ignored
+func (l *Lookup) Query(metrics bool, logFrom logutil.LogFrom) error {
 	l.mutex.Lock()
 	defer l.mutex.Unlock()
 

--- a/service/deployed_version/types/web/query.go
+++ b/service/deployed_version/types/web/query.go
@@ -48,8 +48,8 @@ func (l *Lookup) Track() {
 	}
 }
 
-// Query queries the source,
-// and returns whether a new release was found, and updates LatestVersion if so.
+// Query queries the source
+// and returns whether a new release was found, updating LatestVersion if so.
 //
 // Parameters:
 //
@@ -64,8 +64,8 @@ func (l *Lookup) Query(metrics bool, logFrom logutil.LogFrom) error {
 	return err
 }
 
-// Query queries the source,
-// and returns whether a new release was found, and updates LatestVersion if so.
+// Query queries the source
+// and returns whether a new release was found, updating LatestVersion if so.
 func (l *Lookup) query(writeToDB bool, logFrom logutil.LogFrom) error {
 	body, err := l.httpRequest(logFrom)
 	if err != nil {

--- a/service/latest_version/types/github/api_type/types.go
+++ b/service/latest_version/types/github/api_type/types.go
@@ -41,6 +41,11 @@ func (r *Release) String() string {
 	return util.ToJSONString(r)
 }
 
+// ReleaseSort sorts releases by SemanticVersion in descending order.
+func ReleaseSort(a, b Release) bool {
+	return a.SemanticVersion.LessThan(b.SemanticVersion)
+}
+
 // Asset is the format of an Asset on api.github.com/repos/OWNER/REPO/releases.
 type Asset struct {
 	URL                string `json:"url,omitempty"`

--- a/service/latest_version/types/github/github.go
+++ b/service/latest_version/types/github/github.go
@@ -18,37 +18,13 @@ package github
 import (
 	"encoding/json"
 	"fmt"
-	"sort"
 
 	"github.com/Masterminds/semver/v3"
 
 	github_types "github.com/release-argus/Argus/service/latest_version/types/github/api_type"
+	"github.com/release-argus/Argus/service/shared"
 	logutil "github.com/release-argus/Argus/util/log"
 )
-
-// insertionSort performs an 'insertion sort' of the given `release` into the `filteredReleases` slice.
-// This operation assumes that semantic versioning is enabled, and sorts the releases accordingly.
-func insertionSort(release github_types.Release, filteredReleases *[]github_types.Release) {
-	n := len(*filteredReleases)
-	// find the insertion point.
-	i := sort.Search(n, func(index int) bool {
-		return (*filteredReleases)[index].SemanticVersion.LessThan(release.SemanticVersion)
-	})
-
-	// append an empty release to the end of the slice.
-	*filteredReleases = append(*filteredReleases, github_types.Release{})
-
-	// insert the release at the insertion point.
-	if i < n {
-		// shift elements to the right to make room for this release.
-		copy((*filteredReleases)[i+1:], (*filteredReleases)[i:])
-		// overwrite the element at the insertion point.
-		(*filteredReleases)[i] = release
-	} else {
-		// append the release to the end of the slice.
-		(*filteredReleases)[n] = release
-	}
-}
 
 // filterGitHubReleases filters releases based on the following:
 //   - URLCommands.
@@ -104,7 +80,7 @@ func (l *Lookup) filterGitHubReleases(logFrom logutil.LogFrom) []github_types.Re
 			continue
 		}
 		// else, insertion sort the release.
-		insertionSort(release, &filteredReleases)
+		filteredReleases = shared.InsertionSort(filteredReleases, release, github_types.ReleaseSort)
 	}
 	return filteredReleases
 }

--- a/service/latest_version/types/github/github_test.go
+++ b/service/latest_version/types/github/github_test.go
@@ -22,59 +22,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/Masterminds/semver/v3"
-
 	"github.com/release-argus/Argus/service/latest_version/filter"
 	github_types "github.com/release-argus/Argus/service/latest_version/types/github/api_type"
 	"github.com/release-argus/Argus/test"
 	"github.com/release-argus/Argus/util"
 	logutil "github.com/release-argus/Argus/util/log"
 )
-
-func TestInsertionSort(t *testing.T) {
-	// GIVEN a list of releases and a release to add.
-	tests := map[string]struct {
-		release  string
-		expectAt int
-	}{
-		"newer release": {
-			release: "1.0.0", expectAt: 0},
-		"middle release": {
-			release: "0.2.0", expectAt: 2},
-		"oldest release": {
-			release: "0.0.0", expectAt: 5},
-	}
-
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-
-			releases := []github_types.Release{
-				{TagName: "0.99.0"},
-				{TagName: "0.3.0"},
-				{TagName: "0.1.0"},
-				{TagName: "0.0.1"},
-				{TagName: "0.0.0"},
-			}
-			for i := range releases {
-				semVer, _ := semver.NewVersion(releases[i].TagName)
-				releases[i].SemanticVersion = semVer
-			}
-
-			// WHEN insertionSort is called with a release.
-			release := github_types.Release{TagName: tc.release}
-			semVer, _ := semver.NewVersion(release.TagName)
-			release.SemanticVersion = semVer
-			insertionSort(release, &releases)
-
-			// THEN it can be found at the expected index.
-			if releases[tc.expectAt].TagName != release.TagName {
-				t.Errorf("%s\nwant: %v to be inserted at index %d\ngot:  %v",
-					packageName, release, tc.expectAt, release)
-			}
-		})
-	}
-}
 
 func TestLookup_FilterGitHubReleases(t *testing.T) {
 	// GIVEN a bunch of releases.

--- a/service/latest_version/types/github/query.go
+++ b/service/latest_version/types/github/query.go
@@ -33,7 +33,7 @@ import (
 )
 
 // Query queries the source
-// and returns whether a new release was found and updates LatestVersion if so.
+// and returns whether a new release was found, updating LatestVersion if so.
 //
 // Parameters:
 //   - metrics: if true, set Prometheus metrics based on the query.
@@ -48,7 +48,7 @@ func (l *Lookup) Query(metrics bool, logFrom logutil.LogFrom) (bool, error) {
 }
 
 // Query queries the source
-// and returns whether a new release was found and updates LatestVersion if so.
+// and returns whether a new release was found, updating LatestVersion if so.
 func (l *Lookup) query(logFrom logutil.LogFrom) (bool, error) {
 	page := 1
 	var newVersion bool

--- a/service/shared/help_test.go
+++ b/service/shared/help_test.go
@@ -1,0 +1,17 @@
+// Copyright [2025] [Argus]
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shared
+
+var packageName = "service_shared"

--- a/service/shared/insertion-sort.go
+++ b/service/shared/insertion-sort.go
@@ -1,0 +1,35 @@
+// Copyright [2025] [Argus]
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shared
+
+import "sort"
+
+// InsertionSort performs an 'insertion sort' of item into items.
+// It inserts an item into a sorted slice, maintaining the order as determined by the less function.
+func InsertionSort[T any](items []T, item T, less func(a, b T) bool) []T {
+	// Find insertion index.
+	i := sort.Search(len(items), func(idx int) bool {
+		return less(items[idx], item)
+	})
+
+	// Grow slice.
+	items = append(items, *new(T))
+	// Shift right.
+	copy(items[i+1:], items[i:])
+	// Insert.
+	items[i] = item
+
+	return items
+}

--- a/service/shared/insertion-sort_test.go
+++ b/service/shared/insertion-sort_test.go
@@ -1,0 +1,196 @@
+// Copyright [2025] [Argus]
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shared
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestInsertionSort_int(t *testing.T) {
+	tests := map[string]struct {
+		name     string
+		items    []int
+		item     int
+		less     func(a, b int) bool
+		expected []int
+	}{
+		"Insert int into empty slice": {
+			items:    []int{},
+			item:     5,
+			less:     func(a, b int) bool { return a < b },
+			expected: []int{5},
+		},
+		"Insert at beginning": {
+			items:    []int{3, 2, 1},
+			item:     5,
+			less:     func(a, b int) bool { return a < b },
+			expected: []int{5, 3, 2, 1},
+		},
+		"Insert at end": {
+			items:    []int{8, 6, 4},
+			item:     2,
+			less:     func(a, b int) bool { return a < b },
+			expected: []int{8, 6, 4, 2},
+		},
+		"Insert in the middle": {
+			items:    []int{8, 6, 4},
+			item:     5,
+			less:     func(a, b int) bool { return a < b },
+			expected: []int{8, 6, 5, 4},
+		},
+		"Insert duplicate value": {
+			items:    []int{8, 6, 4},
+			item:     6,
+			less:     func(a, b int) bool { return a < b },
+			expected: []int{8, 6, 6, 4},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			// WHEN InsertionSort is called.
+			result := InsertionSort(tc.items, tc.item, tc.less)
+
+			// THEN the result is as expected.
+			if !reflect.DeepEqual(result, tc.expected) {
+				t.Errorf("%s\nwant: %v\ngot:  %v",
+					packageName, result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestInsertionSort_String(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		items    []string
+		item     string
+		less     func(a, b string) bool
+		expected []string
+	}
+
+	tests := map[string]testCase{
+		"Insert string into empty slice": {
+			items:    []string{},
+			item:     "banana",
+			less:     func(a, b string) bool { return a < b },
+			expected: []string{"banana"},
+		},
+		"Insert at beginning (desc order)": {
+			items:    []string{"c", "b", "a"},
+			item:     "d",
+			less:     func(a, b string) bool { return a < b },
+			expected: []string{"d", "c", "b", "a"},
+		},
+		"Insert in the middle": {
+			items:    []string{"z", "m", "a"},
+			item:     "h",
+			less:     func(a, b string) bool { return a < b },
+			expected: []string{"z", "m", "h", "a"},
+		},
+		"Insert at end": {
+			items:    []string{"z", "y", "x"},
+			item:     "w",
+			less:     func(a, b string) bool { return a < b },
+			expected: []string{"z", "y", "x", "w"},
+		},
+		"Insert duplicate": {
+			items:    []string{"c", "b"},
+			item:     "b",
+			less:     func(a, b string) bool { return a < b },
+			expected: []string{"c", "b", "b"},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			// WHEN InsertionSort is called.
+			result := InsertionSort(tc.items, tc.item, tc.less)
+
+			// THEN the result is as expected.
+			if !reflect.DeepEqual(result, tc.expected) {
+				t.Errorf("%s\nwant: %v\ngot:  %v",
+					packageName, tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestInsertionSort_Struct(t *testing.T) {
+	type person struct {
+		name string
+		age  int
+	}
+
+	lessByAge := func(a, b person) bool { return a.age < b.age }
+
+	// GIVEN a slice of persons and a person to insert.
+	tests := map[string]struct {
+		items    []person
+		item     person
+		expected []person
+	}{
+		"Insert person into empty slice": {
+			items:    []person{},
+			item:     person{name: "Bob", age: 30},
+			expected: []person{{name: "Bob", age: 30}},
+		},
+		"Insert at beginning": {
+			items: []person{{"Ann", 40}, {"Bill", 35}, {"Cara", 20}},
+			item:  person{"Zed", 50},
+			expected: []person{
+				{"Zed", 50}, {"Ann", 40}, {"Bill", 35}, {"Cara", 20},
+			},
+		},
+		"Insert in the middle": {
+			items: []person{{"Ann", 40}, {"Bill", 35}, {"Cara", 20}},
+			item:  person{"Dom", 33},
+			expected: []person{
+				{"Ann", 40}, {"Bill", 35}, {"Dom", 33}, {"Cara", 20},
+			},
+		},
+		"Insert at end": {
+			items:    []person{{"Ann", 40}, {"Bill", 35}},
+			item:     person{"Eve", 10},
+			expected: []person{{"Ann", 40}, {"Bill", 35}, {"Eve", 10}},
+		},
+		"Insert duplicate age": {
+			items:    []person{{"Ann", 40}, {"Bill", 35}},
+			item:     person{"Ben", 35},
+			expected: []person{{"Ann", 40}, {"Bill", 35}, {"Ben", 35}},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			// WHEN InsertionSort is called.
+			result := InsertionSort(tc.items, tc.item, lessByAge)
+
+			// THEN the result is as expected.
+			if !reflect.DeepEqual(result, tc.expected) {
+				t.Errorf("%s\nwant: %v\ngot:  %v",
+					packageName, tc.expected, result)
+			}
+		})
+	}
+}

--- a/service/track_test.go
+++ b/service/track_test.go
@@ -159,7 +159,7 @@ func TestService_Track(t *testing.T) {
 				latestVersion: test.TrimYAML(`
 					url_commands:
 						- type: regex
-							regex: '([0-9.]+)'
+							regex: '"([0-9.]+)"'
 					require: null
 				`),
 			},
@@ -177,7 +177,7 @@ func TestService_Track(t *testing.T) {
 					allow_invalid_certs: true
 					url_commands:
 						- type: regex
-							regex: '([0-9.]+)'
+							regex: '"([0-9.]+)"'
 					require: null
 				`),
 			},
@@ -196,7 +196,7 @@ func TestService_Track(t *testing.T) {
 					allow_invalid_certs: false
 					url_commands:
 						- type: regex
-							regex: '([0-9.]+)'
+							regex: '"([0-9.]+)"'
 					require: null
 				`),
 			},

--- a/util/map_string_string_test.go
+++ b/util/map_string_string_test.go
@@ -102,28 +102,28 @@ func TestMapStringStringOmitNull_UnmarshalJSON(t *testing.T) {
 			errRegex: `^$`,
 		},
 		"single kv": {
-			input:    test.TrimJSON(`{
+			input: test.TrimJSON(`{
 				"foo":"bar"
 			}`),
 			expected: MapStringStringOmitNull{"foo": "bar"},
 			errRegex: `^$`,
 		},
 		"null value omitted": {
-			input:    test.TrimJSON(`{
+			input: test.TrimJSON(`{
 				"a":null
 			}`),
 			expected: MapStringStringOmitNull{},
 			errRegex: `^$`,
 		},
 		"empty string value kept": {
-			input:    test.TrimJSON(`{
+			input: test.TrimJSON(`{
 				"a":""
 			}`),
 			expected: MapStringStringOmitNull{"a": ""},
 			errRegex: `^$`,
 		},
 		"invalid JSON (array)": {
-			input:    test.TrimJSON(`
+			input: test.TrimJSON(`
 				[]`),
 			errRegex: `json: cannot unmarshal .* into Go value of type map\[string\]\*string`,
 		},


### PR DESCRIPTION
GitHub `latest_version`'s already perform an insertion sort when semantic_versioning is enabled. This adds sorting to `latest_version` 'url' types with semantic_versioning.

- The first version looked at for the 'require' options will be the largest version (when semantic_versioning enabled)