### PR TITLE
feat(templating): add support for 'tags' array

### DIFF
--- a/service/status/help_test.go
+++ b/service/status/help_test.go
@@ -48,7 +48,8 @@ func testStatus() (status *Status) {
 		&dashboard.Options{
 			Icon:       "https://example.com/icon.png",
 			IconLinkTo: "https://example.com/icon-link",
-			WebURL:     "https://example.com"})
+			WebURL:     "https://example.com",
+			Tags:       []string{"foo", "bar"}})
 
 	status.SetApprovedVersion("1.1.1", false)
 	status.SetLatestVersion("2.2.2", "2002-02-02T02:02:02Z", false)

--- a/service/status/info/info.go
+++ b/service/status/info/info.go
@@ -19,7 +19,7 @@ import "sync"
 
 // ServiceInfo holds information about a service.
 type ServiceInfo struct {
-	mutex *sync.RWMutex `json:"-"` // Mutex for thread-safe access
+	mutex *sync.RWMutex // Mutex for thread-safe access
 
 	ID   string `json:"id,omitempty"`   // Service ID
 	Name string `json:"name,omitempty"` // Service name
@@ -32,6 +32,8 @@ type ServiceInfo struct {
 	ApprovedVersion string `json:"approved_version,omitempty"` // The version of the Service that has been approved for deployment.
 	DeployedVersion string `json:"deployed_version,omitempty"` // The version of the Service that is deployed.
 	LatestVersion   string `json:"latest_version,omitempty"`   // The latest version of the Service found from query().
+
+	Tags []string `json:"tags,omitempty"` // Tags for the Service.
 }
 
 // SetMutex sets the mutex pointer for thread-safe access.

--- a/service/status/status.go
+++ b/service/status/status.go
@@ -248,6 +248,7 @@ func (s *Status) Init(
 	s.ServiceInfo.ID = serviceID
 	s.ServiceInfo.Name = serviceName
 	s.ServiceInfo.URL = serviceURL
+	s.ServiceInfo.Tags = dashboard.Tags
 
 	s.Dashboard = dashboard
 	s.ServiceInfo.SetMutex(&s.mutex)

--- a/service/status/status_test.go
+++ b/service/status/status_test.go
@@ -51,11 +51,12 @@ func TestStatus_Unmarshal(t *testing.T) {
 
 			// WHEN UnmarshalX is called on the Status.
 			var status Status
-			if tc.format == "YAML" {
+			switch tc.format {
+			case "YAML":
 				var node yaml.Node
-				status.UnmarshalYAML(&node)
-			} else if tc.format == "JSON" {
-				status.UnmarshalJSON([]byte(""))
+				_ = status.UnmarshalYAML(&node)
+			case "JSON":
+				_ = status.UnmarshalJSON([]byte(""))
 			}
 
 			// THEN the mutex is correctly handed to the ServiceInfo.
@@ -189,6 +190,8 @@ func TestService_ServiceInfo(t *testing.T) {
 	status.Dashboard.IconLinkTo = iconLinkTo
 	webURL := "https://example.com/web"
 	status.Dashboard.WebURL = webURL
+	tags := []string{"tag1", "tag2"}
+	status.ServiceInfo.Tags = tags
 
 	approvedVersion := "approved.version"
 	status.SetApprovedVersion(approvedVersion, false)
@@ -210,6 +213,7 @@ func TestService_ServiceInfo(t *testing.T) {
 		Icon:       icon,
 		IconLinkTo: iconLinkTo,
 		WebURL:     webURL,
+		Tags:       tags,
 
 		DeployedVersion: deployedVersion,
 		ApprovedVersion: approvedVersion,

--- a/util/help_test.go
+++ b/util/help_test.go
@@ -16,7 +16,9 @@
 
 package util
 
-import serviceinfo "github.com/release-argus/Argus/service/status/info"
+import (
+	serviceinfo "github.com/release-argus/Argus/service/status/info"
+)
 
 var packageName = "util"
 
@@ -33,5 +35,6 @@ func testServiceInfo() serviceinfo.ServiceInfo {
 		ApprovedVersion: "APPROVED",
 		DeployedVersion: "DEPLOYED",
 		LatestVersion:   "NEW",
+		Tags:            []string{"tag1", "tag2"},
 	}
 }

--- a/util/template.go
+++ b/util/template.go
@@ -50,10 +50,11 @@ func TemplateString(template string, context serviceinfo.ServiceInfo) string {
 		"icon":             context.Icon,
 		"icon_link_to":     context.IconLinkTo,
 		"web_url":          context.WebURL,
-		"version":          context.LatestVersion,
 		"approved_version": context.ApprovedVersion,
 		"deployed_version": context.DeployedVersion,
+		"version":          context.LatestVersion,
 		"latest_version":   context.LatestVersion,
+		"tags":             context.Tags,
 	})
 	if err != nil {
 		panic(err)

--- a/util/template_test.go
+++ b/util/template_test.go
@@ -69,16 +69,29 @@ func TestTemplate_String(t *testing.T) {
 				WebURL:        svcInfo.WebURL,
 				LatestVersion: svcInfo.LatestVersion},
 		},
+		"valid django template with array access": {
+			template: "{{ tags | first }}-{{ tags.0 }}_{{ tags|slice:'1:2'|first }}-{{ tags | last }}-{{ tags.1 }}_{{ tags | join:',' }}",
+			want: fmt.Sprintf("%s-%s_%s-%s-%s_%s,%s",
+				svcInfo.Tags[0], svcInfo.Tags[0],
+				svcInfo.Tags[1], svcInfo.Tags[1], svcInfo.Tags[1],
+				svcInfo.Tags[0], svcInfo.Tags[1]),
+			serviceInfo: svcInfo},
+		"valid django template with array access out of bounds": {
+			template: "{{ tags.0 }}-{{ tags.1 }}-{{ tags.2 }}-{{ tags.3 }}",
+			want: fmt.Sprintf("%s-%s--",
+				svcInfo.Tags[0], svcInfo.Tags[1]),
+			serviceInfo: svcInfo},
 		"invalid django template panic": {
 			template:    "-{% 'a' == 'a' %}{{ service_id }}{% endif %}-{{ service_url }}-{{ web_url }}-{{ version }}",
 			panicRegex:  test.StringPtr("Tag name must be an identifier"),
 			serviceInfo: svcInfo},
 		"all django vars": {
-			template: "{{ service_id }}-{{ service_name }}-{{ service_url }}--{{ icon }}-{{ icon_link_to }}-{{ web_url }}--{{ version }}-{{ approved_version }}-{{ deployed_version }}-{{ latest_version }}",
-			want: fmt.Sprintf("%s-%s-%s--%s-%s-%s--%s-%s-%s-%s",
+			template: "{{ service_id }}-{{ service_name }}-{{ service_url }}--{{ icon }}-{{ icon_link_to }}-{{ web_url }}--{{ version }}-{{ approved_version }}-{{ deployed_version }}-{{ latest_version }}-{{ tags|first }}-{{ tags.1 }}",
+			want: fmt.Sprintf("%s-%s-%s--%s-%s-%s--%s-%s-%s-%s-%s-%s",
 				svcInfo.ID, svcInfo.Name, svcInfo.URL,
 				svcInfo.Icon, svcInfo.IconLinkTo, svcInfo.WebURL,
-				svcInfo.LatestVersion, svcInfo.ApprovedVersion, svcInfo.DeployedVersion, svcInfo.LatestVersion),
+				svcInfo.LatestVersion, svcInfo.ApprovedVersion, svcInfo.DeployedVersion, svcInfo.LatestVersion,
+				svcInfo.Tags[0], svcInfo.Tags[1]),
 			serviceInfo: svcInfo},
 	}
 

--- a/util/util.go
+++ b/util/util.go
@@ -64,18 +64,18 @@ func ValueOrValue[T comparable](first T, second T) T {
 	return second
 }
 
-// DereferenceOrDefault returns the value of `check` if not nil,
+// DereferenceOrDefault returns the value of `ptr` if not nil,
 // otherwise default for the type.
-func DereferenceOrDefault[T comparable](check *T) T {
-	if check == nil {
+func DereferenceOrDefault[T any](ptr *T) T {
+	if ptr == nil {
 		return *new(T)
 	}
-	return *check
+	return *ptr
 }
 
 // DereferenceOrValue returns the value of 'ptr' if non-nil,
 // otherwise the 'fallback'.
-func DereferenceOrValue[T comparable](ptr *T, fallback T) T {
+func DereferenceOrValue[T any](ptr *T, fallback T) T {
 	if ptr != nil {
 		return *ptr
 	}
@@ -83,7 +83,7 @@ func DereferenceOrValue[T comparable](ptr *T, fallback T) T {
 }
 
 // CopyPointer returns a pointer to a copy of the value of `ptr`.
-func CopyPointer[T comparable](ptr *T) *T {
+func CopyPointer[T any](ptr *T) *T {
 	if ptr == nil {
 		return nil
 	}


### PR DESCRIPTION
e.g.
tags: ['alpha', 'bravo']

| template                              | result       |
|---------------------------------------|--------------|
| `{{ tags \| first }}`                 | alpha        |
| `{{ tags.0 }}`                        | alpha        |
| `{{ tags \| slice:'1:2' \| first }}`  | bravo        |
| `{{ tags \| last }}`                  | bravo        |
| `{{ tags.1 }}`                        | bravo        |
| `{{ tags \| join:',' }}`              | alpha,bravo  |
| `{{ tags.2 }}`                        |              |
