### PR TITLE
fix(ui): ignore `<secret>` placeholder in string length validation

### DIFF
--- a/web/ui/react-app/src/utils/api/types/config-edit/validators.ts
+++ b/web/ui/react-app/src/utils/api/types/config-edit/validators.ts
@@ -10,6 +10,7 @@ import { isEmptyOrNull } from '@/utils';
 import { addZodIssuesToContext } from '@/utils/api/types/config-edit/shared/add-issues.ts';
 import { safeParse } from '@/utils/api/types/config-edit/shared/safeparse.ts';
 import { isEmpty } from '@/utils/is-empty';
+import { SecretValue } from '@/utils/secret-value';
 
 /* Field validation */
 
@@ -193,6 +194,7 @@ export const validateStringLength =
 		if (
 			arg &&
 			typeof arg === 'string' &&
+			arg !== SecretValue &&
 			(arg.length < min || arg.length > max)
 		) {
 			ctx.addIssue({

--- a/web/ui/react-app/src/utils/secret-value.ts
+++ b/web/ui/react-app/src/utils/secret-value.ts
@@ -1,0 +1,2 @@
+/* Value representing a secret returned from the API */
+export const SecretValue = '<secret>';


### PR DESCRIPTION
`Teams` has validaion for 32-character UUID string lengths (though we just allow alphanumberic of 32-36 to allow for `-`'s)

When you have a Teams notifier saved, the API will return `<secret>` as the field value. This validation would then fail as `<secret>` is less than 32 characters :/. So I've changed the validation to allow `<secret>`