### PR TITLE
feat(notify): slack, add threadts support

### DIFF
--- a/web/ui/react-app/src/components/modals/service-edit/notify-types/slack.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/notify-types/slack.tsx
@@ -82,7 +82,17 @@ const SLACK = ({ name, main }: { name: string; main?: NotifySlackSchema }) => {
 					}}
 				/>
 				<FieldText
-					colSize={{ sm: 12 }}
+					defaultVal={defaults?.params?.threadts}
+					label="Thread TS"
+					name={`${name}.params.threadts`}
+					tooltip={{
+						content:
+							'TS value of the parent message (to send message as reply in thread)',
+						type: 'string',
+					}}
+					type="text"
+				/>
+				<FieldText
 					defaultVal={defaults?.params?.title}
 					label="Title"
 					name={`${name}.params.title`}

--- a/web/ui/react-app/src/utils/api/types/config-edit/notify/schemas.ts
+++ b/web/ui/react-app/src/utils/api/types/config-edit/notify/schemas.ts
@@ -521,9 +521,10 @@ export const notifySlackSchema = notifyBaseSchema.extend({
 			botname: z.string().default(''),
 			color: z.string().default(''),
 			icon: z.string().default(''),
+			threadts: z.string().default(''),
 			title: z.string().default(''),
 		})
-		.default({ botname: '', color: '', icon: '', title: '' }),
+		.default({ botname: '', color: '', icon: '', threadts: '', title: '' }),
 	type: z.literal(NOTIFY_TYPE_MAP.SLACK.value),
 	url_fields: z
 		.object({


### PR DESCRIPTION
Add support for `slack.param.threadts`
- TS value of the parent message (to send message as reply in thread)