### PR TITLE
fix(command): use candidate version in `require.command` templates

### DIFF
--- a/command/types_test.go
+++ b/command/types_test.go
@@ -121,9 +121,7 @@ func TestController_CopyFailsFrom(t *testing.T) {
 						tc.from.ServiceStatus.Fails.Command.Set(k, *v)
 					}
 				}
-				for i, v := range tc.fromNextRunnable {
-					tc.from.nextRunnable[i] = v
-				}
+				copy(tc.from.nextRunnable, tc.fromNextRunnable)
 			}
 			if tc.to != nil && tc.to.Command != nil {
 				tc.to.Init(

--- a/service/latest_version/filter/command.go
+++ b/service/latest_version/filter/command.go
@@ -22,13 +22,15 @@ import (
 )
 
 // ExecCommand will run Command.
-func (r *Require) ExecCommand(logFrom logutil.LogFrom) error {
+func (r *Require) ExecCommand(version string, logFrom logutil.LogFrom) error {
 	if r == nil || len(r.Command) == 0 {
 		return nil
 	}
 
 	// Apply the template vars to the command.
-	cmd := r.Command.ApplyTemplate(r.Status.GetServiceInfo())
+	serviceInfo := r.Status.GetServiceInfo()
+	serviceInfo.LatestVersion = version
+	cmd := r.Command.ApplyTemplate(serviceInfo)
 
 	// Execute the command.
 	if err := cmd.Exec(logFrom); err != nil {

--- a/service/latest_version/types/github/query.go
+++ b/service/latest_version/types/github/query.go
@@ -405,7 +405,7 @@ func (l *Lookup) releaseMeetsRequirements(release github_types.Release, logFrom 
 	}
 
 	// If the Command didn't return successfully.
-	if err := l.Require.ExecCommand(logFrom); err != nil {
+	if err := l.Require.ExecCommand(version, logFrom); err != nil {
 		return "", "", err //nolint:wrapcheck
 	}
 

--- a/service/latest_version/types/web/query.go
+++ b/service/latest_version/types/web/query.go
@@ -179,7 +179,7 @@ func (l *Lookup) versionMeetsRequirements(version, body string, logFrom logutil.
 	}
 
 	// If the Command didn't return successfully.
-	if err := l.Require.ExecCommand(logFrom); err != nil {
+	if err := l.Require.ExecCommand(version, logFrom); err != nil {
 		return err //nolint:wrapcheck
 	}
 


### PR DESCRIPTION
Forgot to give `latest_version.require.command` checks on new version candidates the version of that candidate, so it was using the previous version.

e.g. latest_version = 1.0.0

query finds 1.0.1

`latest_version.require.command` = ["echo", "{{ version }}"]
did give 'echo 1.0.0'
now gives 'echo 1.0.1'