### PR TITLE
refactor(go): stop using pointers to channels

### DIFF
--- a/command/announce_test.go
+++ b/command/announce_test.go
@@ -76,7 +76,7 @@ func TestController_AnnounceCommand(t *testing.T) {
 				test.StringPtr("11m"))
 			if !tc.nilChannel {
 				announceChannel := make(chan []byte, 4)
-				controller.ServiceStatus.AnnounceChannel = &announceChannel
+				controller.ServiceStatus.AnnounceChannel = announceChannel
 			}
 			if tc.failed != nil {
 				controller.Failed.Set(tc.index, *tc.failed)
@@ -90,7 +90,7 @@ func TestController_AnnounceCommand(t *testing.T) {
 			if controller.ServiceStatus.AnnounceChannel == nil {
 				return
 			}
-			m := <-*controller.ServiceStatus.AnnounceChannel
+			m := <-controller.ServiceStatus.AnnounceChannel
 			var parsed apitype.WebSocketMessage
 			json.Unmarshal(m, &parsed)
 

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -114,10 +114,10 @@ func TestCommand_Exec(t *testing.T) {
 
 func TestController_ExecIndex(t *testing.T) {
 	// GIVEN a Controller with different Commands to execute.
-	announce := make(chan []byte, 8)
+	announceChannel := make(chan []byte, 8)
 	controller := Controller{}
 	svcStatus := status.New(
-		&announce, nil, nil,
+		announceChannel, nil, nil,
 		"",
 		"", "",
 		"", "",
@@ -179,9 +179,9 @@ func TestController_ExecIndex(t *testing.T) {
 			if !tc.noAnnounce {
 				runNumber++
 			}
-			if len(announce) != runNumber {
+			if len(announceChannel) != runNumber {
 				t.Fatalf("%s\nCommand run not announced\nwant: %d\ngot:  %d",
-					packageName, runNumber, len(announce))
+					packageName, runNumber, len(announceChannel))
 			}
 		})
 	}
@@ -220,8 +220,8 @@ func TestController_Exec(t *testing.T) {
 			// t.Parallel() - Cannot run in parallel since we're using stdout.
 			releaseStdout := test.CaptureStdout()
 
-			announce := make(chan []byte, 8)
-			controller := testController(&announce)
+			announceChannel := make(chan []byte, 8)
+			controller := testController(announceChannel)
 
 			// WHEN the Command @index is executed.
 			controller.Command = tc.commands
@@ -247,9 +247,9 @@ func TestController_Exec(t *testing.T) {
 			if !tc.noAnnounce {
 				runNumber = len(*controller.Command)
 			}
-			if len(announce) != runNumber {
+			if len(announceChannel) != runNumber {
 				t.Fatalf("%s\nCommand run not announced\nwant: %d\ngot:  %d",
-					packageName, runNumber, len(announce))
+					packageName, runNumber, len(announceChannel))
 			}
 		})
 	}

--- a/command/help_test.go
+++ b/command/help_test.go
@@ -39,10 +39,10 @@ func TestMain(m *testing.M) {
 	os.Exit(exitCode)
 }
 
-func testController(announce *chan []byte) (control *Controller) {
+func testController(announceChannel chan []byte) (control *Controller) {
 	control = &Controller{}
 	svcStatus := status.New(
-		announce, nil, nil,
+		announceChannel, nil, nil,
 		"",
 		"", "",
 		"", "",

--- a/config/edit.go
+++ b/config/edit.go
@@ -74,12 +74,12 @@ func (c *Config) AddService(oldServiceID string, newService *service.Service) er
 
 	// Trigger a save if the Service has changed.
 	if changedService {
-		*c.HardDefaults.Service.Status.SaveChannel <- true
+		c.HardDefaults.Service.Status.SaveChannel <- true
 	}
 
 	// Update the database if the service is new, or the versions changed.
 	if changedDB {
-		*c.HardDefaults.Service.Status.DatabaseChannel <- dbtype.Message{
+		c.HardDefaults.Service.Status.DatabaseChannel <- dbtype.Message{
 			ServiceID: newService.ID,
 			Cells: []dbtype.Cell{
 				{Column: "latest_version", Value: newService.Status.LatestVersion()},
@@ -129,7 +129,7 @@ func (c *Config) RenameService(oldService string, newService *service.Service) {
 	c.Order = util.ReplaceElement(c.Order, oldService, newService.ID)
 	c.Service[newService.ID] = newService
 	// Rename the primary key for this service in the database.
-	*c.HardDefaults.Service.Status.DatabaseChannel <- dbtype.Message{
+	c.HardDefaults.Service.Status.DatabaseChannel <- dbtype.Message{
 		ServiceID: oldService,
 		Cells: []dbtype.Cell{
 			{Column: "id", Value: newService.ID}}}
@@ -162,5 +162,5 @@ func (c *Config) DeleteService(serviceID string) {
 	delete(c.Service, serviceID)
 
 	// Trigger save.
-	*c.HardDefaults.Service.Status.SaveChannel <- true
+	c.HardDefaults.Service.Status.SaveChannel <- true
 }

--- a/config/edit_test.go
+++ b/config/edit_test.go
@@ -118,11 +118,11 @@ func TestConfig_AddService(t *testing.T) {
 					packageName, tc.wantOrder, cfg.Order)
 			}
 			// AND the DatabaseChannel should have a message waiting if the service was added.
-			if len(*cfg.HardDefaults.Service.Status.DatabaseChannel) != tc.dbMessages {
+			if len(cfg.HardDefaults.Service.Status.DatabaseChannel) != tc.dbMessages {
 				t.Errorf("%s\nDatabaseChannel mismatch\nwant: %d messages\ngot:  %d",
-					packageName, tc.dbMessages, len(*cfg.HardDefaults.Service.Status.DatabaseChannel))
-				for i := 0; i <= len(*cfg.HardDefaults.Service.Status.DatabaseChannel); i++ {
-					msg := <-*cfg.HardDefaults.Service.Status.DatabaseChannel
+					packageName, tc.dbMessages, len(cfg.HardDefaults.Service.Status.DatabaseChannel))
+				for i := 0; i <= len(cfg.HardDefaults.Service.Status.DatabaseChannel); i++ {
+					msg := <-cfg.HardDefaults.Service.Status.DatabaseChannel
 					t.Log(msg)
 				}
 			}
@@ -285,11 +285,11 @@ func TestConfig_RenameService(t *testing.T) {
 			if !tc.fail {
 				want = 1
 			}
-			if len(*cfg.HardDefaults.Service.Status.DatabaseChannel) != want {
+			if len(cfg.HardDefaults.Service.Status.DatabaseChannel) != want {
 				t.Errorf("%s\nDatabaseChannel mismatch\nwant: %d messages\ngot:  %d",
-					packageName, want, len(*cfg.HardDefaults.Service.Status.DatabaseChannel))
-				for i := 0; i <= len(*cfg.HardDefaults.Service.Status.DatabaseChannel); i++ {
-					msg := <-*cfg.HardDefaults.Service.Status.DatabaseChannel
+					packageName, want, len(cfg.HardDefaults.Service.Status.DatabaseChannel))
+				for i := 0; i <= len(cfg.HardDefaults.Service.Status.DatabaseChannel); i++ {
+					msg := <-cfg.HardDefaults.Service.Status.DatabaseChannel
 					t.Log(msg)
 				}
 			}
@@ -347,11 +347,11 @@ func TestConfig_DeleteService(t *testing.T) {
 			if tc.dbMessage {
 				want = 1
 			}
-			if len(*cfg.HardDefaults.Service.Status.DatabaseChannel) != want {
+			if len(cfg.HardDefaults.Service.Status.DatabaseChannel) != want {
 				t.Errorf("%s\nDatabaseChannel mismatch\nwant: %d messages\ngot:  %d",
-					packageName, want, len(*cfg.HardDefaults.Service.Status.DatabaseChannel))
-				for i := 0; i <= len(*cfg.HardDefaults.Service.Status.DatabaseChannel); i++ {
-					msg := <-*cfg.HardDefaults.Service.Status.DatabaseChannel
+					packageName, want, len(cfg.HardDefaults.Service.Status.DatabaseChannel))
+				for i := 0; i <= len(cfg.HardDefaults.Service.Status.DatabaseChannel); i++ {
+					msg := <-cfg.HardDefaults.Service.Status.DatabaseChannel
 					t.Log(msg)
 				}
 			}

--- a/config/help_test.go
+++ b/config/help_test.go
@@ -58,9 +58,9 @@ func testConfig() Config {
 		HardDefaults: Defaults{
 			Service: service.Defaults{
 				Status: status.NewDefaults(
-					nil, &databaseChannel, &saveChannel)}},
-		DatabaseChannel: &databaseChannel,
-		SaveChannel:     &saveChannel,
+					nil, databaseChannel, saveChannel)}},
+		DatabaseChannel: databaseChannel,
+		SaveChannel:     saveChannel,
 	}
 }
 
@@ -118,11 +118,11 @@ func testLoadBasic(file string, t *testing.T) *Config {
 		logutil.LogFrom{}, err != nil)
 
 	saveChannel := make(chan bool, 32)
-	config.SaveChannel = &saveChannel
+	config.SaveChannel = saveChannel
 	config.HardDefaults.Service.Status.SaveChannel = config.SaveChannel
 
 	databaseChannel := make(chan dbtype.Message, 32)
-	config.DatabaseChannel = &databaseChannel
+	config.DatabaseChannel = databaseChannel
 	config.HardDefaults.Service.Status.DatabaseChannel = config.DatabaseChannel
 
 	config.GetOrder(data)
@@ -188,7 +188,7 @@ func testServiceURL(id string) *service.Service {
 			&dashboard.OptionsDefaults{}, &dashboard.OptionsDefaults{}),
 		Options: *options,
 		Status: *status.New(
-			&announceChannel, &databaseChannel, &saveChannel,
+			announceChannel, databaseChannel, saveChannel,
 			"",
 			"", "",
 			"", "",

--- a/config/init.go
+++ b/config/init.go
@@ -97,10 +97,10 @@ func (c *Config) Load(file string, flagset *map[string]bool) {
 	c.GetOrder(data)
 
 	databaseChannel := make(chan dbtype.Message, 32)
-	c.DatabaseChannel = &databaseChannel
+	c.DatabaseChannel = databaseChannel
 
 	saveChannel := make(chan bool, 32)
-	c.SaveChannel = &saveChannel
+	c.SaveChannel = saveChannel
 
 	for _, svc := range c.Service {
 		svc.Status = *status.New(

--- a/config/test/main.go
+++ b/config/test/main.go
@@ -62,9 +62,9 @@ func BareConfig(nilFlags bool) (cfg *config.Config) {
 
 	// Announce channel.
 	announceChannel := make(chan []byte, 16)
-	cfg.HardDefaults.Service.Status.AnnounceChannel = &announceChannel
+	cfg.HardDefaults.Service.Status.AnnounceChannel = announceChannel
 	// Save channel.
 	saveChannel := make(chan bool, 16)
-	cfg.HardDefaults.Service.Status.SaveChannel = &saveChannel
+	cfg.HardDefaults.Service.Status.SaveChannel = saveChannel
 	return
 }

--- a/config/types.go
+++ b/config/types.go
@@ -37,6 +37,6 @@ type Config struct {
 	Order      []string         `yaml:"-"`                 // Ordered slice of all Service id's.
 	Service    service.Services `yaml:"service,omitempty"` // The services to monitor.
 
-	DatabaseChannel *chan dbtype.Message `yaml:"-"` // Channel for broadcasts to the Database.
-	SaveChannel     *chan bool           `yaml:"-"` // Channel for triggering a save of the config.
+	DatabaseChannel chan dbtype.Message `yaml:"-"` // Channel for broadcasts to the Database.
+	SaveChannel     chan bool           `yaml:"-"` // Channel for triggering a save of the config.
 }

--- a/db/handlers.go
+++ b/db/handlers.go
@@ -27,7 +27,7 @@ import (
 // incoming messages to the DatabaseChannel.
 func (api *api) handler() {
 	defer api.db.Close()
-	for message := range *api.config.DatabaseChannel {
+	for message := range api.config.DatabaseChannel {
 		// If the message is to delete a row.
 		if message.Delete {
 			api.deleteRow(message.ServiceID)

--- a/db/handlers_test.go
+++ b/db/handlers_test.go
@@ -253,7 +253,7 @@ func TestAPI_Handler(t *testing.T) {
 		ServiceID: target,
 		Cells:     []dbtype.Cell{cell2},
 	}
-	*tAPI.config.DatabaseChannel <- msg1
+	tAPI.config.DatabaseChannel <- msg1
 	time.Sleep(250 * time.Millisecond)
 
 	// THEN the cell was changed in the DB.
@@ -266,7 +266,7 @@ func TestAPI_Handler(t *testing.T) {
 	// ------------------------------
 
 	// WHEN a message is sent to the DatabaseChannel deleting a row.
-	*tAPI.config.DatabaseChannel <- dbtype.Message{
+	tAPI.config.DatabaseChannel <- dbtype.Message{
 		ServiceID: target,
 		Delete:    true,
 	}
@@ -283,9 +283,9 @@ func TestAPI_Handler(t *testing.T) {
 	// ------------------------------
 
 	// WHEN multiple messages are targeting the same row in quick succession.
-	*tAPI.config.DatabaseChannel <- msg1
+	tAPI.config.DatabaseChannel <- msg1
 	wantLatestVersion := msg2.Cells[0].Value
-	*tAPI.config.DatabaseChannel <- msg2
+	tAPI.config.DatabaseChannel <- msg2
 	time.Sleep(250 * time.Millisecond)
 
 	// THEN the last message is the one that is applied.

--- a/db/help_test.go
+++ b/db/help_test.go
@@ -82,8 +82,8 @@ func testConfig() (cfg *config.Config) {
 			"keep2",
 			"delete3",
 		},
-		DatabaseChannel: &databaseChannel,
-		SaveChannel:     &saveChannel,
+		DatabaseChannel: databaseChannel,
+		SaveChannel:     saveChannel,
 	}
 
 	// Services.

--- a/db/init_test.go
+++ b/db/init_test.go
@@ -380,7 +380,7 @@ func TestAPI_Run(t *testing.T) {
 	// WHEN a message is send to the DatabaseChannel targeting latest_version.
 	target := "keep0"
 	cell := dbtype.Cell{Column: "latest_version", Value: "9.9.9"}
-	*cfg.DatabaseChannel <- dbtype.Message{
+	cfg.DatabaseChannel <- dbtype.Message{
 		ServiceID: target,
 		Cells:     []dbtype.Cell{cell},
 	}
@@ -446,7 +446,7 @@ func TestAPI_extractServiceStatus(t *testing.T) {
 			rand.Intn(10), rand.Intn(10), rand.Intn(10)),
 			false)
 
-		*tAPI.config.DatabaseChannel <- dbtype.Message{
+		tAPI.config.DatabaseChannel <- dbtype.Message{
 			ServiceID: id,
 			Cells: []dbtype.Cell{
 				{Column: "id", Value: id},

--- a/service/delete.go
+++ b/service/delete.go
@@ -30,7 +30,7 @@ func (s *Service) PrepDelete(removeFromDB bool) {
 
 	// Delete the row for this service in the database.
 	if removeFromDB {
-		*s.HardDefaults.Status.DatabaseChannel <- dbtype.Message{
+		s.HardDefaults.Status.DatabaseChannel <- dbtype.Message{
 			ServiceID: s.ID,
 			Delete:    true}
 	}

--- a/service/deployed_version/help_test.go
+++ b/service/deployed_version/help_test.go
@@ -61,7 +61,7 @@ func testLookup(lookupType string, failing bool) Lookup {
 	saveChannel := make(chan bool, 5)
 	databaseChannel := make(chan dbtype.Message, 5)
 	svcStatus := status.New(
-		&announceChannel, &databaseChannel, &saveChannel,
+		announceChannel, databaseChannel, saveChannel,
 		"",
 		"", "",
 		"", "",

--- a/service/deployed_version/refresh_test.go
+++ b/service/deployed_version/refresh_test.go
@@ -193,7 +193,7 @@ func TestRefresh(t *testing.T) {
 				}
 			}
 			// AND announce is only true when expected.
-			gotAnnounces := len(*targetStatus.AnnounceChannel)
+			gotAnnounces := len(targetStatus.AnnounceChannel)
 			if gotAnnounces != tc.announce {
 				t.Errorf("%s\nannounce channel count mismatch\nwant: %d\ngot:  %d",
 					packageName, tc.announce, gotAnnounces)

--- a/service/deployed_version/types/base/query_test.go
+++ b/service/deployed_version/types/base/query_test.go
@@ -169,8 +169,8 @@ func TestLookup_HandleNewVersion(t *testing.T) {
 				Status: &status.Status{},
 			}
 			// Status.
-			announceChan := make(chan []byte, 2)
-			lookup.Status.AnnounceChannel = &announceChan
+			announceChannel := make(chan []byte, 2)
+			lookup.Status.AnnounceChannel = announceChannel
 			lookup.Status.Init(
 				0, 0, 0,
 				name, "", "",
@@ -194,7 +194,7 @@ func TestLookup_HandleNewVersion(t *testing.T) {
 			lookup.HandleNewVersion(tc.versions.newVersion, tc.versions.releaseDate, true, logFrom)
 
 			// THEN an announcement should be made when expected.
-			gotLen := len(*lookup.Status.AnnounceChannel)
+			gotLen := len(lookup.Status.AnnounceChannel)
 			if gotLen != tc.wantAnnounces {
 				t.Errorf("%s\nAnnounce channel length mismatch\nwant: %d\ngot:  %d",
 					packageName, tc.wantAnnounces, gotLen)

--- a/service/deployed_version/types/manual/help_test.go
+++ b/service/deployed_version/types/manual/help_test.go
@@ -61,7 +61,7 @@ func testLookup(version string, failing bool) *Lookup {
 	saveChannel := make(chan bool, 5)
 	databaseChannel := make(chan dbtype.Message, 5)
 	svcStatus := status.New(
-		&announceChannel, &databaseChannel, &saveChannel,
+		announceChannel, databaseChannel, saveChannel,
 		"",
 		"", "",
 		"", "",

--- a/service/deployed_version/types/manual/query_test.go
+++ b/service/deployed_version/types/manual/query_test.go
@@ -168,7 +168,7 @@ func TestLookup_Query(t *testing.T) {
 					packageName, wantVersion, dvl.Version)
 			}
 			// AND the correct number of announces are queued.
-			gotAnnounces := len(*dvl.Status.AnnounceChannel)
+			gotAnnounces := len(dvl.Status.AnnounceChannel)
 			if gotAnnounces != tc.announces {
 				t.Errorf("%s\nannounce count mismatch\nwant: %d\ngot:  %d",
 					packageName, tc.announces, gotAnnounces)
@@ -201,7 +201,7 @@ func TestLookup_Query__RateLimit(t *testing.T) {
 	}
 	// AND no announces are queued.
 	wantAnnounces := 0
-	gotAnnounces := len(*dvl.Status.AnnounceChannel)
+	gotAnnounces := len(dvl.Status.AnnounceChannel)
 	if gotAnnounces != wantAnnounces {
 		t.Errorf("%s\nannounce count mismatch\nwant: %d\ngot:  %d",
 			packageName, wantAnnounces, gotAnnounces)

--- a/service/deployed_version/types/web/help_test.go
+++ b/service/deployed_version/types/web/help_test.go
@@ -59,7 +59,7 @@ func testLookup(failing bool) *Lookup {
 	saveChannel := make(chan bool, 5)
 	databaseChannel := make(chan dbtype.Message, 5)
 	svcStatus := status.New(
-		&announceChannel, &databaseChannel, &saveChannel,
+		announceChannel, databaseChannel, saveChannel,
 		"",
 		"", "",
 		"", "",

--- a/service/deployed_version/types/web/query_test.go
+++ b/service/deployed_version/types/web/query_test.go
@@ -259,7 +259,7 @@ func TestLookup_Track(t *testing.T) {
 				dbChannel := make(chan dbtype.Message, 4)
 				announceChannel := make(chan []byte, 4)
 				svcStatus := status.New(
-					&announceChannel, &dbChannel, nil,
+					announceChannel, dbChannel, nil,
 					"",
 					tc.startDeployedVersion, "",
 					tc.startLatestVersion, "",
@@ -316,15 +316,15 @@ func TestLookup_Track(t *testing.T) {
 				t.Errorf("%s\nLatestVersion mismatch\nwant: %q\ngot:  %q",
 					packageName, tc.wantLatestVersion, gotLatestVersion)
 			}
-			if gotAnnounces := len(*tc.lookup.Status.AnnounceChannel); gotAnnounces != tc.wantAnnounces {
+			if gotAnnounces := len(tc.lookup.Status.AnnounceChannel); gotAnnounces != tc.wantAnnounces {
 				for i := 0; i < gotAnnounces; i++ {
 					t.Logf("%s\nAnnounce message - %s\n",
-						packageName, <-(*tc.lookup.Status.AnnounceChannel))
+						packageName, <-(tc.lookup.Status.AnnounceChannel))
 				}
 				t.Errorf("%s\nAnnounceChannel length mismatch\nwant: %d\ngot:  %d",
 					packageName, tc.wantAnnounces, gotAnnounces)
 			}
-			if gotDatabaseMessages := len(*tc.lookup.Status.DatabaseChannel); gotDatabaseMessages != tc.wantDatabaseMessages {
+			if gotDatabaseMessages := len(tc.lookup.Status.DatabaseChannel); gotDatabaseMessages != tc.wantDatabaseMessages {
 				t.Errorf("%s\nDatabaseChannel length mismatch\nwant: %d\ngot:  %d",
 					packageName, tc.wantDatabaseMessages, gotDatabaseMessages)
 			}

--- a/service/handlers_test.go
+++ b/service/handlers_test.go
@@ -87,14 +87,14 @@ func TestService_HandleSkip(t *testing.T) {
 				return
 			}
 			// AND the correct amount of changes are queued in the announce channel.
-			if len(*svc.Status.AnnounceChannel) != tc.wantAnnounces {
+			if len(svc.Status.AnnounceChannel) != tc.wantAnnounces {
 				t.Errorf("%s\nAnnounceChannel length mismatch\nwant: %d messages\ngot:  %d",
-					packageName, tc.wantAnnounces, len(*svc.Status.AnnounceChannel))
+					packageName, tc.wantAnnounces, len(svc.Status.AnnounceChannel))
 			}
 			// AND the correct amount of messages are queued in the database channel.
-			if len(*svc.Status.DatabaseChannel) != tc.wantDatabaseMessages {
+			if len(svc.Status.DatabaseChannel) != tc.wantDatabaseMessages {
 				t.Errorf("%s\nDatabaseChannel length mismatch\nwant: %d\ngot:  %d",
-					packageName, tc.wantDatabaseMessages, len(*svc.Status.DatabaseChannel))
+					packageName, tc.wantDatabaseMessages, len(svc.Status.DatabaseChannel))
 			}
 		})
 	}
@@ -234,9 +234,9 @@ func TestService_HandleCommand(t *testing.T) {
 					packageName, want, got)
 			}
 			// THEN the correct amount of changes are queued in the channel.
-			if len(*svc.Status.AnnounceChannel) != tc.wantAnnounces {
+			if len(svc.Status.AnnounceChannel) != tc.wantAnnounces {
 				t.Errorf("%s\nAnnounceChannel length mismatch\nwant: %d messages\ngot:  %d",
-					packageName, tc.wantAnnounces, len(*svc.Status.AnnounceChannel))
+					packageName, tc.wantAnnounces, len(svc.Status.AnnounceChannel))
 				fails := ""
 				for i := range svc.Command {
 					fails += fmt.Sprintf("%d=%s, ",
@@ -244,8 +244,8 @@ func TestService_HandleCommand(t *testing.T) {
 				}
 				t.Logf("%s\ncommandFails: {%s}", fails[:len(fails)-2],
 					packageName)
-				for len(*svc.Status.AnnounceChannel) != 0 {
-					msg := <-*svc.Status.AnnounceChannel
+				for len(svc.Status.AnnounceChannel) != 0 {
+					msg := <-svc.Status.AnnounceChannel
 					t.Logf("%s - service.Service.HandleCommand() %#v",
 						packageName, string(msg))
 				}
@@ -394,9 +394,9 @@ func TestService_HandleWebHook(t *testing.T) {
 					packageName, want, got)
 			}
 			// THEN the correct amount of changes are queued in the channel.
-			if len(*svc.Status.AnnounceChannel) != tc.wantAnnounces {
+			if len(svc.Status.AnnounceChannel) != tc.wantAnnounces {
 				t.Errorf("%s\nAnnounceChannel length mismatch\nwant: %d messages\ngot:  %d",
-					packageName, tc.wantAnnounces, len(*svc.Status.AnnounceChannel))
+					packageName, tc.wantAnnounces, len(svc.Status.AnnounceChannel))
 				fails := ""
 				for i := range svc.WebHook {
 					fails += fmt.Sprintf("%s=%s, ",
@@ -404,8 +404,8 @@ func TestService_HandleWebHook(t *testing.T) {
 				}
 				t.Logf("%s\nwebhookFails: {%s}",
 					fails[:len(fails)-2], packageName)
-				for len(*svc.Status.AnnounceChannel) != 0 {
-					msg := <-*svc.Status.AnnounceChannel
+				for len(svc.Status.AnnounceChannel) != 0 {
+					msg := <-svc.Status.AnnounceChannel
 					t.Logf("%s - %#v",
 						packageName, string(msg))
 				}
@@ -571,13 +571,13 @@ func TestService_HandleUpdateActions(t *testing.T) {
 					packageName, want, got)
 			}
 			// THEN the correct amount of changes are queued in the channel.
-			if len(*svc.Status.AnnounceChannel) != tc.wantAnnounces {
+			if len(svc.Status.AnnounceChannel) != tc.wantAnnounces {
 				t.Errorf("%s\nAnnounceChannel length mismatch\nwant: %d\ngot:  %d",
-					packageName, tc.wantAnnounces, len(*svc.Status.AnnounceChannel))
+					packageName, tc.wantAnnounces, len(svc.Status.AnnounceChannel))
 				t.Logf("%s - Fails:\n%s",
 					packageName, svc.Status.Fails.String("  "))
-				for len(*svc.Status.AnnounceChannel) != 0 {
-					msg := <-*svc.Status.AnnounceChannel
+				for len(svc.Status.AnnounceChannel) != 0 {
+					msg := <-svc.Status.AnnounceChannel
 					t.Logf("%s - AnnounceChannel message: %#v",
 						packageName, string(msg))
 				}
@@ -825,13 +825,13 @@ func TestService_HandleFailedActions(t *testing.T) {
 					packageName, want, got)
 			}
 			// AND the correct amount of changes are queued in the channel.
-			if len(*svc.Status.AnnounceChannel) != tc.wantAnnounces {
+			if len(svc.Status.AnnounceChannel) != tc.wantAnnounces {
 				t.Errorf("%s\nAnnounceChannel length mismatch\nwant: %d\ngot:  %d",
-					packageName, tc.wantAnnounces, len(*svc.Status.AnnounceChannel))
+					packageName, tc.wantAnnounces, len(svc.Status.AnnounceChannel))
 				t.Logf("%s - Fails:\n%s",
 					packageName, svc.Status.Fails.String("  "))
-				for len(*svc.Status.AnnounceChannel) != 0 {
-					msg := <-*svc.Status.AnnounceChannel
+				for len(svc.Status.AnnounceChannel) != 0 {
+					msg := <-svc.Status.AnnounceChannel
 					t.Logf("%s - %#v",
 						packageName, string(msg))
 				}
@@ -1028,9 +1028,9 @@ func TestService_UpdateLatestApproved(t *testing.T) {
 					packageName, want, got)
 			}
 			// AND the correct amount of changes are queued in the channel.
-			if len(*svc.Status.AnnounceChannel) != tc.wantAnnounces {
+			if len(svc.Status.AnnounceChannel) != tc.wantAnnounces {
 				t.Errorf("%s\nAnnounceChannel length mismatch\nwant: %d\ngot:  %d",
-					packageName, tc.wantAnnounces, len(*svc.Status.AnnounceChannel))
+					packageName, tc.wantAnnounces, len(svc.Status.AnnounceChannel))
 			}
 		})
 	}
@@ -1192,9 +1192,9 @@ func TestService_UpdatedVersion(t *testing.T) {
 					packageName, startLV, gotDV)
 			}
 			// AND the correct amount of changes are queued in the channel.
-			if len(*svc.Status.AnnounceChannel) != tc.wantAnnounces {
+			if len(svc.Status.AnnounceChannel) != tc.wantAnnounces {
 				t.Errorf("%s\nAnnounceChannel length mismatch\nwant: %d\ngot:  %d",
-					packageName, tc.wantAnnounces, len(*svc.Status.AnnounceChannel))
+					packageName, tc.wantAnnounces, len(svc.Status.AnnounceChannel))
 			}
 		})
 	}

--- a/service/help_test.go
+++ b/service/help_test.go
@@ -63,7 +63,7 @@ func testStatus() *status.Status {
 	)
 
 	return status.New(
-		&announceChannel, &databaseChannel, &saveChannel,
+		announceChannel, databaseChannel, saveChannel,
 		"",
 		"", "",
 		"", "",

--- a/service/latest_version/help_test.go
+++ b/service/latest_version/help_test.go
@@ -69,7 +69,7 @@ func testLookup(lookupType string, failing bool) Lookup {
 	saveChannel := make(chan bool, 5)
 	databaseChannel := make(chan dbtype.Message, 5)
 	svcStatus := status.New(
-		&announceChannel, &databaseChannel, &saveChannel,
+		announceChannel, databaseChannel, saveChannel,
 		"",
 		"", "",
 		"", "",

--- a/service/latest_version/types/base/query_test.go
+++ b/service/latest_version/types/base/query_test.go
@@ -167,8 +167,8 @@ func TestLookup_HandleNewVersion(t *testing.T) {
 			lookup := &Lookup{
 				Status: &status.Status{},
 			}
-			announceChan := make(chan []byte, 2)
-			lookup.Status.AnnounceChannel = &announceChan
+			announceChannel := make(chan []byte, 2)
+			lookup.Status.AnnounceChannel = announceChannel
 			lookup.Status.Init(
 				0, 0, 0,
 				name, "", "",
@@ -194,7 +194,7 @@ func TestLookup_HandleNewVersion(t *testing.T) {
 			if tc.wantAnnounce {
 				wantLen = 1
 			}
-			gotLen := len(*lookup.Status.AnnounceChannel)
+			gotLen := len(lookup.Status.AnnounceChannel)
 			if gotLen != wantLen {
 				t.Errorf("%s\nAnnounce channel length mismatch\nwant: %d\ngot:  %d",
 					packageName, wantLen, gotLen)

--- a/service/latest_version/types/github/help_test.go
+++ b/service/latest_version/types/github/help_test.go
@@ -102,7 +102,7 @@ func testLookup(failing bool) *Lookup {
 	saveChannel := make(chan bool, 5)
 	databaseChannel := make(chan dbtype.Message, 5)
 	svcStatus := status.New(
-		&announceChannel, &databaseChannel, &saveChannel,
+		announceChannel, databaseChannel, saveChannel,
 		"",
 		"", "",
 		"", "",

--- a/service/latest_version/types/web/help_test.go
+++ b/service/latest_version/types/web/help_test.go
@@ -59,7 +59,7 @@ func testLookup(failing bool) *Lookup {
 	saveChannel := make(chan bool, 5)
 	databaseChannel := make(chan dbtype.Message, 5)
 	svcStatus := status.New(
-		&announceChannel, &databaseChannel, &saveChannel,
+		announceChannel, databaseChannel, saveChannel,
 		"",
 		"", "",
 		"", "",

--- a/service/latest_version/types/web/query_test.go
+++ b/service/latest_version/types/web/query_test.go
@@ -635,9 +635,9 @@ func TestQuery(t *testing.T) {
 					t.Fatalf("%s\nLatestVersion mismatch\nwant: %q\ngot:  %q",
 						packageName, tc.hadStatus.latestVersionWant, lookup.Status.LatestVersion())
 				}
-				if want := 1; tc.want.announce && len(*lookup.Status.AnnounceChannel) != want {
+				if want := 1; tc.want.announce && len(lookup.Status.AnnounceChannel) != want {
 					t.Fatalf("%s\nannouncement mismatch\nwant: %d\ngot:  %d",
-						packageName, want, len(*lookup.Status.AnnounceChannel))
+						packageName, want, len(lookup.Status.AnnounceChannel))
 				}
 				if newVersion != tc.want.newVersion {
 					t.Fatalf("%s\nnewVersion mismatch\nwant: %t\ngot:  %t",

--- a/service/new_test.go
+++ b/service/new_test.go
@@ -4174,7 +4174,7 @@ func TestService_CheckFetches(t *testing.T) {
 				&webhook.WebHooksDefaults{}, &webhook.Defaults{}, &webhook.Defaults{},
 			)
 			announceChannel := make(chan []byte, 5)
-			tc.svc.Status.AnnounceChannel = &announceChannel
+			tc.svc.Status.AnnounceChannel = announceChannel
 			tc.svc.Status.SetLatestVersion(tc.startLatestVersion, "", false)
 			tc.svc.Status.SetDeployedVersion(tc.startDeployedVersion, "", false)
 
@@ -4198,9 +4198,9 @@ func TestService_CheckFetches(t *testing.T) {
 					packageName, tc.wantDeployedVersion, tc.svc.Status.DeployedVersion())
 			}
 			want := 0
-			if len(*tc.svc.Status.AnnounceChannel) != want {
+			if len(tc.svc.Status.AnnounceChannel) != want {
 				t.Errorf("%s\nAnnounceChannel length mismatch\nwant: %d messages\ngot:  %d",
-					packageName, want, len(*tc.svc.Status.AnnounceChannel))
+					packageName, want, len(tc.svc.Status.AnnounceChannel))
 			}
 		})
 	}

--- a/service/status/announce_test.go
+++ b/service/status/announce_test.go
@@ -53,7 +53,7 @@ func TestStatus_AnnounceFirstVersion(t *testing.T) {
 			if tc.nilChannel {
 				return
 			}
-			gotData := <-*status.AnnounceChannel
+			gotData := <-status.AnnounceChannel
 			var got apitype.WebSocketMessage
 			json.Unmarshal(gotData, &got)
 			if got.ServiceData.ID != wantID {
@@ -101,7 +101,7 @@ func TestStatus_AnnounceQuery(t *testing.T) {
 			if tc.nilChannel {
 				return
 			}
-			gotData := <-*status.AnnounceChannel
+			gotData := <-status.AnnounceChannel
 			var got apitype.WebSocketMessage
 			json.Unmarshal(gotData, &got)
 			if got.ServiceData.ID != wantID {
@@ -146,7 +146,7 @@ func TestStatus_AnnounceQueryNewVersion(t *testing.T) {
 			if tc.nilChannel {
 				return
 			}
-			gotData := <-*status.AnnounceChannel
+			gotData := <-status.AnnounceChannel
 			var got apitype.WebSocketMessage
 			json.Unmarshal(gotData, &got)
 			if got.ServiceData.ID != wantID {
@@ -195,7 +195,7 @@ func TestStatus_AnnounceUpdate(t *testing.T) {
 			if tc.nilChannel {
 				return
 			}
-			gotData := <-*status.AnnounceChannel
+			gotData := <-status.AnnounceChannel
 			var got apitype.WebSocketMessage
 			json.Unmarshal(gotData, &got)
 			if got.ServiceData.ID != wantID {
@@ -243,7 +243,7 @@ func TestStatus_announceApproved(t *testing.T) {
 			if tc.nilChannel {
 				return
 			}
-			gotData := <-*status.AnnounceChannel
+			gotData := <-status.AnnounceChannel
 			var got apitype.WebSocketMessage
 			json.Unmarshal(gotData, &got)
 			if got.ServiceData.ID != wantID {

--- a/service/status/help_test.go
+++ b/service/status/help_test.go
@@ -34,7 +34,7 @@ func testStatus() (status *Status) {
 		databaseChannel = make(chan dbtype.Message, 5)
 	)
 	svcStatus := New(
-		&announceChannel, &databaseChannel, &saveChannel,
+		announceChannel, databaseChannel, saveChannel,
 		"",
 		"", "",
 		"", "",

--- a/service/status/status.go
+++ b/service/status/status.go
@@ -32,9 +32,9 @@ import (
 
 // statusBase is the base struct for the Status struct.
 type statusBase struct {
-	AnnounceChannel *chan []byte         // Announce to the WebSocket.
-	DatabaseChannel *chan dbtype.Message // Broadcasts to the Database.
-	SaveChannel     *chan bool           // Trigger a save of the config.
+	AnnounceChannel chan []byte         // Announce to the WebSocket.
+	DatabaseChannel chan dbtype.Message // Broadcasts to the Database.
+	SaveChannel     chan bool           // Trigger a save of the config.
 }
 
 // Defaults are the default values for the Status struct.
@@ -44,9 +44,9 @@ type Defaults struct {
 
 // NewDefaults returns a new Defaults struct.
 func NewDefaults(
-	announceChannel *chan []byte,
-	databaseChannel *chan dbtype.Message,
-	saveChannel *chan bool,
+	announceChannel chan []byte,
+	databaseChannel chan dbtype.Message,
+	saveChannel chan bool,
 ) Defaults {
 	return Defaults{
 		statusBase: statusBase{
@@ -108,9 +108,9 @@ type Status struct {
 
 // New Status struct.
 func New(
-	announceChannel *chan []byte,
-	databaseChannel *chan dbtype.Message,
-	saveChannel *chan bool,
+	announceChannel chan []byte,
+	databaseChannel chan dbtype.Message,
+	saveChannel chan bool,
 
 	av string,
 	dv, dvT string,
@@ -228,7 +228,7 @@ func (s *Status) String() string {
 }
 
 // SetAnnounceChannel will set the AnnounceChannel.
-func (s *Status) SetAnnounceChannel(channel *chan []byte) {
+func (s *Status) SetAnnounceChannel(channel chan []byte) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
@@ -532,7 +532,7 @@ func (s *Status) SendAnnounce(payload *[]byte) {
 		return
 	}
 
-	*s.AnnounceChannel <- *payload
+	s.AnnounceChannel <- *payload
 }
 
 // sendDatabase payload to the DatabaseChannel.
@@ -541,7 +541,7 @@ func (s *Status) sendDatabase(payload *dbtype.Message) {
 		return
 	}
 
-	*s.DatabaseChannel <- *payload
+	s.DatabaseChannel <- *payload
 }
 
 // SendSave request to the SaveChannel.
@@ -553,7 +553,7 @@ func (s *Status) SendSave() {
 		return
 	}
 
-	*s.SaveChannel <- true
+	s.SaveChannel <- true
 }
 
 // setLatestVersionIsDeployedMetric sets the Prometheus metric for whether the LatestVersion is deployed.

--- a/service/status/status_test.go
+++ b/service/status/status_test.go
@@ -332,7 +332,7 @@ func TestStatus_ApprovedVersion(t *testing.T) {
 			announceChannel := make(chan []byte, 4)
 			databaseChannel := make(chan dbtype.Message, 4)
 			status := New(
-				&announceChannel, &databaseChannel, nil,
+				announceChannel, databaseChannel, nil,
 				tc.hadApprovedVersion,
 				"", "",
 				"", "",
@@ -369,14 +369,14 @@ func TestStatus_ApprovedVersion(t *testing.T) {
 					packageName, deployedVersion, got)
 			}
 			// 	AnnounceChannel:
-			if len(*status.AnnounceChannel) != tc.wantMessages {
+			if len(status.AnnounceChannel) != tc.wantMessages {
 				t.Errorf("%s\nAnnounceChannel length mismatch\nwant: %d messages\ngot:  %d",
-					packageName, tc.wantMessages, len(*status.AnnounceChannel))
+					packageName, tc.wantMessages, len(status.AnnounceChannel))
 			}
 			// 	DatabaseChannel:
-			if len(*status.DatabaseChannel) != tc.wantMessages {
+			if len(status.DatabaseChannel) != tc.wantMessages {
 				t.Errorf("%s\nDatabaseChannel length mismatch\nwant: %d messages\ngot:  %d",
-					packageName, tc.wantMessages, len(*status.DatabaseChannel))
+					packageName, tc.wantMessages, len(status.DatabaseChannel))
 			}
 			// AND LatestVersionIsDeployedVersion metric is updated.
 			gotMetric := testutil.ToFloat64(metric.LatestVersionIsDeployed.WithLabelValues(status.ServiceInfo.ID))
@@ -493,7 +493,7 @@ func TestStatus_DeployedVersion(t *testing.T) {
 			for _, haveDB := range []bool{false, true} {
 				dbChannel := make(chan dbtype.Message, 4)
 				status := New(
-					nil, &dbChannel, nil,
+					nil, dbChannel, nil,
 					tc.had.approvedVersion,
 					tc.had.deployedVersion, tc.had.deployedVersionTimestamp,
 					tc.had.latestVersion, "",
@@ -613,7 +613,7 @@ func TestStatus_LatestVersion(t *testing.T) {
 			for _, haveDB := range []bool{false, true} {
 				dbChannel := make(chan dbtype.Message, 8)
 				status := New(
-					nil, &dbChannel, nil,
+					nil, dbChannel, nil,
 					"",
 					"", "",
 					tc.had.version, tc.had.timestamp,
@@ -776,7 +776,7 @@ func TestStatus_SendAnnounce(t *testing.T) {
 
 			announceChannel := make(chan []byte, 4)
 			status := New(
-				&announceChannel, nil, nil,
+				announceChannel, nil, nil,
 				"",
 				"", "",
 				"", "",
@@ -795,7 +795,7 @@ func TestStatus_SendAnnounce(t *testing.T) {
 			// THEN the AnnounceChannel is sent a message if not deleting or nil.
 			got := 0
 			if status.AnnounceChannel != nil {
-				got = len(*status.AnnounceChannel)
+				got = len(status.AnnounceChannel)
 			}
 			want := 1
 			if tc.deleting || tc.nilChannel {
@@ -826,7 +826,7 @@ func TestStatus_sendDatabase(t *testing.T) {
 
 			databaseChannel := make(chan dbtype.Message, 4)
 			status := New(
-				nil, &databaseChannel, nil,
+				nil, databaseChannel, nil,
 				"",
 				"", "",
 				"", "",
@@ -849,7 +849,7 @@ func TestStatus_sendDatabase(t *testing.T) {
 			}
 			got := 0
 			if status.DatabaseChannel != nil {
-				got = len(*status.DatabaseChannel)
+				got = len(status.DatabaseChannel)
 			}
 			if got != want {
 				t.Errorf("%s\nDatabaseChannel length mismatch\nwant: %d messages\ngot:  %d",
@@ -876,7 +876,7 @@ func TestStatus_SendSave(t *testing.T) {
 
 			saveChannel := make(chan bool, 4)
 			status := New(
-				nil, nil, &saveChannel,
+				nil, nil, saveChannel,
 				"",
 				"", "",
 				"", "",
@@ -899,7 +899,7 @@ func TestStatus_SendSave(t *testing.T) {
 			}
 			got := 0
 			if status.SaveChannel != nil {
-				got = len(*status.SaveChannel)
+				got = len(status.SaveChannel)
 			}
 			if got != want {
 				t.Errorf("%s\nSaveChannel length mismatch\nwant: %d messages\ngot:  %d",
@@ -1322,22 +1322,22 @@ func TestNewDefaults(t *testing.T) {
 	saveChannel := make(chan bool, 4)
 
 	// WHEN NewDefaults is called.
-	statusDefaults := NewDefaults(&announceChannel, &databaseChannel, &saveChannel)
+	statusDefaults := NewDefaults(announceChannel, databaseChannel, saveChannel)
 
 	// THEN the AnnounceChannel is set to the given channel.
-	if &announceChannel != statusDefaults.AnnounceChannel {
+	if announceChannel != statusDefaults.AnnounceChannel {
 		t.Errorf("%s\nAnnounceChannel not initialised correctly.\nwant: %v\ngot:  %v",
-			packageName, &announceChannel, statusDefaults.AnnounceChannel)
+			packageName, announceChannel, statusDefaults.AnnounceChannel)
 	}
 	// AND the DatabaseChannel is set to the given channel.
-	if &databaseChannel != statusDefaults.DatabaseChannel {
+	if databaseChannel != statusDefaults.DatabaseChannel {
 		t.Errorf("%s\nDatabaseChannel not initialised correctly.\nwant: %v\ngot:  %v",
-			packageName, &databaseChannel, statusDefaults.DatabaseChannel)
+			packageName, databaseChannel, statusDefaults.DatabaseChannel)
 	}
 	// AND the SaveChannel is set to the given channel.
-	if &saveChannel != statusDefaults.SaveChannel {
+	if saveChannel != statusDefaults.SaveChannel {
 		t.Errorf("%s\nSaveChannel not initialised correctly.\nwant: %v\ngot:  %v",
-			packageName, &saveChannel, statusDefaults.SaveChannel)
+			packageName, saveChannel, statusDefaults.SaveChannel)
 	}
 }
 
@@ -1353,7 +1353,7 @@ func TestStatus_Copy(t *testing.T) {
 	latestVersionTimestamp := "2023-01-02T00:00:00Z"
 	lastQueried := "2023-01-03T00:00:00Z"
 	status := New(
-		&announceChannel, &databaseChannel, &saveChannel,
+		announceChannel, databaseChannel, saveChannel,
 		approvedVersion,
 		deployedVersion, deployedVersionTimestamp,
 		latestVersion, latestVersionTimestamp,
@@ -1434,7 +1434,7 @@ func TestStatus_SetAnnounceChannel(t *testing.T) {
 	// GIVEN a Status with an initial AnnounceChannel.
 	initialChannel := make(chan []byte, 4)
 	status := New(
-		&initialChannel, nil, nil,
+		initialChannel, nil, nil,
 		"",
 		"", "",
 		"", "",
@@ -1443,18 +1443,18 @@ func TestStatus_SetAnnounceChannel(t *testing.T) {
 
 	// WHEN SetAnnounceChannel is called with a new channel.
 	newChannel := make(chan []byte, 4)
-	status.SetAnnounceChannel(&newChannel)
+	status.SetAnnounceChannel(newChannel)
 
 	// THEN the AnnounceChannel should be updated to the new channel.
-	if &newChannel != status.AnnounceChannel {
+	if newChannel != status.AnnounceChannel {
 		t.Errorf("%s\nAnnounceChannel not set correctly.\nwant: %v\ngot:  %v",
-			packageName, &newChannel, status.AnnounceChannel)
+			packageName, newChannel, status.AnnounceChannel)
 	}
 
 	// AND the initial channel should no longer be the AnnounceChannel.
-	if &initialChannel == status.AnnounceChannel {
+	if initialChannel == status.AnnounceChannel {
 		t.Errorf("%s\nAnnounceChannel shouldn't have been reset to be the initial channel.\nwant: %v\ngot:  %v",
-			packageName, &newChannel, status.AnnounceChannel)
+			packageName, newChannel, status.AnnounceChannel)
 	}
 }
 

--- a/service/track_test.go
+++ b/service/track_test.go
@@ -570,29 +570,29 @@ func TestService_Track(t *testing.T) {
 				}
 			}
 			// AnnounceChannel.
-			if gotAnnounceMessages := len(*svc.Status.AnnounceChannel); gotAnnounceMessages != tc.wantAnnounces {
+			if gotAnnounceMessages := len(svc.Status.AnnounceChannel); gotAnnounceMessages != tc.wantAnnounces {
 				t.Errorf("%s\nAnnounceChannel length mismatch\nwant: %d messages\ngot:  %d",
 					packageName, tc.wantAnnounces, gotAnnounceMessages)
 				for gotAnnounceMessages > 0 {
 					var msg apitype.WebSocketMessage
-					msgBytes := <-*svc.Status.AnnounceChannel
+					msgBytes := <-svc.Status.AnnounceChannel
 					json.Unmarshal(msgBytes, &msg)
 					t.Logf("%s - got message: {%+v}",
 						packageName, msg)
-					gotAnnounceMessages = len(*svc.Status.AnnounceChannel)
+					gotAnnounceMessages = len(svc.Status.AnnounceChannel)
 				}
 			}
 			// DatabaseChannel.
-			if gotDatabaseMessages := len(*svc.Status.DatabaseChannel); gotDatabaseMessages != tc.wantDatabaseMessages {
+			if gotDatabaseMessages := len(svc.Status.DatabaseChannel); gotDatabaseMessages != tc.wantDatabaseMessages {
 				t.Errorf("%s\nDatabaseChannel length mismatch\nwant: %d messages\ngot:  %d",
 					packageName, tc.wantDatabaseMessages, gotDatabaseMessages)
 				for gotDatabaseMessages > 0 {
 					var msg apitype.WebSocketMessage
-					msgBytes := <-*svc.Status.AnnounceChannel
+					msgBytes := <-svc.Status.AnnounceChannel
 					json.Unmarshal(msgBytes, &msg)
 					t.Logf("%s - got message:\n{%v}\n",
 						packageName, msg)
-					gotDatabaseMessages = len(*svc.Status.DatabaseChannel)
+					gotDatabaseMessages = len(svc.Status.DatabaseChannel)
 				}
 			}
 			// Track should finish if it is not Active and is not being deleted.

--- a/testing/service_test.go
+++ b/testing/service_test.go
@@ -218,7 +218,7 @@ func TestServiceTest(t *testing.T) {
 					&webhook.WebHooksDefaults{}, &webhook.Defaults{}, &hardDefaults.WebHook)
 				// will do a call for latest_version* and one for deployed_version*.
 				dbChannel := make(chan dbtype.Message, 4)
-				tc.services[tc.flag].Status.DatabaseChannel = &dbChannel
+				tc.services[tc.flag].Status.DatabaseChannel = dbChannel
 			}
 
 			// WHEN ServiceTest is called with the test Config.

--- a/web/api/v1/help_test.go
+++ b/web/api/v1/help_test.go
@@ -84,7 +84,7 @@ func testLoad(file string) *config.Config {
 	config.Load(file, &flags)
 	config.Init()
 	announceChannel := make(chan []byte, 8)
-	config.HardDefaults.Service.Status.AnnounceChannel = &announceChannel
+	config.HardDefaults.Service.Status.AnnounceChannel = announceChannel
 
 	return &config
 }
@@ -164,8 +164,8 @@ func testService(id string, semVer bool) *service.Service {
 		&webhook.WebHooksDefaults{}, &webhook.Defaults{}, &webhookHardDefaults)
 
 	// Status channels.
-	svc.Status.AnnounceChannel = &announceChannel
-	svc.Status.DatabaseChannel = &databaseChannel
+	svc.Status.AnnounceChannel = announceChannel
+	svc.Status.DatabaseChannel = databaseChannel
 
 	return &svc
 }

--- a/web/api/v1/http-api-action_test.go
+++ b/web/api/v1/http-api-action_test.go
@@ -549,7 +549,7 @@ func TestHTTP_httpServiceRunActions(t *testing.T) {
 				packageName, expecting)
 			got := 0
 			for expecting != 0 {
-				message := <-*api.Config.HardDefaults.Service.Status.AnnounceChannel
+				message := <-api.Config.HardDefaults.Service.Status.AnnounceChannel
 				if message == nil {
 					stdout := releaseStdout()
 					t.Log(time.Now(), stdout)
@@ -565,9 +565,9 @@ func TestHTTP_httpServiceRunActions(t *testing.T) {
 				expecting--
 			}
 			// extra message check.
-			extraMessages := len(*api.Config.HardDefaults.Service.Status.AnnounceChannel)
+			extraMessages := len(api.Config.HardDefaults.Service.Status.AnnounceChannel)
 			if extraMessages != 0 {
-				raw := <-*api.Config.HardDefaults.Service.Status.AnnounceChannel
+				raw := <-api.Config.HardDefaults.Service.Status.AnnounceChannel
 				t.Fatalf("%s\nwasn't expecting another message but got one\n%#v\n%s",
 					packageName, extraMessages, string(raw))
 			}

--- a/web/api/v1/http-api-edit_test.go
+++ b/web/api/v1/http-api-edit_test.go
@@ -452,7 +452,7 @@ func TestHTTP_LatestVersionRefresh(t *testing.T) {
 			if tc.wants.announce {
 				wantAnnounces = 1
 			}
-			if got := len(*svc.Status.AnnounceChannel); got != wantAnnounces {
+			if got := len(svc.Status.AnnounceChannel); got != wantAnnounces {
 				t.Errorf("%s\nDeployedVersionRefresh - Announcements length mismatch\nwant: %d\ngot:  %d",
 					packageName, wantAnnounces, got)
 			}
@@ -1225,7 +1225,7 @@ func TestHTTP_ServiceDelete(t *testing.T) {
 		&api.Config.WebHook, &api.Config.Defaults.WebHook, &api.Config.HardDefaults.WebHook)
 	_ = api.Config.AddService("", svc)
 	// Drain db from the Service addition.
-	<-*api.Config.DatabaseChannel
+	<-api.Config.DatabaseChannel
 	tests := []struct {
 		name      string
 		serviceID string
@@ -1300,11 +1300,11 @@ func TestHTTP_ServiceDelete(t *testing.T) {
 			// AND the service is removed from the database (if the req was OK).
 			if tc.wants.statusCode == http.StatusOK {
 				time.Sleep(time.Second)
-				if len(*api.Config.DatabaseChannel) == 0 {
+				if len(api.Config.DatabaseChannel) == 0 {
 					t.Errorf("%s\nservice %q not removed from database",
 						packageName, tc.serviceID)
 				} else {
-					msg := <-*api.Config.DatabaseChannel
+					msg := <-api.Config.DatabaseChannel
 					if msg.Delete != true {
 						t.Errorf("%s\nServiceDelete should have sent a deletion to the db, not\n%+v",
 							packageName, msg)

--- a/web/api/v1/http-api-service.go
+++ b/web/api/v1/http-api-service.go
@@ -85,7 +85,7 @@ func (api *API) httpServiceOrderSet(w http.ResponseWriter, r *http.Request) {
 	// Announce to the WebSocket.
 	api.announceOrder()
 	// Trigger save.
-	*api.Config.HardDefaults.Service.Status.SaveChannel <- true
+	api.Config.HardDefaults.Service.Status.SaveChannel <- true
 }
 
 func (api *API) httpServiceSummary(w http.ResponseWriter, r *http.Request) {

--- a/web/api/v1/http_test.go
+++ b/web/api/v1/http_test.go
@@ -458,11 +458,11 @@ func TestHTTP_DisableRoutes(t *testing.T) {
 
 					// Test each route for this set of disabled routes.
 					for name, tc := range tests {
-						if len(*announceChannel) != 0 {
-							<-(*announceChannel)
+						if len(announceChannel) != 0 {
+							<-(announceChannel)
 						}
-						if len(*saveChannel) != 0 {
-							<-(*saveChannel)
+						if len(saveChannel) != 0 {
+							<-(saveChannel)
 						}
 
 						if !strings.HasPrefix(name, "-") && util.Contains(disabledRoutes, name) {

--- a/web/api/v1/util.go
+++ b/web/api/v1/util.go
@@ -54,7 +54,7 @@ func (api *API) announceEdit(oldData *apitype.ServiceSummary, newData *apitype.S
 	}
 
 	// Announce all edits to refresh caches.
-	*api.Config.HardDefaults.Service.Status.AnnounceChannel <- payloadData
+	api.Config.HardDefaults.Service.Status.AnnounceChannel <- payloadData
 }
 
 // announceDelete broadcasts a DELETE message to all WebSocket clients.
@@ -63,7 +63,7 @@ func (api *API) announceDelete(serviceID string) {
 		Page:    "APPROVALS",
 		Type:    "DELETE",
 		SubType: serviceID})
-	*api.Config.HardDefaults.Service.Status.AnnounceChannel <- payloadData
+	api.Config.HardDefaults.Service.Status.AnnounceChannel <- payloadData
 }
 
 // announceOrder broadcasts an ORDER message to all WebSocket clients.
@@ -73,7 +73,7 @@ func (api *API) announceOrder() {
 		Type:    "SERVICE",
 		SubType: "ORDER",
 		Order:   &api.Config.Order})
-	*api.Config.HardDefaults.Service.Status.AnnounceChannel <- payloadData
+	api.Config.HardDefaults.Service.Status.AnnounceChannel <- payloadData
 }
 
 // ConstantTimeCompare returns whether the slices x and y have equal contents.

--- a/web/api/v1/util_test.go
+++ b/web/api/v1/util_test.go
@@ -77,7 +77,7 @@ func TestAnnounceDelete(t *testing.T) {
 	serviceID := "test-service"
 	announceChannel := make(chan []byte, 2)
 	statusDefaults := status.NewDefaults(
-		&announceChannel,
+		announceChannel,
 		nil,
 		nil)
 	api := &API{
@@ -116,7 +116,7 @@ func TestAnnounceOrder(t *testing.T) {
 	// GIVEN an API instance with a service order.
 	announceChannel := make(chan []byte, 2)
 	statusDefaults := status.NewDefaults(
-		&announceChannel,
+		announceChannel,
 		nil,
 		nil)
 	order := []string{"some-order"}
@@ -212,7 +212,7 @@ func TestAnnounceEdit(t *testing.T) {
 	// GIVEN an API instance and old/new service data.
 	announceChannel := make(chan []byte, 2)
 	statusDefaults := status.NewDefaults(
-		&announceChannel,
+		announceChannel,
 		nil,
 		nil)
 	api := &API{

--- a/web/help_test.go
+++ b/web/help_test.go
@@ -200,9 +200,9 @@ func testService(t *testing.T, id string) (svc *service.Service) {
 		sDatabaseChannel = make(chan dbtype.Message, 5)
 		sSaveChannel     = make(chan bool, 5)
 	)
-	svc.Status.AnnounceChannel = &sAnnounceChannel
-	svc.Status.DatabaseChannel = &sDatabaseChannel
-	svc.Status.SaveChannel = &sSaveChannel
+	svc.Status.AnnounceChannel = sAnnounceChannel
+	svc.Status.DatabaseChannel = sDatabaseChannel
+	svc.Status.SaveChannel = sSaveChannel
 	svc.Status.Init(
 		len(svc.Notify),
 		len(svc.Command), len(svc.WebHook),

--- a/web/web.go
+++ b/web/web.go
@@ -59,9 +59,9 @@ func newWebUI(cfg *config.Config) *mux.Router {
 	router := NewRouter(cfg, hub)
 
 	// Hand out the broadcast channel
-	cfg.HardDefaults.Service.Status.AnnounceChannel = &hub.Broadcast
+	cfg.HardDefaults.Service.Status.AnnounceChannel = hub.Broadcast
 	for _, svc := range cfg.Service {
-		svc.Status.SetAnnounceChannel(&hub.Broadcast)
+		svc.Status.SetAnnounceChannel(hub.Broadcast)
 	}
 
 	return router

--- a/webhook/announce_test.go
+++ b/webhook/announce_test.go
@@ -58,7 +58,7 @@ func TestWebHook_AnnounceSend(t *testing.T) {
 			webhook.ServiceStatus.AnnounceChannel = nil
 			if !tc.nilChannel {
 				announceChannel := make(chan []byte, 4)
-				webhook.ServiceStatus.AnnounceChannel = &announceChannel
+				webhook.ServiceStatus.AnnounceChannel = announceChannel
 			}
 
 			// WH AnnounceCommand is run.
@@ -68,7 +68,7 @@ func TestWebHook_AnnounceSend(t *testing.T) {
 			if webhook.ServiceStatus.AnnounceChannel == nil {
 				return
 			}
-			m := <-*webhook.ServiceStatus.AnnounceChannel
+			m := <-webhook.ServiceStatus.AnnounceChannel
 			var parsed apitype.WebSocketMessage
 			json.Unmarshal(m, &parsed)
 


### PR DESCRIPTION
- `chan` is already a reference type; `*chan` provides no benefit