### PR TITLE
fix(ui): carry old data to renamed service and replace order array

### DIFF
--- a/web/ui/react-app/src/lib/query-keys.ts
+++ b/web/ui/react-app/src/lib/query-keys.ts
@@ -20,7 +20,7 @@ export const QUERY_KEYS = {
 			...QUERY_KEYS.SERVICE.BASE(serviceID),
 			'actions',
 		],
-		BASE: (serviceID: string) => ['service', { service: serviceID }],
+		BASE: (serviceID: string) => ['service', serviceID],
 		EDIT_DEFAULTS: () => ['service', 'edit', 'defaults'],
 		EDIT_ITEM: (serviceID: string) => [
 			...QUERY_KEYS.SERVICE.BASE(serviceID),
@@ -29,7 +29,7 @@ export const QUERY_KEYS = {
 		ORDER: () => ['service', 'order'],
 		SUMMARY_ITEM: (serviceID: string) => [
 			...QUERY_KEYS.SERVICE.SUMMARY_ITEM_BASE,
-			{ service: serviceID },
+			serviceID,
 		],
 		SUMMARY_ITEM_BASE: ['service', 'summary'],
 	},

--- a/web/ui/react-app/src/modals/action-release.tsx
+++ b/web/ui/react-app/src/modals/action-release.tsx
@@ -316,6 +316,7 @@ const ActionReleaseModal = () => {
 		queryFn: () => mapRequest('ACTION_GET', { serviceID: modal.service.id }),
 		queryKey: QUERY_KEYS.SERVICE.ACTIONS(modal.service.id),
 		refetchOnMount: 'always',
+		refetchOnWindowFocus: false,
 		staleTime: 0,
 	});
 


### PR DESCRIPTION
- Move cached service data when renaming a service.
- Replace ORDER array reference to trigger useEffect reloads.