### PR TITLE
fix(ui): support notify.<type> with no explicit type field

### DIFF
--- a/web/ui/react-app/src/utils/api/types/config-edit/notify/form/builder.ts
+++ b/web/ui/react-app/src/utils/api/types/config-edit/notify/form/builder.ts
@@ -389,7 +389,10 @@ export const buildNotifySchemaWithFallbacks = (
 	const schemaDataMains = Object.entries(mains ?? {}).reduce<
 		Record<string, NotifySchemaValues>
 	>((acc, [key, value]) => {
-		const itemType = value.type;
+		const nameLower = key.toLowerCase();
+		const itemType =
+			value?.type ?? (isNotifyType(nameLower) ? nameLower : null);
+		if (itemType === null) return acc; // Skip unsupported types.
 		const data = applyDefaultsRecursive(value, combinedDefaults[itemType]);
 
 		acc[key] = safeParse({


### PR DESCRIPTION
Zod wasn't recognising
notify.matrix as type matrix
```yaml
notify:
    matrix:
        url_fields:
            ...
```
was requiring
```yaml
notify:
    matrix:
        type: matrix
        url_fields:
            ...
```

This makes it fallback to name if type isn't explicitly provided (and checks that name is of a supported type)