### PR TITLE
feat(cli): add environment variable hints to '-h' help output

### DIFF
--- a/cmd/argus/main.go
+++ b/cmd/argus/main.go
@@ -32,11 +32,26 @@ import (
 )
 
 var (
-	configFile       = flag.String("config.file", "config.yml", "Argus configuration file path.")
-	configCheckFlag  = flag.Bool("config.check", false, "Print the fully-parsed config.")
-	testCommandsFlag = flag.String("test.commands", "", "Put the name of the Service to test the `commands` of.")
-	testNotifyFlag   = flag.String("test.notify", "", "Put the name of the Notify service to send a test message.")
-	testServiceFlag  = flag.String("test.service", "", "Put the name of the Service to test the version query.")
+	configFile = flag.String(
+		"config.file",
+		"config.yml",
+		"Argus configuration file path.")
+	configCheckFlag = flag.Bool(
+		"config.check",
+		false,
+		"Print the fully-parsed config.")
+	testCommandsFlag = flag.String(
+		"test.commands",
+		"",
+		"Put the name of the Service to test the `commands` of.")
+	testNotifyFlag = flag.String(
+		"test.notify",
+		"",
+		"Put the name of the Notify service to send a test message.")
+	testServiceFlag = flag.String(
+		"test.service",
+		"",
+		"Put the name of the Service to test the version query.")
 )
 
 // main loads the config and then calls `service.Track` to monitor

--- a/config/settings.go
+++ b/config/settings.go
@@ -29,16 +29,46 @@ import (
 
 // Export the flags.
 var (
-	LogLevel             = flag.String("log.level", "INFO", "ERROR, WARN, INFO, VERBOSE or DEBUG")
-	LogTimestamps        = flag.Bool("log.timestamps", false, "Enable timestamps in CLI output.")
-	DataDatabaseFile     = flag.String("data.database-file", "data/argus.db", "Database file path.")
-	WebListenHost        = flag.String("web.listen-host", "0.0.0.0", "IP address to listen on for UI, API, and telemetry.")
-	WebListenPort        = flag.String("web.listen-port", "8080", "Port to listen on for UI, API, and telemetry.")
-	WebCertFile          = flag.String("web.cert-file", "", "HTTPS certificate file path.")
-	WebPKeyFile          = flag.String("web.pkey-file", "", "HTTPS private key file path.")
-	WebRoutePrefix       = flag.String("web.route-prefix", "/", "Prefix for web endpoints")
-	WebBasicAuthUsername = flag.String("web.basic-auth.username", "", "Username for basic auth")
-	WebBasicAuthPassword = flag.String("web.basic-auth.password", "", "Password for basic auth")
+	LogLevel = flag.String(
+		"log.level",
+		"INFO",
+		"ERROR, WARN, INFO, VERBOSE or DEBUG. (env_var=ARGUS_LOG_LEVEL)")
+	LogTimestamps = flag.Bool(
+		"log.timestamps",
+		false,
+		"Enable timestamps in CLI output. (env_var=ARGUS_LOG_TIMESTAMPS)")
+	DataDatabaseFile = flag.String(
+		"data.database-file",
+		"data/argus.db",
+		"Database file path. (env_var=ARGUS_DATA_DATABASE_FILE)")
+	WebListenHost = flag.String(
+		"web.listen-host",
+		"0.0.0.0",
+		"IP address to listen on for UI, API, and telemetry. (env_var=ARGUS_WEB_LISTEN_HOST)")
+	WebListenPort = flag.String(
+		"web.listen-port",
+		"8080",
+		"Port to listen on for UI, API, and telemetry. (env_var=ARGUS_WEB_LISTEN_PORT)")
+	WebCertFile = flag.String(
+		"web.cert-file",
+		"",
+		"HTTPS certificate file path. (env_var=ARGUS_WEB_CERT_FILE)")
+	WebPKeyFile = flag.String(
+		"web.pkey-file",
+		"",
+		"HTTPS private key file path. (env_var=ARGUS_WEB_PKEY_FILE)")
+	WebRoutePrefix = flag.String(
+		"web.route-prefix",
+		"/",
+		"Prefix for web endpoints. (env_var=ARGUS_WEB_ROUTE_PREFIX)")
+	WebBasicAuthUsername = flag.String(
+		"web.basic-auth.username",
+		"",
+		"Username for basic auth. (env_var=ARGUS_WEB_BASIC_AUTH_USERNAME)")
+	WebBasicAuthPassword = flag.String(
+		"web.basic-auth.password",
+		"",
+		"Password for basic auth. (env_var=ARGUS_WEB_BASIC_AUTH_PASSWORD)")
 )
 
 // Settings for the binary.


### PR DESCRIPTION
Add the environment variables relating to each command line argment.
```sh
./argus -h
Usage of ./argus:
  -config.check
    	Print the fully-parsed config.
  -config.file string
    	Argus configuration file path. (env_var=ARGUS_CONFIG_FILE) (default "config.yml")
  -data.database-file string
    	Database file path. (env_var=ARGUS_DATA_DATABASE_FILE) (default "data/argus.db")
  -log.level string
    	ERROR, WARN, INFO, VERBOSE or DEBUG. (env_var=ARGUS_LOG_LEVEL) (default "INFO")
  -log.timestamps
    	Enable timestamps in CLI output. (env_var=ARGUS_LOG_TIMESTAMPS)
  -test.commands commands
    	Put the name of the Service to test the commands of.
  -test.notify string
    	Put the name of the Notify service to send a test message.
  -test.service string
    	Put the name of the Service to test the version query.
  -web.basic-auth.password string
    	Password for basic auth. (env_var=ARGUS_WEB_BASIC_AUTH_PASSWORD)
  -web.basic-auth.username string
    	Username for basic auth. (env_var=ARGUS_WEB_BASIC_AUTH_USERNAME)
  -web.cert-file string
    	HTTPS certificate file path. (env_var=ARGUS_WEB_CERT_FILE)
  -web.listen-host string
    	IP address to listen on for UI, API, and telemetry. (env_var=ARGUS_WEB_LISTEN_HOST) (default "0.0.0.0")
  -web.listen-port string
    	Port to listen on for UI, API, and telemetry. (env_var=ARGUS_WEB_LISTEN_PORT) (default "8080")
  -web.pkey-file string
    	HTTPS private key file path. (env_var=ARGUS_WEB_PKEY_FILE)
  -web.route-prefix string
    	Prefix for web endpoints. (env_var=ARGUS_WEB_ROUTE_PREFIX) (default "/")
```
fixes #631 