### PR TITLE
fix(latest-version,deployed-version,webhook): respect proxy env vars in requests

### DIFF
--- a/_healthcheck/main.go
+++ b/_healthcheck/main.go
@@ -1,12 +1,26 @@
+// Copyright [2025] [Argus]
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*
 ./healthcheck http://localhost:8080/api/v1/healthcheck
+
 	200   == nothing
 	error == os.Exit(1)
 */
 package main
 
 import (
-	"crypto/tls"
 	"fmt"
 	"net/http"
 	"os"
@@ -20,7 +34,7 @@ func main() {
 	url := os.Args[1]
 
 	//#nosec G402 -- Ignore TLS for healthcheck.
-	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	http.DefaultTransport.(*http.Transport).TLSClientConfig.InsecureSkipVerify = true
 	//#nosec G107 -- explicitly set URL.
 	if _, err := http.Get(url); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v", err)

--- a/service/deployed_version/types/web/query.go
+++ b/service/deployed_version/types/web/query.go
@@ -16,7 +16,6 @@
 package web
 
 import (
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
@@ -86,12 +85,11 @@ func (l *Lookup) query(writeToDB bool, logFrom logutil.LogFrom) error {
 
 // httpRequest makes a HTTP GET request to the URL, and returns the body.
 func (l *Lookup) httpRequest(logFrom logutil.LogFrom) ([]byte, error) {
-	customTransport := &http.Transport{}
+	customTransport := http.DefaultTransport.(*http.Transport).Clone()
 	// HTTPS insecure skip verify.
 	if l.allowInvalidCerts() {
-		customTransport = http.DefaultTransport.(*http.Transport).Clone()
 		//#nosec G402 -- explicitly wanted InsecureSkipVerify
-		customTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+		customTransport.TLSClientConfig.InsecureSkipVerify = true
 	}
 
 	// Create the request.

--- a/service/latest_version/types/web/query.go
+++ b/service/latest_version/types/web/query.go
@@ -16,7 +16,6 @@
 package web
 
 import (
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
@@ -81,12 +80,11 @@ func (l *Lookup) query(logFrom logutil.LogFrom) (bool, error) {
 
 // httpRequest makes a HTTP GET request to the URL and returns the body.
 func (l *Lookup) httpRequest(logFrom logutil.LogFrom) ([]byte, error) {
-	customTransport := &http.Transport{}
+	customTransport := http.DefaultTransport.(*http.Transport).Clone()
 	// HTTPS insecure skip verify.
 	if l.allowInvalidCerts() {
-		customTransport = http.DefaultTransport.(*http.Transport).Clone()
 		//#nosec G402 -- explicitly wanted InsecureSkipVerify
-		customTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+		customTransport.TLSClientConfig.InsecureSkipVerify = true
 	}
 
 	// Create the request.

--- a/webhook/send.go
+++ b/webhook/send.go
@@ -17,7 +17,6 @@ package webhook
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
@@ -124,11 +123,10 @@ func (wh *WebHook) try(logFrom logutil.LogFrom) error {
 	defer cancel()
 
 	// HTTPS insecure skip verify.
-	customTransport := &http.Transport{}
+	customTransport := http.DefaultTransport.(*http.Transport).Clone()
 	if wh.GetAllowInvalidCerts() {
-		customTransport = http.DefaultTransport.(*http.Transport).Clone()
 		//#nosec G402 -- explicitly wanted InsecureSkipVerify.
-		customTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+		customTransport.TLSClientConfig.InsecureSkipVerify = true
 	}
 
 	client := &http.Client{Transport: customTransport}


### PR DESCRIPTION
Clone the default transport, ensuring proxy environment variables are respected (`HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY`)