### PR TITLE
fix(ui): include 'old_index' on webhook edits for secret refs

### DIFF
--- a/web/ui/package-lock.json
+++ b/web/ui/package-lock.json
@@ -5562,20 +5562,6 @@
 				}
 			}
 		},
-		"node_modules/vite-tsconfig-paths/node_modules/typescript": {
-			"version": "5.9.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-			"extraneous": true,
-			"license": "Apache-2.0",
-			"bin": {
-				"tsc": "bin/tsc",
-				"tsserver": "bin/tsserver"
-			},
-			"engines": {
-				"node": ">=14.17"
-			}
-		},
 		"node_modules/yallist": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",

--- a/web/ui/react-app/src/utils/api/types/config-edit/notify/form/builder.ts
+++ b/web/ui/react-app/src/utils/api/types/config-edit/notify/form/builder.ts
@@ -440,7 +440,6 @@ export const buildNotifySchemaWithFallbacks = (
 				type: itemType,
 			},
 			fallback: {
-				old_index: item.name,
 				type: defaultType,
 			},
 			path: path,

--- a/web/ui/react-app/src/utils/api/types/config-edit/webhook/form/builder.ts
+++ b/web/ui/react-app/src/utils/api/types/config-edit/webhook/form/builder.ts
@@ -87,10 +87,16 @@ export const buildWebHooksSchemaWithFallbacks = (
 		const nameLower = item.name.toLowerCase();
 		const itemType =
 			main?.type ?? (isWebHookType(nameLower) ? nameLower : defaultType);
+		const itemHeaders = (item?.headers ?? []).map((h, i) => ({
+			...h,
+			old_index: i,
+		}));
 
 		return safeParse({
 			data: {
 				...item,
+				headers: itemHeaders,
+				old_index: item.name,
 				type: itemType,
 			},
 			fallback: {


### PR DESCRIPTION
webhooks and webhook headers weren't including `old_index` on edit API requests, so `<secret>` values couldn't be resolved and were lost