### PR TITLE
refactor: replace WriteString(fmt.Sprintf(...)) with fmt.Fprintf

### DIFF
--- a/notify/shoutrrr/shoutrrr.go
+++ b/notify/shoutrrr/shoutrrr.go
@@ -387,8 +387,8 @@ func jsonMapToString(param string, prefix string) string {
 			builder.WriteString("&")
 		}
 
-		builder.WriteString(fmt.Sprintf("%s%s=%s",
-			prefix, key, jsonMap[key]))
+		_, _ = fmt.Fprintf(&builder, "%s%s=%s",
+			prefix, key, jsonMap[key])
 	}
 	return builder.String()
 }

--- a/notify/shoutrrr/types.go
+++ b/notify/shoutrrr/types.go
@@ -100,8 +100,8 @@ func (s *ShoutrrrsDefaults) String(prefix string) string {
 			if itemStr == "{}\n" {
 				delim = " "
 			}
-			builder.WriteString(fmt.Sprintf("%s%s:%s%s",
-				prefix, k, delim, itemStr))
+			_, _ = fmt.Fprintf(&builder, "%s%s:%s%s",
+				prefix, k, delim, itemStr)
 		}
 	}
 

--- a/service/latest_version/filter/docker.go
+++ b/service/latest_version/filter/docker.go
@@ -125,27 +125,27 @@ func (d *DockerCheckDefaults) String(prefix string) string {
 
 	var builder strings.Builder
 	if d.Type != "" {
-		builder.WriteString(fmt.Sprintf("%stype: %s\n",
-			prefix, d.Type))
+		_, _ = fmt.Fprintf(&builder, "%stype: %s\n",
+			prefix, d.Type)
 	}
 
 	if d.RegistryGHCR != nil {
 		registryGHCRStr := d.RegistryGHCR.String(prefix + "    ")
 		if registryGHCRStr != "" {
-			builder.WriteString(fmt.Sprintf("%sghcr:\n%s",
-				prefix, registryGHCRStr))
+			_, _ = fmt.Fprintf(&builder, "%sghcr:\n%s",
+				prefix, registryGHCRStr)
 		}
 	}
 	registryHubStr := d.RegistryHub.String(prefix + "    ")
 	if registryHubStr != "" {
-		builder.WriteString(fmt.Sprintf("%shub:\n%s",
-			prefix, registryHubStr))
+		_, _ = fmt.Fprintf(&builder, "%shub:\n%s",
+			prefix, registryHubStr)
 	}
 	if d.RegistryQuay != nil {
 		registryQuayStr := d.RegistryQuay.String(prefix + "    ")
 		if registryQuayStr != "" {
-			builder.WriteString(fmt.Sprintf("%squay:\n%s",
-				prefix, registryQuayStr))
+			_, _ = fmt.Fprintf(&builder, "%squay:\n%s",
+				prefix, registryQuayStr)
 		}
 	}
 

--- a/service/latest_version/filter/docker_test.go
+++ b/service/latest_version/filter/docker_test.go
@@ -1668,7 +1668,7 @@ func TestRequire_DockerTagCheck(t *testing.T) {
 			require := Require{Docker: tc.dockerCheck}
 
 			// WHEN DockerTagCheck is called on it.
-			err := require.DockerTagCheck("0.23.0")
+			err := require.DockerTagCheck("0.29.0")
 
 			// THEN the err is what we expect.
 			e := util.ErrorToString(err)

--- a/service/status/fails.go
+++ b/service/status/fails.go
@@ -111,8 +111,8 @@ func (f *failsBase) String(prefix string) string {
 		if f.fails[key] != nil {
 			val = strconv.FormatBool(*f.fails[key])
 		}
-		builder.WriteString(fmt.Sprintf("%s%s: %s\n",
-			prefix, key, val))
+		_, _ = fmt.Fprintf(&builder, "%s%s: %s\n",
+			prefix, key, val)
 	}
 
 	return builder.String()
@@ -197,8 +197,8 @@ func (f *FailsCommand) String(prefix string) string {
 			val = strconv.FormatBool(*fail)
 		}
 
-		builder.WriteString(fmt.Sprintf("%s- %d: %s\n",
-			prefix, i, val))
+		_, _ = fmt.Fprintf(&builder, "%s- %d: %s\n",
+			prefix, i, val)
 	}
 
 	return builder.String()
@@ -246,18 +246,18 @@ func (f *Fails) String(prefix string) string {
 	itemPrefix := prefix + "  "
 
 	if shoutrrrStr := f.Shoutrrr.String(itemPrefix); shoutrrrStr != "" {
-		builder.WriteString(fmt.Sprintf("%sshoutrrr:\n%s",
-			prefix, shoutrrrStr))
+		_, _ = fmt.Fprintf(&builder, "%sshoutrrr:\n%s",
+			prefix, shoutrrrStr)
 	}
 
 	if commandStr := f.Command.String(itemPrefix); commandStr != "" {
-		builder.WriteString(fmt.Sprintf("%scommand:\n%s",
-			prefix, commandStr))
+		_, _ = fmt.Fprintf(&builder, "%scommand:\n%s",
+			prefix, commandStr)
 	}
 
 	if webhookStr := f.WebHook.String(itemPrefix); webhookStr != "" {
-		builder.WriteString(fmt.Sprintf("%swebhook:\n%s",
-			prefix, webhookStr))
+		_, _ = fmt.Fprintf(&builder, "%swebhook:\n%s",
+			prefix, webhookStr)
 	}
 
 	if builder.Len() == 0 {

--- a/service/status/status.go
+++ b/service/status/status.go
@@ -204,21 +204,18 @@ func (s *Status) String() string {
 		switch v := f.Value.(type) {
 		case string:
 			if v != "" {
-				builder.WriteString(
-					fmt.Sprintf("%s: %v\n",
-						f.Name, v))
+				_, _ = fmt.Fprintf(&builder, "%s: %v\n",
+					f.Name, v)
 			}
 		case uint:
 			if v != 0 {
-				builder.WriteString(
-					fmt.Sprintf("%s: %d\n",
-						f.Name, v))
+				_, _ = fmt.Fprintf(&builder, "%s: %d\n",
+					f.Name, v)
 			}
 		case *Fails:
 			if fails := v.String("  "); fails != "" {
-				builder.WriteString(
-					fmt.Sprintf("%s:\n%s",
-						f.Name, fails))
+				_, _ = fmt.Fprintf(&builder, "%s:\n%s",
+					f.Name, fails)
 			}
 		}
 	}

--- a/webhook/types.go
+++ b/webhook/types.go
@@ -122,8 +122,8 @@ func (whd *WebHooksDefaults) String(prefix string) string {
 			if itemStr == "{}\n" {
 				delim = " "
 			}
-			builder.WriteString(fmt.Sprintf("%s%s:%s%s",
-				prefix, k, delim, itemStr))
+			_, _ = fmt.Fprintf(&builder, "%s%s:%s%s",
+				prefix, k, delim, itemStr)
 		}
 	}
 


### PR DESCRIPTION
Use fmt.Fprintf to write directly to the builder instead of WriteString(fmt.Sprintf(...)) to satisfy staticcheck QF1012 and avoid unnecessary string allocation