### PR TITLE
feat(latest-version): url, support for `headers`

### DIFF
--- a/service/deployed_version/refresh.go
+++ b/service/deployed_version/refresh.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/release-argus/Argus/service/shared"
 	"github.com/release-argus/Argus/util"
 	logutil "github.com/release-argus/Argus/util/log"
 )
@@ -33,6 +34,7 @@ func Refresh(
 	previousType string,
 	overrides *string,
 	semanticVersioning *string, // nil, "true", "false", "null" (unchanged, true, false, default).
+	secretRefs *shared.VSecretRef,
 ) (string, error) {
 	if lookup == nil {
 		return "", errors.New("lookup is nil")
@@ -63,6 +65,7 @@ func Refresh(
 		if err != nil {
 			return "", err
 		}
+		newLookup.InheritSecrets(lookup, secretRefs)
 	} else if previousType == "manual" && newLookup.GetType() == "manual" &&
 		overrides != nil {
 		if err := json.Unmarshal([]byte(*overrides), &lookup); err != nil {

--- a/service/deployed_version/types/base/base.go
+++ b/service/deployed_version/types/base/base.go
@@ -100,6 +100,6 @@ func (l *Lookup) Query(_ bool, _ logutil.LogFrom) error {
 }
 
 // InheritSecrets will inherit secrets from the `otherLookup`.
-func (l *Lookup) InheritSecrets(otherLookup Interface, secretRefs *shared.DVSecretRef) {
+func (l *Lookup) InheritSecrets(otherLookup Interface, secretRefs *shared.VSecretRef) {
 	// Nothing to inherit.
 }

--- a/service/deployed_version/types/base/base_test.go
+++ b/service/deployed_version/types/base/base_test.go
@@ -273,7 +273,7 @@ func TestInheritSecrets(t *testing.T) {
 	otherLookup := &testLookup{
 		Lookup: Lookup{
 			Type: "other"}}
-	secretRefs := &shared.DVSecretRef{
+	secretRefs := &shared.VSecretRef{
 		Headers: []shared.OldIntIndex{
 			{OldIndex: test.IntPtr(0)}},
 	}

--- a/service/deployed_version/types/base/interface.go
+++ b/service/deployed_version/types/base/interface.go
@@ -41,7 +41,7 @@ type Interface interface {
 	Query(metrics bool, logFrom logutil.LogFrom) (err error)
 
 	// InheritSecrets will inherit secrets from the `otherLookup`.
-	InheritSecrets(otherLookup Interface, secretRefs *shared.DVSecretRef)
+	InheritSecrets(otherLookup Interface, secretRefs *shared.VSecretRef)
 
 	// Helpers:
 

--- a/service/deployed_version/types/web/query.go
+++ b/service/deployed_version/types/web/query.go
@@ -149,9 +149,11 @@ func (l *Lookup) httpRequest(logFrom logutil.LogFrom) ([]byte, error) {
 }
 
 // getVersion returns the latest version from `body` that matches the URLCommands, and Regex requirements.
-func (l *Lookup) getVersion(body []byte, logFrom logutil.LogFrom) (version string, err error) {
+func (l *Lookup) getVersion(body []byte, logFrom logutil.LogFrom) (string, error) {
+	var version string
 	// If JSON is provided, use it to extract the version.
 	if l.JSON != "" {
+		var err error
 		version, err = util.GetValueByKey(body, l.JSON, l.url())
 		if err != nil {
 			logutil.Log.Error(err, logFrom, true)

--- a/service/deployed_version/types/web/types_test.go
+++ b/service/deployed_version/types/web/types_test.go
@@ -368,7 +368,7 @@ func TestLookup_InheritSecrets(t *testing.T) {
 	tests := map[string]struct {
 		lookup     *Lookup
 		other      *Lookup
-		secretRefs *shared.DVSecretRef
+		secretRefs *shared.VSecretRef
 		want       *Lookup
 	}{
 		"inherit BasicAuth password": {
@@ -382,7 +382,7 @@ func TestLookup_InheritSecrets(t *testing.T) {
 					Username: "user",
 					Password: "password",
 				}},
-			secretRefs: &shared.DVSecretRef{},
+			secretRefs: &shared.VSecretRef{},
 			want: &Lookup{
 				BasicAuth: &BasicAuth{
 					Username: "user",
@@ -391,19 +391,19 @@ func TestLookup_InheritSecrets(t *testing.T) {
 		},
 		"inherit headers": {
 			lookup: &Lookup{
-				Headers: []Header{
+				Headers: shared.Headers{
 					{Key: "X-Test", Value: util.SecretValue},
 				}},
 			other: &Lookup{
-				Headers: []Header{
+				Headers: shared.Headers{
 					{Key: "X-Test", Value: "secret"},
 				}},
-			secretRefs: &shared.DVSecretRef{
+			secretRefs: &shared.VSecretRef{
 				Headers: []shared.OldIntIndex{
 					{OldIndex: test.IntPtr(0)},
 				}},
 			want: &Lookup{
-				Headers: []Header{
+				Headers: shared.Headers{
 					{Key: "X-Test", Value: "secret"}}},
 		},
 		"no inheritance when no secrets": {
@@ -411,78 +411,78 @@ func TestLookup_InheritSecrets(t *testing.T) {
 				BasicAuth: &BasicAuth{
 					Username: "user",
 					Password: "password"},
-				Headers: []Header{
+				Headers: shared.Headers{
 					{Key: "X-Test", Value: "value"}},
 			},
 			other: &Lookup{
 				BasicAuth: &BasicAuth{
 					Username: "user",
 					Password: "other_password"},
-				Headers: []Header{
+				Headers: shared.Headers{
 					{Key: "X-Test", Value: "other_value"}},
 			},
-			secretRefs: &shared.DVSecretRef{},
+			secretRefs: &shared.VSecretRef{},
 			want: &Lookup{
 				BasicAuth: &BasicAuth{
 					Username: "user",
 					Password: "password"},
-				Headers: []Header{
+				Headers: shared.Headers{
 					{Key: "X-Test", Value: "value"}},
 			},
 		},
 		"no inheritance when no matching headers": {
 			lookup: &Lookup{
-				Headers: []Header{
+				Headers: shared.Headers{
 					{Key: "X-Test", Value: util.SecretValue}},
 			},
 			other: &Lookup{
-				Headers: []Header{
+				Headers: shared.Headers{
 					{Key: "X-Other", Value: "secret"}},
 			},
-			secretRefs: &shared.DVSecretRef{
+			secretRefs: &shared.VSecretRef{
 				Headers: []shared.OldIntIndex{
 					{OldIndex: test.IntPtr(1)}},
 			},
 			want: &Lookup{
-				Headers: []Header{
+				Headers: shared.Headers{
 					{Key: "X-Test", Value: util.SecretValue}},
 			},
 		},
 		"no inheritance when secretRefs out of bounds": {
 			lookup: &Lookup{
-				Headers: []Header{
+				Headers: shared.Headers{
 					{Key: "X-Test", Value: util.SecretValue},
 					{Key: "X-Other", Value: util.SecretValue}},
 			},
 			other: &Lookup{
-				Headers: []Header{
+				Headers: shared.Headers{
 					{Key: "X-Test", Value: "secret"}},
 			},
-			secretRefs: &shared.DVSecretRef{
+			secretRefs: &shared.VSecretRef{
 				Headers: []shared.OldIntIndex{
 					{OldIndex: test.IntPtr(1)}},
 			},
 			want: &Lookup{
-				Headers: []Header{
+				Headers: shared.Headers{
 					{Key: "X-Test", Value: util.SecretValue},
 					{Key: "X-Other", Value: util.SecretValue}},
 			},
 		},
 		"no inheritance when secretRef index nil": {
 			lookup: &Lookup{
-				Headers: []Header{
+				Headers: shared.Headers{
 					{Key: "X-Test", Value: util.SecretValue}},
 			},
 			other: &Lookup{
-				Headers: []Header{
+				Headers: shared.Headers{
 					{Key: "X-Test", Value: "secret"}},
 			},
-			secretRefs: &shared.DVSecretRef{
+			secretRefs: &shared.VSecretRef{
 				Headers: []shared.OldIntIndex{
 					{OldIndex: nil}},
 			},
 			want: &Lookup{
-				Headers: []Header{
+				Headers: shared.Headers{
 					{Key: "X-Test", Value: util.SecretValue}},
 			},
 		},

--- a/service/latest_version/types.go
+++ b/service/latest_version/types.go
@@ -121,7 +121,7 @@ func ChangeType(newType string, lookup base.Interface, overridesJSON string) (ba
 		return nil, err
 	}
 
-	newStruct.Inherit(lookup)
+	newStruct.InheritSecrets(lookup, nil)
 
 	// Apply overrides.
 	if overridesJSON != "" {

--- a/service/latest_version/types/base/base.go
+++ b/service/latest_version/types/base/base.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/release-argus/Argus/service/latest_version/filter"
 	opt "github.com/release-argus/Argus/service/option"
+	"github.com/release-argus/Argus/service/shared"
 	"github.com/release-argus/Argus/service/status"
 	"github.com/release-argus/Argus/util"
 	logutil "github.com/release-argus/Argus/util/log"
@@ -130,8 +131,8 @@ func (l *Lookup) inheritRequireTokens(fromLookup Interface) {
 	require.Inherit(fromRequire)
 }
 
-// Inherit values from `fromLookup` if the values should query the same data.
-func (l *Lookup) Inherit(fromLookup Interface) {
+// InheritSecrets will inherit secrets from `fromLookup` if the values should query the same data.
+func (l *Lookup) InheritSecrets(fromLookup Interface, secretRefs *shared.VSecretRef) {
 	l.inheritRequireTokens(fromLookup)
 }
 

--- a/service/latest_version/types/base/base_test.go
+++ b/service/latest_version/types/base/base_test.go
@@ -427,8 +427,8 @@ func TestInherit(t *testing.T) {
 					packageName, err)
 			}
 
-			// WHEN Inherit is called.
-			toLookup.Inherit(fromLookup)
+			// WHEN InheritSecrets is called.
+			toLookup.InheritSecrets(fromLookup, nil)
 
 			// THEN the Docker.(QueryToken|ValidUntil) are copied over when expected.
 			if tc.inheritDockerToken {

--- a/service/latest_version/types/base/interface.go
+++ b/service/latest_version/types/base/interface.go
@@ -18,6 +18,7 @@ package base
 import (
 	"github.com/release-argus/Argus/service/latest_version/filter"
 	opt "github.com/release-argus/Argus/service/option"
+	"github.com/release-argus/Argus/service/shared"
 	"github.com/release-argus/Argus/service/status"
 	logutil "github.com/release-argus/Argus/util/log"
 )
@@ -38,8 +39,8 @@ type Interface interface {
 	// Query the Lookup for the latest version.
 	Query(metrics bool, logFrom logutil.LogFrom) (newVersion bool, err error)
 
-	// Inherit state values from `fromLookup` if the values should query the same data.
-	Inherit(fromLookup Interface)
+	// InheritSecrets will inherit secrets from `otherLookup` if the values should query the same data.
+	InheritSecrets(otherLookup Interface, secretRefs *shared.VSecretRef)
 
 	// ServiceURL returns the Service URL for the Lookup.
 	ServiceURL() string

--- a/service/latest_version/types/github/refresh.go
+++ b/service/latest_version/types/github/refresh.go
@@ -17,12 +17,13 @@ package github
 
 import (
 	"github.com/release-argus/Argus/service/latest_version/types/base"
+	"github.com/release-argus/Argus/service/shared"
 )
 
 // Inherit values from `fromLookup` if the values should query the same source.
 //
 //	Values: githubData, Require.
-func (l *Lookup) Inherit(fromLookup base.Interface) {
+func (l *Lookup) InheritSecrets(fromLookup base.Interface, secretRefs *shared.VSecretRef) {
 	// Check whether inheriting from a GitHub Lookup.
 	if newGitHubLookup, ok := fromLookup.(*Lookup); ok && newGitHubLookup.URL == l.URL {
 		// Querying the same GitHub repo, and the ETag differs.
@@ -33,5 +34,5 @@ func (l *Lookup) Inherit(fromLookup base.Interface) {
 		}
 	}
 
-	l.Lookup.Inherit(fromLookup)
+	l.Lookup.InheritSecrets(fromLookup, secretRefs)
 }

--- a/service/latest_version/types/github/refresh_test.go
+++ b/service/latest_version/types/github/refresh_test.go
@@ -142,8 +142,8 @@ func TestLookup_Inherit(t *testing.T) {
 					packageName, err)
 			}
 
-			// WHEN we call Inherit.
-			toLookup.Inherit(fromLookup)
+			// WHEN we call InheritSecrets.
+			toLookup.InheritSecrets(fromLookup, nil)
 
 			// THEN the Data is copied when expected.
 			if tc.inheritData {

--- a/service/latest_version/types/web/query.go
+++ b/service/latest_version/types/web/query.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 
+	"github.com/release-argus/Argus/util"
 	logutil "github.com/release-argus/Argus/util/log"
 )
 
@@ -98,6 +99,9 @@ func (l *Lookup) httpRequest(logFrom logutil.LogFrom) ([]byte, error) {
 
 	// Set headers.
 	req.Header.Set("Connection", "close")
+	for _, header := range l.Headers {
+		req.Header.Set(util.EvalEnvVars(header.Key), util.EvalEnvVars(header.Value))
+	}
 
 	// Send the request.
 	client := &http.Client{Transport: customTransport}

--- a/service/latest_version/types/web/types.go
+++ b/service/latest_version/types/web/types.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/release-argus/Argus/service/latest_version/types/base"
 	opt "github.com/release-argus/Argus/service/option"
+	"github.com/release-argus/Argus/service/shared"
 	"github.com/release-argus/Argus/service/status"
 	"github.com/release-argus/Argus/util"
 )
@@ -32,7 +33,8 @@ import (
 type Lookup struct {
 	base.Lookup `json:",inline" yaml:",inline"` // Base struct for a Lookup.
 
-	AllowInvalidCerts *bool `json:"allow_invalid_certs,omitempty" yaml:"allow_invalid_certs,omitempty"` // Allow invalid SSL certificates.
+	AllowInvalidCerts *bool          `json:"allow_invalid_certs,omitempty" yaml:"allow_invalid_certs,omitempty"` // Allow invalid SSL certificates.
+	Headers           shared.Headers `json:"headers,omitempty" yaml:"headers,omitempty"`                         // OPTIONAL: request headers.
 }
 
 // New returns a new Lookup from a string in a given format (json/yaml).
@@ -89,4 +91,13 @@ func (l *Lookup) unmarshal(unmarshalFunc func(interface{}) error) error {
 	l.Type = "url"
 
 	return nil
+}
+
+// InheritSecrets will inherit secrets from the `otherLookup`.
+func (l *Lookup) InheritSecrets(otherLookup base.Interface, secretRefs *shared.VSecretRef) {
+	l.Lookup.InheritSecrets(otherLookup, secretRefs)
+
+	if otherL, ok := otherLookup.(*Lookup); ok && secretRefs != nil {
+		l.Headers.InheritSecrets(otherL.Headers, secretRefs.Headers)
+	}
 }

--- a/service/new.go
+++ b/service/new.go
@@ -35,7 +35,8 @@ import (
 // oldSecretRefs contains the indexes to use for SecretValues.
 type oldSecretRefs struct {
 	ID                    string                           `json:"id"`
-	DeployedVersionLookup shared.DVSecretRef               `json:"deployed_version,omitempty"`
+	LatestVersion         shared.VSecretRef                `json:"latest_version,omitempty"`
+	DeployedVersionLookup shared.VSecretRef                `json:"deployed_version,omitempty"`
 	Notify                map[string]shared.OldStringIndex `json:"notify,omitempty"`
 	WebHook               map[string]shared.WHSecretRef    `json:"webhook,omitempty"`
 }
@@ -44,7 +45,8 @@ type oldSecretRefs struct {
 func (o *oldSecretRefs) UnmarshalJSON(data []byte) error {
 	aux := struct {
 		ID                    string                  `json:"id"`
-		DeployedVersionLookup shared.DVSecretRef      `json:"deployed_version,omitempty"`
+		LatestVersion         shared.VSecretRef       `json:"latest_version,omitempty"`
+		DeployedVersionLookup shared.VSecretRef       `json:"deployed_version,omitempty"`
 		Notify                []shared.OldStringIndex `json:"notify,omitempty"`
 		WebHook               []shared.WHSecretRef    `json:"webhook,omitempty"`
 	}{}
@@ -151,7 +153,7 @@ func FromPayload(
 }
 
 // giveSecretsLatestVersion from the `oldLatestVersion`.
-func (s *Service) giveSecretsLatestVersion(oldLatestVersion latestver.Lookup) {
+func (s *Service) giveSecretsLatestVersion(oldLatestVersion latestver.Lookup, secretRefs *shared.VSecretRef) {
 	if s == nil || oldLatestVersion == nil {
 		return
 	}
@@ -166,11 +168,11 @@ func (s *Service) giveSecretsLatestVersion(oldLatestVersion latestver.Lookup) {
 		}
 	}
 
-	s.LatestVersion.Inherit(oldLatestVersion)
+	s.LatestVersion.InheritSecrets(oldLatestVersion, secretRefs)
 }
 
 // giveSecretsDeployedVersion from the `oldDeployedVersion`.
-func (s *Service) giveSecretsDeployedVersion(oldDeployedVersion deployedver.Lookup, secretRefs *shared.DVSecretRef) {
+func (s *Service) giveSecretsDeployedVersion(oldDeployedVersion deployedver.Lookup, secretRefs *shared.VSecretRef) {
 	if s.DeployedVersionLookup == nil || oldDeployedVersion == nil {
 		return
 	}
@@ -278,7 +280,7 @@ func (s *Service) giveSecrets(oldService *Service, secretRefs oldSecretRefs) {
 
 	// Latest Version.
 	if s.LatestVersion != nil {
-		s.giveSecretsLatestVersion(oldService.LatestVersion)
+		s.giveSecretsLatestVersion(oldService.LatestVersion, &secretRefs.LatestVersion)
 	}
 	// Deployed Version.
 	s.giveSecretsDeployedVersion(oldService.DeployedVersionLookup, &secretRefs.DeployedVersionLookup)

--- a/service/shared/headers.go
+++ b/service/shared/headers.go
@@ -1,0 +1,53 @@
+// Copyright [2025] [Argus]
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package shared provides shared functionality for Latest Version and Deployed Version lookups.
+package shared
+
+import "github.com/release-argus/Argus/util"
+
+// Header to use in a HTTP request.
+type Header struct {
+	Key   string `json:"key" yaml:"key"`     // Header key, e.g. X-Sig.
+	Value string `json:"value" yaml:"value"` // Value to give the key.
+}
+
+type Headers []Header
+
+// InheritSecrets copies secret values from otherHeaders that are referenced in secretRefs.
+func (h *Headers) InheritSecrets(otherHeaders Headers, secretRefs []OldIntIndex) {
+	// If we don't have headers in both locations.
+	if len(*h) == 0 && len(otherHeaders) == 0 {
+		return
+	}
+
+	for i := range *h {
+		// If referencing a secret of an existing header.
+		if (*h)[i].Value == util.SecretValue {
+			// Don't have a secretRef for this header.
+			if i >= len(secretRefs) {
+				break
+			}
+			oldIndex := secretRefs[i].OldIndex
+			// Not a reference to an old Header.
+			if oldIndex == nil {
+				continue
+			}
+
+			if *oldIndex < len(otherHeaders) {
+				(*h)[i].Value = otherHeaders[*oldIndex].Value
+			}
+		}
+	}
+}

--- a/service/shared/headers_test.go
+++ b/service/shared/headers_test.go
@@ -1,0 +1,213 @@
+// Copyright [2025] [Argus]
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build unit
+
+// Package shared provides shared functionality for Latest Version and Deployed Version lookups.
+package shared
+
+import (
+	"testing"
+
+	"github.com/release-argus/Argus/test"
+	"github.com/release-argus/Argus/util"
+)
+
+func TestInheritSecrets(t *testing.T) {
+	// GIVEN a set of Headers and a list of secretRefs.
+	tests := []struct {
+		name         string
+		h            Headers
+		otherHeaders Headers
+		secretRefs   []OldIntIndex
+		want         Headers
+	}{
+		{
+			name:         "no headers in either",
+			h:            Headers{},
+			otherHeaders: Headers{},
+			secretRefs:   nil,
+			want:         Headers{},
+		},
+		{
+			name: "no secrets to inherit",
+			h: Headers{
+				{Key: "X-Test", Value: "Value1"},
+				{Key: "X-Another", Value: "Value2"},
+			},
+			otherHeaders: Headers{
+				{Key: "X-Secret", Value: "SecretValue"},
+			},
+			secretRefs: []OldIntIndex{
+				{OldIndex: test.IntPtr(0)},
+			},
+			want: Headers{
+				{Key: "X-Test", Value: "Value1"},
+				{Key: "X-Another", Value: "Value2"},
+			},
+		},
+		{
+			name: "inherit secrets when valid reference",
+			h: Headers{
+				{Key: "X-Test", Value: util.SecretValue},
+			},
+			otherHeaders: Headers{
+				{Key: "X-Secret", Value: "SecretValue"},
+			},
+			secretRefs: []OldIntIndex{
+				{OldIndex: test.IntPtr(0)},
+			},
+			want: Headers{
+				{Key: "X-Test", Value: "SecretValue"},
+			},
+		},
+		{
+			name: "can't inherit secrets with nil secretRefs",
+			h: Headers{
+				{Key: "X-Test", Value: util.SecretValue},
+			},
+			otherHeaders: Headers{
+				{Key: "X-Secret", Value: "SecretValue"},
+			},
+			secretRefs: nil,
+			want: Headers{
+				{Key: "X-Test", Value: util.SecretValue},
+			},
+		},
+		{
+			name: "cam\t inherit secrets with nil OldIndex",
+			h: Headers{
+				{Key: "X-Test", Value: util.SecretValue},
+			},
+			otherHeaders: Headers{
+				{Key: "X-Secret", Value: "SecretValue"},
+			},
+			secretRefs: []OldIntIndex{
+				{OldIndex: nil},
+			},
+			want: Headers{
+				{Key: "X-Test", Value: util.SecretValue},
+			},
+		},
+		{
+			name: "can't inherit secrets when OldIndex out of range",
+			h: Headers{
+				{Key: "X-Test", Value: util.SecretValue},
+			},
+			otherHeaders: Headers{
+				{Key: "X-Secret", Value: "SecretValue"},
+			},
+			secretRefs: []OldIntIndex{
+				{OldIndex: test.IntPtr(2)},
+			},
+			want: Headers{
+				{Key: "X-Test", Value: util.SecretValue},
+			},
+		},
+		{
+			name: "inherit multiple secrets",
+			h: Headers{
+				{Key: "X-First", Value: util.SecretValue},
+				{Key: "X-Second", Value: util.SecretValue},
+				{Key: "X-Third", Value: "NotASecret"},
+			},
+			otherHeaders: Headers{
+				{Key: "X-Secret1", Value: "SecretValue1"},
+				{Key: "X-Secret2", Value: "SecretValue2"},
+			},
+			secretRefs: []OldIntIndex{
+				{OldIndex: test.IntPtr(0)},
+				{OldIndex: test.IntPtr(1)},
+				{OldIndex: test.IntPtr(2)},
+			},
+			want: Headers{
+				{Key: "X-First", Value: "SecretValue1"},
+				{Key: "X-Second", Value: "SecretValue2"},
+				{Key: "X-Third", Value: "NotASecret"},
+			},
+		},
+		{
+			name: "inherit multiple secrets in different order",
+			h: Headers{
+				{Key: "X-First", Value: util.SecretValue},
+				{Key: "X-Second", Value: util.SecretValue},
+				{Key: "X-Third", Value: util.SecretValue},
+			},
+			otherHeaders: Headers{
+				{Key: "X-Secret1", Value: "SecretValue1"},
+				{Key: "X-Secret2", Value: "SecretValue2"},
+			},
+			secretRefs: []OldIntIndex{
+				{OldIndex: test.IntPtr(1)},
+				{OldIndex: test.IntPtr(0)},
+			},
+			want: Headers{
+				{Key: "X-First", Value: "SecretValue2"},
+				{Key: "X-Second", Value: "SecretValue1"},
+				{Key: "X-Third", Value: util.SecretValue},
+			},
+		},
+		{
+			name: "extra secretRefs ignored",
+			h: Headers{
+				{Key: "X-First", Value: util.SecretValue},
+			},
+			otherHeaders: Headers{
+				{Key: "X-Secret1", Value: "SecretValue1"},
+				{Key: "X-Secret2", Value: "SecretValue2"},
+			},
+			secretRefs: []OldIntIndex{
+				{OldIndex: test.IntPtr(0)},
+				{OldIndex: test.IntPtr(1)},
+			},
+			want: Headers{
+				{Key: "X-First", Value: "SecretValue1"},
+			},
+		},
+		{
+			name: "empty secretRefs and otherHeaders",
+			h: Headers{
+				{Key: "X-First", Value: util.SecretValue},
+			},
+			otherHeaders: Headers{},
+			secretRefs:   nil,
+			want: Headers{
+				{Key: "X-First", Value: util.SecretValue},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := tc.h
+
+			// WHEN InheritSecrets is called.
+			h.InheritSecrets(tc.otherHeaders, tc.secretRefs)
+
+			// THEN the length is as expected.
+			if len(h) != len(tc.want) {
+				t.Fatalf("got %v, want %v", h, tc.want)
+			}
+			// AND the headers are as expected.
+			for i := range h {
+				if h[i] != tc.want[i] {
+					t.Errorf("%s\nindex %d: got %v, want %v",
+						packageName, i, h[i], tc.want[i])
+				}
+			}
+		})
+	}
+}

--- a/service/shared/help_test.go
+++ b/service/shared/help_test.go
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build unit
+
+// Package shared provides shared functionality for Latest Version and Deployed Version lookups.
 package shared
 
 var packageName = "service_shared"

--- a/service/shared/insertion-sort.go
+++ b/service/shared/insertion-sort.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package shared provides shared functionality for Latest Version and Deployed Version lookups.
 package shared
 
 import "sort"

--- a/service/shared/insertion-sort_test.go
+++ b/service/shared/insertion-sort_test.go
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build unit
+
+// Package shared provides shared functionality for Latest Version and Deployed Version lookups.
 package shared
 
 import (

--- a/service/shared/types.go
+++ b/service/shared/types.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package shared provides shared functionality for Latest Version and Deployed Version lookups.
 package shared
 
 // OldIntIndex to look at for any SecretValues used.
@@ -24,8 +25,8 @@ type OldStringIndex struct {
 	OldIndex string `json:"old_index,omitempty"`
 }
 
-// DVSecretRef contains the reference for the DeployedVersionLookup SecretValues.
-type DVSecretRef struct {
+// VSecretRef contains the reference for the DeployedVersionLookup SecretValues.
+type VSecretRef struct {
 	Headers []OldIntIndex `json:"headers,omitempty"`
 }
 

--- a/service/types_test.go
+++ b/service/types_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/release-argus/Argus/service/latest_version/types/github"
 	lv_web "github.com/release-argus/Argus/service/latest_version/types/web"
 	opt "github.com/release-argus/Argus/service/option"
+	"github.com/release-argus/Argus/service/shared"
 	"github.com/release-argus/Argus/service/status"
 	"github.com/release-argus/Argus/test"
 	"github.com/release-argus/Argus/util"
@@ -1349,7 +1350,7 @@ func TestService_UnmarshalJSON(t *testing.T) {
 					BasicAuth: &dv_web.BasicAuth{
 						Username: "foo",
 						Password: "bar"},
-					Headers: []dv_web.Header{
+					Headers: shared.Headers{
 						{Key: "foo", Value: "bar"},
 						{Key: "something", Value: "else"}},
 					Body:          "removed_on_verify",
@@ -1973,7 +1974,7 @@ func TestService_UnmarshalYAML(t *testing.T) {
 					BasicAuth: &dv_web.BasicAuth{
 						Username: "foo",
 						Password: "bar"},
-					Headers: []dv_web.Header{
+					Headers: shared.Headers{
 						{Key: "foo", Value: "bar"},
 						{Key: "something", Value: "else"}},
 					Body:          "removed_on_verify",

--- a/web/api/types/argus.go
+++ b/web/api/types/argus.go
@@ -435,6 +435,7 @@ type LatestVersion struct {
 	AllowInvalidCerts *bool                 `json:"allow_invalid_certs,omitempty" yaml:"allow_invalid_certs,omitempty"` // Default - false = Disallows invalid HTTPS certificates.
 	UsePreRelease     *bool                 `json:"use_prerelease,omitempty" yaml:"use_prerelease,omitempty"`           // Whether to use GitHub prereleases.
 	URLCommands       *URLCommands          `json:"url_commands,omitempty" yaml:"url_commands,omitempty"`               // Commands to filter the release from the URL request.
+	Headers           []Header              `json:"headers,omitempty" yaml:"headers,omitempty"`                         // Request Headers.
 	Require           *LatestVersionRequire `json:"require,omitempty" yaml:"require,omitempty"`                         // Requirements before treating a release as valid.
 }
 

--- a/web/ui/react-app/src/components/approvals/service.tsx
+++ b/web/ui/react-app/src/components/approvals/service.tsx
@@ -2,7 +2,7 @@ import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { useQuery } from '@tanstack/react-query';
 import { GripVertical, Pencil } from 'lucide-react';
-import { type FC, memo, useCallback, useMemo } from 'react';
+import { type FC, useCallback, useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import ServiceImage from '@/components/approvals/service-image';
 import ServiceInfo from '@/components/approvals/service-info';
@@ -179,4 +179,4 @@ const Service: FC<ServiceProps> = ({ id, editable = false }) => {
 	);
 };
 
-export default memo(Service);
+export default Service;

--- a/web/ui/react-app/src/components/approvals/toolbar/toolbar.tsx
+++ b/web/ui/react-app/src/components/approvals/toolbar/toolbar.tsx
@@ -1,3 +1,4 @@
+import type { FC } from 'react';
 import EditModeToggle from '@/components/approvals/toolbar/edit-mode-toggle';
 import FilterDropdown from '@/components/approvals/toolbar/filter-dropdown';
 import SearchBar from '@/components/approvals/toolbar/search-bar';
@@ -5,7 +6,6 @@ import TagSelect from '@/components/approvals/toolbar/tag-select';
 import ViewToggle from '@/components/approvals/toolbar/view-toggle';
 import { ButtonGroup } from '@/components/ui/button-group';
 import { TooltipProvider } from '@/components/ui/tooltip';
-import { type FC, memo } from 'react';
 
 /**
  * ApprovalsToolbar
@@ -28,4 +28,4 @@ const ApprovalsToolbar: FC = () => (
 	</div>
 );
 
-export default memo(ApprovalsToolbar);
+export default ApprovalsToolbar;

--- a/web/ui/react-app/src/components/generic/field-key-val-map.tsx
+++ b/web/ui/react-app/src/components/generic/field-key-val-map.tsx
@@ -1,5 +1,5 @@
 import { Minus, Plus } from 'lucide-react';
-import { type FC, memo, useCallback, useEffect, useMemo } from 'react';
+import { type FC, useCallback, useEffect, useMemo } from 'react';
 import { useFieldArray, useFormContext, useWatch } from 'react-hook-form';
 import FieldKeyVal from '@/components/generic/field-key-val';
 import FieldLabelWithTooltip from '@/components/generic/field-label';
@@ -130,7 +130,7 @@ const FieldKeyValMap: FC<FieldKeyValMapProps> = ({
 			>
 				{fields.map(({ id: _id }, index) => (
 					<FieldKeyVal
-						colSpan={colSpan - 1}
+						colSpan={colSpan}
 						defaults={usingDefaults ? defaults?.[index] : undefined}
 						key={_id}
 						name={`${name}.${index}`}
@@ -146,4 +146,4 @@ const FieldKeyValMap: FC<FieldKeyValMapProps> = ({
 	);
 };
 
-export default memo(FieldKeyValMap);
+export default FieldKeyValMap;

--- a/web/ui/react-app/src/components/generic/field-key-val.tsx
+++ b/web/ui/react-app/src/components/generic/field-key-val.tsx
@@ -1,5 +1,5 @@
 import { Trash2 } from 'lucide-react';
-import { type FC, memo } from 'react';
+import type { FC } from 'react';
 import { FieldText } from '@/components/generic/field';
 import type { HeaderPlaceholders } from '@/components/generic/field-shared';
 import { Button } from '@/components/ui/button';
@@ -37,8 +37,8 @@ const FieldKeyVal: FC<FieldKeyValProps> = ({
 	removeMe,
 	placeholders,
 }) => {
-	const keyColSpan = Math.round(colSpan / 2);
 	const valueColSpan = Math.floor(colSpan / 2);
+	const keyColSpan = colSpan - valueColSpan - 1;
 
 	return (
 		<>
@@ -54,7 +54,10 @@ const FieldKeyVal: FC<FieldKeyValProps> = ({
 				</Button>
 			</div>
 			<FieldGroup
-				className={cn(`col-span-${colSpan}`, 'grid grid-cols-subgrid gap-x-2')}
+				className={cn(
+					`col-span-${colSpan - 1}`,
+					'grid grid-cols-subgrid gap-x-2',
+				)}
 			>
 				<FieldText
 					colSize={{ sm: keyColSpan, xs: keyColSpan }}
@@ -75,4 +78,4 @@ const FieldKeyVal: FC<FieldKeyValProps> = ({
 	);
 };
 
-export default memo(FieldKeyVal);
+export default FieldKeyVal;

--- a/web/ui/react-app/src/components/generic/field-list.tsx
+++ b/web/ui/react-app/src/components/generic/field-list.tsx
@@ -1,5 +1,5 @@
 import { Minus, Plus } from 'lucide-react';
-import { type FC, memo, useCallback, useEffect, useMemo } from 'react';
+import { type FC, useCallback, useEffect, useMemo } from 'react';
 import { useFieldArray, useFormContext, useWatch } from 'react-hook-form';
 import { FieldLabel, FieldText } from '@/components/generic/field';
 import type { TooltipWithAriaProps } from '@/components/generic/tooltip';
@@ -136,4 +136,4 @@ const FieldList: FC<FieldListProps> = ({
 	);
 };
 
-export default memo(FieldList);
+export default FieldList;

--- a/web/ui/react-app/src/components/generic/tooltip.tsx
+++ b/web/ui/react-app/src/components/generic/tooltip.tsx
@@ -1,5 +1,5 @@
 import { QuestionMarkCircledIcon } from '@radix-ui/react-icons';
-import { type ComponentProps, type FC, type JSX, memo } from 'react';
+import type { ComponentProps, FC, JSX } from 'react';
 import Tip from '@/components/ui/tip';
 import type { TooltipContent } from '@/components/ui/tooltip';
 import type { ScreenBreakpoint } from '@/types/util';
@@ -88,4 +88,4 @@ const HelpTooltip: FC<HelpTooltipProps> = ({
 	);
 };
 
-export default memo(HelpTooltip);
+export default HelpTooltip;

--- a/web/ui/react-app/src/components/modals/service-edit/command.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/command.tsx
@@ -1,5 +1,5 @@
 import { Minus, Plus, Trash2 } from 'lucide-react';
-import { type FC, memo, useCallback } from 'react';
+import { type FC, useCallback } from 'react';
 import { useFieldArray } from 'react-hook-form';
 import { FieldText } from '@/components/generic/field';
 import { Button } from '@/components/ui/button';
@@ -97,4 +97,4 @@ const Command: FC<CommandProps> = ({ name, defaults, removeMe }) => {
 	);
 };
 
-export default memo(Command);
+export default Command;

--- a/web/ui/react-app/src/components/modals/service-edit/commands.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/commands.tsx
@@ -1,4 +1,4 @@
-import { type FC, memo, useCallback, useEffect, useMemo } from 'react';
+import { type FC, useCallback, useEffect, useMemo } from 'react';
 import { useFieldArray, useFormContext, useWatch } from 'react-hook-form';
 import Command from '@/components/modals/service-edit/command';
 import {
@@ -103,4 +103,5 @@ const EditServiceCommands: FC<EditServiceCommandsProps> = ({
 		</AccordionItem>
 	);
 };
-export default memo(EditServiceCommands);
+
+export default EditServiceCommands;

--- a/web/ui/react-app/src/components/modals/service-edit/dashboard.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/dashboard.tsx
@@ -1,6 +1,6 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { Link } from 'lucide-react';
-import { type FC, memo, useMemo } from 'react';
+import { type FC, useMemo } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { BooleanWithDefault } from '@/components/generic';
 import {
@@ -153,4 +153,4 @@ const EditServiceDashboard: FC = () => {
 	);
 };
 
-export default memo(EditServiceDashboard);
+export default EditServiceDashboard;

--- a/web/ui/react-app/src/components/modals/service-edit/deployed-version-manual.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/deployed-version-manual.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { LoaderCircle, Save } from 'lucide-react';
-import { memo, useState } from 'react';
+import { useState } from 'react';
 import { Controller, useFormContext, useWatch } from 'react-hook-form';
 import { toast } from 'sonner';
 import { FieldLabel } from '@/components/generic/field';
@@ -181,4 +181,4 @@ const DeployedVersionManual = () => {
 	);
 };
 
-export default memo(DeployedVersionManual);
+export default DeployedVersionManual;

--- a/web/ui/react-app/src/components/modals/service-edit/deployed-version-url.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/deployed-version-url.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 import { BooleanWithDefault } from '@/components/generic';
 import {
@@ -203,4 +203,4 @@ const DeployedVersionURL = () => {
 	);
 };
 
-export default memo(DeployedVersionURL);
+export default DeployedVersionURL;

--- a/web/ui/react-app/src/components/modals/service-edit/deployed-version.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/deployed-version.tsx
@@ -1,4 +1,3 @@
-import { memo } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 import { FieldSelect } from '@/components/generic/field';
 import DeployedVersionManual from '@/components/modals/service-edit/deployed-version-manual';
@@ -62,4 +61,4 @@ const EditServiceDeployedVersion = () => {
 	);
 };
 
-export default memo(EditServiceDeployedVersion);
+export default EditServiceDeployedVersion;

--- a/web/ui/react-app/src/components/modals/service-edit/latest-version-require.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/latest-version-require.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo } from 'react';
+import { useMemo } from 'react';
 import { useWatch } from 'react-hook-form';
 import { HelpTooltip } from '@/components/generic';
 import { FieldLabel, FieldSelect, FieldText } from '@/components/generic/field';
@@ -191,4 +191,4 @@ const EditServiceLatestVersionRequire = () => {
 	);
 };
 
-export default memo(EditServiceLatestVersionRequire);
+export default EditServiceLatestVersionRequire;

--- a/web/ui/react-app/src/components/modals/service-edit/latest-version-urlcommand.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/latest-version-urlcommand.tsx
@@ -1,5 +1,5 @@
 import { Trash2 } from 'lucide-react';
-import { type FC, memo } from 'react';
+import type { FC } from 'react';
 import { useWatch } from 'react-hook-form';
 import { FieldSelect } from '@/components/generic/field';
 import RenderURLCommand from '@/components/modals/service-edit/url-commands/render';
@@ -50,4 +50,4 @@ const FormURLCommand: FC<FormURLCommandProps> = ({ name, removeMe }) => {
 	);
 };
 
-export default memo(FormURLCommand);
+export default FormURLCommand;

--- a/web/ui/react-app/src/components/modals/service-edit/latest-version-urlcommands.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/latest-version-urlcommands.tsx
@@ -1,5 +1,5 @@
 import { Minus, Plus } from 'lucide-react';
-import { memo, useCallback } from 'react';
+import { useCallback } from 'react';
 import { useFieldArray } from 'react-hook-form';
 import { FieldLabel } from '@/components/generic/field';
 import FormURLCommand from '@/components/modals/service-edit/latest-version-urlcommand';
@@ -86,4 +86,4 @@ const FormURLCommands = () => {
 	);
 };
 
-export default memo(FormURLCommands);
+export default FormURLCommands;

--- a/web/ui/react-app/src/components/modals/service-edit/latest-version.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/latest-version.tsx
@@ -1,7 +1,11 @@
-import { memo, useEffect } from 'react';
+import { useEffect } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 import { BooleanWithDefault } from '@/components/generic';
-import { FieldSelect, FieldText } from '@/components/generic/field';
+import {
+	FieldKeyValMap,
+	FieldSelect,
+	FieldText,
+} from '@/components/generic/field';
 import EditServiceLatestVersionRequire from '@/components/modals/service-edit/latest-version-require';
 import FormURLCommands from '@/components/modals/service-edit/latest-version-urlcommands';
 import VersionWithLink from '@/components/modals/service-edit/version-with-link';
@@ -90,11 +94,14 @@ const EditServiceLatestVersion = () => {
 						/>
 					</>
 				) : (
-					<BooleanWithDefault
-						defaultValue={defaults?.allow_invalid_certs}
-						label="Allow Invalid Certs"
-						name={`${name}.allow_invalid_certs`}
-					/>
+					<>
+						<BooleanWithDefault
+							defaultValue={defaults?.allow_invalid_certs}
+							label="Allow Invalid Certs"
+							name={`${name}.allow_invalid_certs`}
+						/>
+						<FieldKeyValMap name={`${name}.headers`} />
+					</>
 				)}
 				<FormURLCommands />
 				<EditServiceLatestVersionRequire />
@@ -105,4 +112,4 @@ const EditServiceLatestVersion = () => {
 	);
 };
 
-export default memo(EditServiceLatestVersion);
+export default EditServiceLatestVersion;

--- a/web/ui/react-app/src/components/modals/service-edit/notifiers.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/notifiers.tsx
@@ -1,4 +1,4 @@
-import { type FC, memo, useCallback, useEffect, useMemo } from 'react';
+import { type FC, useCallback, useEffect, useMemo } from 'react';
 import { useFieldArray, useFormContext } from 'react-hook-form';
 import { createOption } from '@/components/generic/field-select-shared';
 import Notify from '@/components/modals/service-edit/notify';
@@ -105,4 +105,4 @@ const EditServiceNotifiers: FC<EditServiceNotifiersProps> = ({ loading }) => {
 	);
 };
 
-export default memo(EditServiceNotifiers);
+export default EditServiceNotifiers;

--- a/web/ui/react-app/src/components/modals/service-edit/notify-types/extra/gotify/extra.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/notify-types/extra/gotify/extra.tsx
@@ -1,5 +1,5 @@
 import { Trash2 } from 'lucide-react';
-import { type FC, memo, useEffect } from 'react';
+import { type FC, useEffect } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 import { FieldSelect } from '@/components/generic/field';
 import { AndroidAction } from '@/components/modals/service-edit/notify-types/extra/gotify/types/android-action.tsx';
@@ -101,4 +101,4 @@ const Extra: FC<ExtraProps> = ({ name, removeMe, defaults }) => {
 	);
 };
 
-export default memo(Extra);
+export default Extra;

--- a/web/ui/react-app/src/components/modals/service-edit/notify-types/extra/gotify/extras.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/notify-types/extra/gotify/extras.tsx
@@ -1,5 +1,5 @@
 import { Minus, Plus } from 'lucide-react';
-import { type FC, memo, useCallback, useEffect, useMemo } from 'react';
+import { type FC, useCallback, useEffect, useMemo } from 'react';
 import { useFieldArray, useFormContext, useWatch } from 'react-hook-form';
 import { FieldLabel } from '@/components/generic/field';
 import type { TooltipWithAriaProps } from '@/components/generic/tooltip';
@@ -145,4 +145,4 @@ const Extras: FC<ExtrasProps> = ({
 	);
 };
 
-export default memo(Extras);
+export default Extras;

--- a/web/ui/react-app/src/components/modals/service-edit/notify-types/extra/ntfy/actions/action.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/notify-types/extra/ntfy/actions/action.tsx
@@ -1,5 +1,5 @@
 import { Trash2 } from 'lucide-react';
-import { type FC, memo } from 'react';
+import type { FC } from 'react';
 import { useWatch } from 'react-hook-form';
 import { FieldSelect, FieldText } from '@/components/generic/field';
 import RenderAction from '@/components/modals/service-edit/notify-types/extra/ntfy/actions/render';
@@ -73,4 +73,4 @@ const NtfyAction: FC<NtfyActionProps> = ({ name, defaults, removeMe }) => {
 	);
 };
 
-export default memo(NtfyAction);
+export default NtfyAction;

--- a/web/ui/react-app/src/components/modals/service-edit/notify-types/extra/ntfy/actions/actions.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/notify-types/extra/ntfy/actions/actions.tsx
@@ -1,5 +1,5 @@
 import { Minus, Plus } from 'lucide-react';
-import { type FC, memo, useCallback, useEffect, useMemo } from 'react';
+import { type FC, useCallback, useEffect, useMemo } from 'react';
 import { useFieldArray, useFormContext, useWatch } from 'react-hook-form';
 import { FieldLabel } from '@/components/generic/field';
 import type { TooltipWithAriaProps } from '@/components/generic/tooltip';
@@ -172,4 +172,4 @@ const NtfyActions: FC<NtfyActionsProps> = ({
 	);
 };
 
-export default memo(NtfyActions);
+export default NtfyActions;

--- a/web/ui/react-app/src/components/modals/service-edit/notify-types/extra/ntfy/actions/render.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/notify-types/extra/ntfy/actions/render.tsx
@@ -1,4 +1,4 @@
-import { type FC, memo } from 'react';
+import type { FC } from 'react';
 import BROADCAST from '@/components/modals/service-edit/notify-types/extra/ntfy/actions/types/broadcast';
 import HTTP from '@/components/modals/service-edit/notify-types/extra/ntfy/actions/types/http';
 import VIEW from '@/components/modals/service-edit/notify-types/extra/ntfy/actions/types/view';
@@ -51,4 +51,4 @@ const RenderAction: FC<RenderTypeProps> = ({ name, targetType, defaults }) => {
 	);
 };
 
-export default memo(RenderAction);
+export default RenderAction;

--- a/web/ui/react-app/src/components/modals/service-edit/notify-types/extra/ntfy/actions/types/broadcast.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/notify-types/extra/ntfy/actions/types/broadcast.tsx
@@ -1,4 +1,4 @@
-import { type FC, memo } from 'react';
+import type { FC } from 'react';
 import {
 	FieldCheck,
 	FieldKeyValMap,
@@ -56,4 +56,4 @@ const BROADCAST: FC<BROADCASTProps> = ({ name, defaults }) => {
 	);
 };
 
-export default memo(BROADCAST);
+export default BROADCAST;

--- a/web/ui/react-app/src/components/modals/service-edit/notify-types/extra/ntfy/actions/types/http.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/notify-types/extra/ntfy/actions/types/http.tsx
@@ -1,4 +1,4 @@
-import { type FC, memo } from 'react';
+import type { FC } from 'react';
 import {
 	FieldCheck,
 	FieldKeyValMap,
@@ -79,4 +79,4 @@ const HTTP: FC<HTTPProps> = ({ name, defaults }) => {
 	);
 };
 
-export default memo(HTTP);
+export default HTTP;

--- a/web/ui/react-app/src/components/modals/service-edit/notify-types/extra/ntfy/actions/types/view.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/notify-types/extra/ntfy/actions/types/view.tsx
@@ -1,4 +1,4 @@
-import { type FC, memo } from 'react';
+import type { FC } from 'react';
 import { FieldCheck, FieldText } from '@/components/generic/field';
 import { NTFY_ACTION_TYPE } from '@/utils/api/types/config/notify/ntfy';
 import type { NtfyActionSchema } from '@/utils/api/types/config-edit/notify/types/ntfy';
@@ -46,4 +46,4 @@ const VIEW: FC<VIEWProps> = ({ name, defaults }) => {
 	);
 };
 
-export default memo(VIEW);
+export default VIEW;

--- a/web/ui/react-app/src/components/modals/service-edit/notify-types/extra/opsgenie/target.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/notify-types/extra/opsgenie/target.tsx
@@ -1,5 +1,5 @@
 import { Trash2 } from 'lucide-react';
-import { type FC, memo } from 'react';
+import type { FC } from 'react';
 import { useWatch } from 'react-hook-form';
 import { FieldSelect, FieldText } from '@/components/generic/field';
 import { Button } from '@/components/ui/button';
@@ -71,4 +71,4 @@ const OpsGenieTarget: FC<OpsGenieTargetProps> = ({
 	);
 };
 
-export default memo(OpsGenieTarget);
+export default OpsGenieTarget;

--- a/web/ui/react-app/src/components/modals/service-edit/notify-types/extra/opsgenie/targets.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/notify-types/extra/opsgenie/targets.tsx
@@ -1,5 +1,5 @@
 import { Minus, Plus } from 'lucide-react';
-import { type FC, memo, useCallback, useEffect, useMemo } from 'react';
+import { type FC, useCallback, useEffect, useMemo } from 'react';
 import { useFieldArray, useFormContext, useWatch } from 'react-hook-form';
 import { FieldLabel } from '@/components/generic/field';
 import type { TooltipWithAriaProps } from '@/components/generic/tooltip';
@@ -144,4 +144,4 @@ const OpsGenieTargets: FC<OpsGenieTargetsProps> = ({
 	);
 };
 
-export default memo(OpsGenieTargets);
+export default OpsGenieTargets;

--- a/web/ui/react-app/src/components/modals/service-edit/notify-types/render.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/notify-types/render.tsx
@@ -1,4 +1,4 @@
-import { type FC, memo, type ReactElement } from 'react';
+import type { FC, ReactElement } from 'react';
 import {
 	BARK,
 	DISCORD,
@@ -79,4 +79,4 @@ const RenderNotify = <T extends keyof NotifyTypeSchema>(props: {
 	return <Component {...rest} />;
 };
 
-export default memo(RenderNotify);
+export default RenderNotify;

--- a/web/ui/react-app/src/components/modals/service-edit/notify.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/notify.tsx
@@ -1,5 +1,5 @@
 import { Trash2 } from 'lucide-react';
-import { type FC, memo, useCallback, useEffect, useMemo } from 'react';
+import { type FC, useCallback, useEffect, useMemo } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 import { FieldSelect, FieldText } from '@/components/generic/field';
 import RenderNotify from '@/components/modals/service-edit/notify-types/render';
@@ -188,4 +188,4 @@ const Notify: FC<NotifyProps> = ({
 	);
 };
 
-export default memo(Notify);
+export default Notify;

--- a/web/ui/react-app/src/components/modals/service-edit/options.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/options.tsx
@@ -1,4 +1,3 @@
-import { memo } from 'react';
 import { BooleanWithDefault } from '@/components/generic';
 import { FieldCheck, FieldText } from '@/components/generic/field';
 import {
@@ -57,4 +56,4 @@ const EditServiceOptions = () => {
 	);
 };
 
-export default memo(EditServiceOptions);
+export default EditServiceOptions;

--- a/web/ui/react-app/src/components/modals/service-edit/root.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/root.tsx
@@ -1,5 +1,5 @@
 import { IdCard, LoaderCircle } from 'lucide-react';
-import { type FC, memo, useCallback, useEffect, useState } from 'react';
+import { type FC, useCallback, useEffect, useState } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 import { FieldText } from '@/components/generic/field';
 import type { TooltipWithAriaProps } from '@/components/generic/tooltip';
@@ -51,7 +51,7 @@ const EditServiceRoot: FC<EditServiceRootProps> = ({ loading }) => {
 
 	// biome-ignore lint/correctness/useExhaustiveDependencies: separateName stable.
 	useEffect(() => {
-		if (!originalName === separateName) {
+		if (Boolean(originalName) !== separateName) {
 			setSeparateName(!!originalName);
 		}
 	}, [originalName]);
@@ -125,4 +125,4 @@ const EditServiceRoot: FC<EditServiceRootProps> = ({ loading }) => {
 	);
 };
 
-export default memo(EditServiceRoot);
+export default EditServiceRoot;

--- a/web/ui/react-app/src/components/modals/service-edit/url-commands/render.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/url-commands/render.tsx
@@ -1,4 +1,4 @@
-import { type FC, memo } from 'react';
+import type { FC } from 'react';
 import { REGEX, REPLACE, SPLIT } from '.';
 import type { URLCommand } from '@/utils/api/types/config/service/latest-version';
 
@@ -32,4 +32,4 @@ const RenderURLCommand = ({
 	return <RenderTypeComponent name={name} />;
 };
 
-export default memo(RenderURLCommand);
+export default RenderURLCommand;

--- a/web/ui/react-app/src/utils/api/types/config-edit/service/types/latest-version.ts
+++ b/web/ui/react-app/src/utils/api/types/config-edit/service/types/latest-version.ts
@@ -8,6 +8,7 @@ import {
 	latestVersionLookupTypeOptions,
 } from '@/utils/api/types/config/service/latest-version';
 import { commandSchema } from '@/utils/api/types/config-edit/command/schemas';
+import { headersSchema } from '@/utils/api/types/config-edit/shared/header/preprocess.ts';
 import { zodStringToNumber } from '@/utils/api/types/config-edit/shared/number-string';
 import {
 	NUMBER_REQUIRED_MESSAGE,
@@ -189,6 +190,7 @@ export const latestVersionLookupSchemaGitHub =
 export const latestVersionLookupSchemaURL =
 	latestVersionLookupSchemaBase.extend({
 		allow_invalid_certs: z.boolean().nullable().default(null),
+		headers: headersSchema,
 		type: z.literal(LATEST_VERSION_LOOKUP_TYPE.URL.value),
 		url: z.string(),
 	});


### PR DESCRIPTION
- latest-version and deployed-version now properly inherit secrets on refreshes