### PR TITLE
feat(ui): error toast for failed service deletion

### DIFF
--- a/web/ui/react-app/src/components/modals/service-edit/deployed-version-manual.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/deployed-version-manual.tsx
@@ -81,7 +81,6 @@ const DeployedVersionManual = () => {
 				},
 			);
 		} catch (error) {
-			console.error('Failed to save version', error);
 			toast.error('Failed to save version:', {
 				description: mutationError?.message,
 			});

--- a/web/ui/react-app/src/components/modals/service-edit/test-notify.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/test-notify.tsx
@@ -108,9 +108,7 @@ const TestNotify: FC<TestNotifyProps> = ({ path, original, extras }) => {
 				setLastFetched(currentTime);
 				await testRefetch();
 			}
-		} catch (error) {
-			console.error('Failed to send notify:', error);
-		}
+		} catch (error) {}
 	};
 
 	// Icon for the test result.

--- a/web/ui/react-app/src/hooks/use-sortable-services.ts
+++ b/web/ui/react-app/src/hooks/use-sortable-services.ts
@@ -109,7 +109,6 @@ export const useSortableServices = () => {
 				}));
 			})
 			.catch((error: unknown) => {
-				console.error('Failed to save order:', error);
 				toast.error('Failed to save order.', {
 					description: `Error: ${error instanceof Error ? error.message : String(error)}`,
 				});

--- a/web/ui/react-app/src/modals/delete-confirm.tsx
+++ b/web/ui/react-app/src/modals/delete-confirm.tsx
@@ -38,7 +38,6 @@ export const DeleteModal: FC<DeleteModalProps> = ({ disabled }) => {
 			hideModal();
 		},
 		onError: (error) => {
-			console.error('Failed to delete service:', error);
 			toast.error('Failed to delete service.', {
 				description: `Error: ${error instanceof Error ? error.message : String(error)}`,
 			});

--- a/web/ui/react-app/src/modals/delete-confirm.tsx
+++ b/web/ui/react-app/src/modals/delete-confirm.tsx
@@ -1,5 +1,6 @@
 import { LoaderCircle } from 'lucide-react';
 import { type FC, useCallback, useState } from 'react';
+import { toast } from 'sonner';
 import {
 	AlertDialog,
 	AlertDialogAction,
@@ -35,6 +36,12 @@ export const DeleteModal: FC<DeleteModalProps> = ({ disabled }) => {
 		onSettled: () => {
 			setOpen(false);
 			hideModal();
+		},
+		onError: (error) => {
+			console.error('Failed to delete service:', error);
+			toast.error('Failed to delete service.', {
+				description: `Error: ${error instanceof Error ? error.message : String(error)}`,
+			});
 		},
 	});
 


### PR DESCRIPTION
Noticed that I'd added this toast for save fails in 0.28.1 (#727), but forgot about delete fails!
<img width="695" height="308" alt="image" src="https://github.com/user-attachments/assets/e62ea927-9a65-4423-ae99-2dd4c940fecc" />

Also cleanup duplicate console error logging on notify sends, manual version saves, and order saves

> draft whilst I'm refactoring (separate branch) struct creation to handle types being in the defaults (#583). With that I've also split out the docker registries into their own struct, so should be able to add in support for ECR (#546) *quite* simply once I've got all the tests setup for these Docker structs