### PR TITLE
feat(web): auth /ws via short-lived token when basic auth is enabled

### DIFF
--- a/notify/shoutrrr/verify.go
+++ b/notify/shoutrrr/verify.go
@@ -1086,8 +1086,7 @@ func (b *Base) validateParamSelect(key string, allowed []string) error {
 // The address may optionally include a URL scheme.
 // If the address cannot be parsed, it is returned unchanged with an empty port.
 func parseHostPort(input string) (string, string) {
-	address := input
-	address = strings.TrimSpace(address)
+	address := strings.TrimSpace(input)
 	// Add scheme if missing (required for net/url).
 	if !strings.Contains(address, "://") {
 		address = "https://" + address

--- a/web/api/types/http.go
+++ b/web/api/types/http.go
@@ -30,6 +30,11 @@ type RefreshAPI struct {
 	Date    time.Time `json:"timestamp"`
 }
 
+// WebSocketTokenAPI is the response given at the /api/v1/ws-token endpoint.
+type WebSocketTokenAPI struct {
+	Token string `json:"token"`
+}
+
 // Response is a generic API response body.
 type Response struct {
 	Error   string `json:"error,omitempty"`

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -42,6 +42,10 @@ type API struct {
 	// take it is rejected with 409. Entries are reference-counted and removed once
 	// no request holds or is waiting on them.
 	serviceOps map[string]*serviceOp
+
+	// wsTokens is non-nil only when Basic Auth is enabled; SetupWebSocket
+	// uses it to gate the "/ws" handshake with a short-lived token.
+	wsTokens *webSocketTokenStore
 }
 
 // serviceOp is a reference-counted per-service operation lock.
@@ -51,7 +55,8 @@ type serviceOp struct {
 }
 
 // NewAPI creates a new API with the provided config.
-func NewAPI(cfg *config.Config) *API {
+// The returned *mux.Route is the "/ws" slot on BaseRouter, sitting outside of basic auth.
+func NewAPI(cfg *config.Config) (*API, *mux.Route) {
 	baseRouter := mux.NewRouter().StrictSlash(true)
 	routePrefix := cfg.Settings.WebRoutePrefix()
 
@@ -73,19 +78,22 @@ func NewAPI(cfg *config.Config) *API {
 			),
 		)
 
+	wsRoute := baseRouter.Path(routePrefix + "/ws")
+
 	api.Router = baseRouter.PathPrefix(routePrefix).Subrouter().StrictSlash(true)
 
 	baseRouter.Handle(
 		routePrefix,
 		http.RedirectHandler(routePrefix+"/", http.StatusPermanentRedirect),
 	)
-	// Add basic auth middleware.
+	// Add basic auth middleware (and a token store for the /ws route).
 	if api.Config.Settings.Web.BasicAuth != nil ||
 		api.Config.Settings.FromFlags.Web.BasicAuth != nil ||
 		api.Config.Settings.HardDefaults.Web.BasicAuth != nil {
+		api.wsTokens = newWebSocketTokenStore()
 		api.Router.Use(api.basicAuthMiddleware())
 	}
-	return api
+	return api, wsRoute
 }
 
 // acquireServiceOp returns serviceID's operation lock, creating it on first use,

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -94,7 +94,7 @@ func TestNewAPI(t *testing.T) {
 				tc.routePrefix = strings.TrimSuffix(tc.routePrefix, "/")
 
 				// WHEN: a new API is created.
-				api := NewAPI(cfg)
+				api, _ := NewAPI(cfg)
 
 				// THEN: the healthcheck endpoint is accessible.
 				req, _ := http.NewRequest(

--- a/web/api/v1/http-api-status.go
+++ b/web/api/v1/http-api-status.go
@@ -25,6 +25,30 @@ import (
 	apitype "github.com/release-argus/Argus/web/api/types"
 )
 
+// httpWebSocketToken issues a short-lived, single-use token for authenticating
+// the "/ws" WebSocket handshake.
+//
+// Safari/WebKit doesn't forward cached HTTP Basic Auth credentials on
+// WebSocket handshake requests, so when Basic Auth is configured, clients
+// fetch a token from this (Basic Auth protected) endpoint and pass it as a
+// "token" query parameter when connecting to "/ws".
+func (api *API) httpWebSocketToken(w http.ResponseWriter, r *http.Request) {
+	if api.wsTokens == nil {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	logFrom := logx.LogFrom{Primary: "httpWebSocketToken", Secondary: getIP(r)}
+
+	api.writeJSON(
+		w,
+		apitype.WebSocketTokenAPI{
+			Token: api.wsTokens.New(),
+		},
+		logFrom,
+	)
+}
+
 // httpRuntimeInfo returns runtime info about the server.
 func (api *API) httpRuntimeInfo(w http.ResponseWriter, r *http.Request) {
 	logFrom := logx.LogFrom{Primary: "httpBuildInfo", Secondary: getIP(r)}

--- a/web/api/v1/http-api-status_test.go
+++ b/web/api/v1/http-api-status_test.go
@@ -25,9 +25,78 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/release-argus/Argus/config/decode"
 	"github.com/release-argus/Argus/internal/test"
 	"github.com/release-argus/Argus/util"
 )
+
+func TestHTTP_HTTPWebSocketToken(t *testing.T) {
+	prefix := fmt.Sprintf("%q\nAPI.httpWebSocketToken()", packageName)
+	file := filepath.Join(t.TempDir(), "config.yml")
+
+	t.Run("no basic auth returns 204", func(t *testing.T) {
+		// GIVEN: an API without Basic Auth (wsTokens is nil).
+		api := testAPI(t, file)
+
+		// WHEN: a request is made for a WebSocket token.
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/ws-token", nil)
+		w := httptest.NewRecorder()
+		api.httpWebSocketToken(w, req)
+		res := w.Result()
+		t.Cleanup(func() { _ = res.Body.Close() })
+
+		// THEN: 204 is returned (no token needed, Basic Auth not configured).
+		if res.StatusCode != http.StatusNoContent {
+			t.Errorf(
+				"%s\nstatus code mismatch\ngot:  %d\nwant: %d",
+				prefix, res.StatusCode, http.StatusNoContent,
+			)
+		}
+	})
+
+	t.Run("with basic auth returns token", func(t *testing.T) {
+		// GIVEN: an API with Basic Auth (wsTokens set).
+		api := testAPI(t, file)
+		api.wsTokens = newWebSocketTokenStore()
+		bodyRegex := test.TrimJSON(`{"token":"[a-z0-9]{`+fmt.Sprint(webSocketTokenLength)+`}"}`) + "\n$"
+
+		// WHEN: a request is made for a WebSocket token.
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/ws-token", nil)
+		w := httptest.NewRecorder()
+		api.httpWebSocketToken(w, req)
+		res := w.Result()
+		t.Cleanup(func() { _ = res.Body.Close() })
+
+		// THEN: a token matching the expected format is returned.
+		data, err := io.ReadAll(res.Body)
+		if err != nil {
+			t.Fatalf(
+				"%s unexpected error:\n%v",
+				prefix, err,
+			)
+		}
+		if got := string(data); !util.RegexCheck(bodyRegex, got) {
+			t.Errorf(
+				"%s body mismatch\ngot:  %q\nwant: %q",
+				prefix, got, bodyRegex,
+			)
+		}
+
+		// AND: the returned token validates successfully against the store.
+		var tokenResp struct {
+			Token string `json:"token"`
+		}
+		if err := decode.Unmarshal("json", data, &tokenResp); err != nil {
+			t.Fatalf("%s failed to unmarshal response: %v", prefix, err)
+		}
+		if !api.wsTokens.Validate(tokenResp.Token) {
+			t.Errorf(
+				"%s returned token %q did not validate against the store",
+				prefix, tokenResp.Token,
+			)
+		}
+	})
+}
 
 func TestHTTP_HTTPRuntimeInfo(t *testing.T) {
 	// GIVEN: an API and a request for the runtime info.

--- a/web/api/v1/http-api-status_test.go
+++ b/web/api/v1/http-api-status_test.go
@@ -25,77 +25,139 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/release-argus/Argus/config"
 	"github.com/release-argus/Argus/config/decode"
 	"github.com/release-argus/Argus/internal/test"
 	"github.com/release-argus/Argus/util"
 )
 
 func TestHTTP_HTTPWebSocketToken(t *testing.T) {
+	// GIVEN: an API without Basic Auth (wsTokens is nil).
 	prefix := fmt.Sprintf("%q\nAPI.httpWebSocketToken()", packageName)
 	file := filepath.Join(t.TempDir(), "config.yml")
+	api := testAPI(t, file)
 
-	t.Run("no basic auth returns 204", func(t *testing.T) {
-		// GIVEN: an API without Basic Auth (wsTokens is nil).
-		api := testAPI(t, file)
+	// WHEN: a request is made for a WebSocket token.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/ws-token", nil)
+	w := httptest.NewRecorder()
+	api.httpWebSocketToken(w, req)
+	res := w.Result()
+	t.Cleanup(func() { _ = res.Body.Close() })
 
-		// WHEN: a request is made for a WebSocket token.
-		req := httptest.NewRequest(http.MethodGet, "/api/v1/ws-token", nil)
-		w := httptest.NewRecorder()
-		api.httpWebSocketToken(w, req)
-		res := w.Result()
-		t.Cleanup(func() { _ = res.Body.Close() })
+	// THEN: 204 is returned (no token needed, Basic Auth not configured).
+	if res.StatusCode != http.StatusNoContent {
+		t.Errorf(
+			"%s\nstatus code mismatch\ngot:  %d\nwant: %d",
+			prefix, res.StatusCode, http.StatusNoContent,
+		)
+	}
+}
 
-		// THEN: 204 is returned (no token needed, Basic Auth not configured).
-		if res.StatusCode != http.StatusNoContent {
-			t.Errorf(
-				"%s\nstatus code mismatch\ngot:  %d\nwant: %d",
-				prefix, res.StatusCode, http.StatusNoContent,
-			)
-		}
-	})
+func TestHTTP_HTTPWebSocketToken__AuthGated(t *testing.T) {
+	// GIVEN: an API with Basic Auth, routed through SetupRoutesAPI so that
+	// "/api/v1/ws-token" sits behind the basic-auth middleware.
+	cfg := config.Config{}
+	cfg.Settings.Web.BasicAuth = &config.WebSettingsBasicAuth{
+		Username: "test", Password: "123",
+	}
+	cfg.Settings.Web.BasicAuth.CheckValues()
+	api, _ := NewAPI(&cfg)
+	api.SetupRoutesAPI()
+	ts := httptest.NewServer(api.BaseRouter)
+	t.Cleanup(ts.Close)
 
-	t.Run("with basic auth returns token", func(t *testing.T) {
-		// GIVEN: an API with Basic Auth (wsTokens set).
-		api := testAPI(t, file)
-		api.wsTokens = newWebSocketTokenStore()
-		bodyRegex := test.TrimJSON(`{"token":"[a-z0-9]{`+fmt.Sprint(webSocketTokenLength)+`}"}`) + "\n$"
+	tokenURL := ts.URL + "/api/v1/ws-token"
 
-		// WHEN: a request is made for a WebSocket token.
-		req := httptest.NewRequest(http.MethodGet, "/api/v1/ws-token", nil)
-		w := httptest.NewRecorder()
-		api.httpWebSocketToken(w, req)
-		res := w.Result()
-		t.Cleanup(func() { _ = res.Body.Close() })
+	tests := map[string]struct {
+		authHeader       string // raw "Authorization" header value ("" to omit it).
+		wantUnauthorized bool
+	}{
+		"rejects request without basic auth": {
+			authHeader:       "",
+			wantUnauthorized: true,
+		},
+		"rejects request with invalid basic auth": {
+			authHeader:       "Basic dGVzdDp3cm9uZw==", // "test:wrong".
+			wantUnauthorized: true,
+		},
+		"issues a token with valid basic auth": {
+			authHeader:       "Basic dGVzdDoxMjM=", // "test:123".
+			wantUnauthorized: false,
+		},
+	}
 
-		// THEN: a token matching the expected format is returned.
-		data, err := io.ReadAll(res.Body)
-		if err != nil {
-			t.Fatalf(
-				"%s unexpected error:\n%v",
-				prefix, err,
-			)
-		}
-		if got := string(data); !util.RegexCheck(bodyRegex, got) {
-			t.Errorf(
-				"%s body mismatch\ngot:  %q\nwant: %q",
-				prefix, got, bodyRegex,
-			)
-		}
+	prefix := fmt.Sprintf("%q\nAPI.httpWebSocketToken() (auth-gated)", packageName)
 
-		// AND: the returned token validates successfully against the store.
-		var tokenResp struct {
-			Token string `json:"token"`
-		}
-		if err := decode.Unmarshal("json", data, &tokenResp); err != nil {
-			t.Fatalf("%s failed to unmarshal response: %v", prefix, err)
-		}
-		if !api.wsTokens.Validate(tokenResp.Token) {
-			t.Errorf(
-				"%s returned token %q did not validate against the store",
-				prefix, tokenResp.Token,
-			)
-		}
-	})
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			// WHEN: "/ws-token" is requested with the given credentials.
+			req, err := http.NewRequest(http.MethodGet, tokenURL, nil)
+			if err != nil {
+				t.Fatalf(
+					"%s request creation failed - %v",
+					prefix, err,
+				)
+			}
+			if tc.authHeader != "" {
+				req.Header.Set("Authorization", tc.authHeader)
+			}
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf(
+					"%s request 'Do' failed - %v",
+					prefix, err,
+				)
+			}
+			t.Cleanup(func() { _ = resp.Body.Close() })
+
+			wantStatusCode := http.StatusOK
+			if tc.wantUnauthorized {
+				wantStatusCode = http.StatusUnauthorized
+			}
+			// THEN: the basic-auth middleware rejects unauthenticated/invalid credential requests
+			// with 401, and a correctly authenticated request passes the middleware.
+			if resp.StatusCode != wantStatusCode {
+				t.Fatalf(
+					"%s status code mismatch\ngot:  %d\nwant: %d",
+					prefix, resp.StatusCode, wantStatusCode,
+				)
+			}
+			// Rejected requests carry no token body to validate.
+			if tc.wantUnauthorized {
+				return
+			}
+
+			// AND: the body is a well-formed token that validates against the store.
+			data, err := io.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatalf(
+					"%s unexpected error:\n%v",
+					prefix, err,
+				)
+			}
+			bodyRegex := fmt.Sprintf(`{"token":"[a-z0-9]{%d}"}`+"\n$", webSocketTokenLength)
+			if got := string(data); !util.RegexCheck(bodyRegex, got) {
+				t.Errorf(
+					"%s body mismatch\ngot:  %q\nwant: %q",
+					prefix, got, bodyRegex,
+				)
+			}
+			var tokenResp struct {
+				Token string `json:"token"`
+			}
+			if err := decode.Unmarshal("json", data, &tokenResp); err != nil {
+				t.Fatalf("%s failed to unmarshal response: %v", prefix, err)
+			}
+			if !api.wsTokens.Validate(tokenResp.Token) {
+				t.Errorf(
+					"%s returned token %q did not validate against the store",
+					prefix, tokenResp.Token,
+				)
+			}
+		})
+	}
 }
 
 func TestHTTP_HTTPRuntimeInfo(t *testing.T) {

--- a/web/api/v1/http.go
+++ b/web/api/v1/http.go
@@ -40,7 +40,7 @@ func (api *API) SetupRoutesAPI() {
 
 	// Only if VERBOSE or DEBUG.
 	if logx.Level() >= 3 {
-		// Apply loggerMiddleware to only the /api/v1 routes.
+		// Apply loggerMiddleware to only the "/api/v1" routes.
 		v1Router.Use(loggerMiddleware)
 	}
 
@@ -53,6 +53,8 @@ func (api *API) SetupRoutesAPI() {
 	v1Router.HandleFunc("/status/runtime", api.httpRuntimeInfo).Methods(http.MethodGet)
 	//   GET, build info.
 	v1Router.HandleFunc("/version", api.httpVersion).Methods(http.MethodGet)
+	//   GET, short-lived token for authenticating the "/ws" WebSocket handshake (only used when basic_auth is enabled).
+	v1Router.HandleFunc("/ws-token", api.httpWebSocketToken).Methods(http.MethodGet)
 	// /flags
 	//   GET, flags.
 	v1Router.HandleFunc("/flags", api.httpFlags).Methods(http.MethodGet)
@@ -149,6 +151,23 @@ func (api *API) DisableRoutes() {
 		})
 
 		return nil
+	})
+}
+
+// SetupWebSocket fills the handler for the "/ws" route.
+// The route must be outside the basic-auth subrouter because Safari/WebKit
+// doesn't forward cached credentials on WebSocket handshakes.
+// When Basic Auth is enabled the client instead passes a short-lived token
+// as a query parameter.
+func (api *API) SetupWebSocket(hub *Hub, wsRoute *mux.Route) {
+	wsRoute.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if api.wsTokens != nil && !api.wsTokens.Validate(r.URL.Query().Get("token")) {
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Connection", "keep-alive")
+		defer r.Body.Close()
+		ServeWs(hub, w, r)
 	})
 }
 

--- a/web/api/v1/http_test.go
+++ b/web/api/v1/http_test.go
@@ -261,7 +261,7 @@ func TestHTTP_SetupRoutesAPI__disableRoutes(t *testing.T) {
 						routePrefix = "/test"
 						cfg.Settings.Web.RoutePrefix = routePrefix
 					}
-					api := NewAPI(cfg)
+					api, _ := NewAPI(cfg)
 					api.SetupRoutesAPI()
 					ts := httptest.NewServer(api.Router)
 					ts.Config.Handler = api.Router
@@ -387,7 +387,7 @@ func TestHTTP_SetupRoutesNodeJS(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := config_test.BareConfig(t, true)
-			api := NewAPI(cfg)
+			api, _ := NewAPI(cfg)
 			api.SetupRoutesNodeJS()
 			ts := httptest.NewServer(api.Router)
 			t.Cleanup(ts.Close)
@@ -456,7 +456,7 @@ func TestHTTP_SetupRoutesFavicon(t *testing.T) {
 
 			cfg := config_test.BareConfig(t, true)
 			cfg.Settings.Web.Favicon = testFaviconSettings(tc.urlPNG, tc.urlSVG)
-			api := NewAPI(cfg)
+			api, _ := NewAPI(cfg)
 			api.SetupRoutesFavicon()
 			ts := httptest.NewServer(api.Router)
 			t.Cleanup(ts.Close)
@@ -524,6 +524,111 @@ func TestHTTP_SetupRoutesFavicon(t *testing.T) {
 					"%s - redirect mismatch\ngot:  %s\nwant: %s",
 					prefix, got, tc.urlSVG,
 				)
+			}
+		})
+	}
+}
+
+func TestAPI_SetupWebSocket(t *testing.T) {
+	tests := map[string]struct {
+		basicAuth        bool
+		staticToken      string // literal '?token=X' value.
+		mintToken        bool   // mint a fresh token from wsTokens and use it.
+		wantUnauthorized bool
+	}{
+		"no basic auth, no token": {
+			basicAuth:        false,
+			wantUnauthorized: false,
+		},
+		"basic auth/no token": {
+			basicAuth:        true,
+			wantUnauthorized: true,
+		},
+		"basic auth/invalid token": {
+			basicAuth:        true,
+			staticToken:      "not-a-real-token",
+			wantUnauthorized: true,
+		},
+		"basic auth/valid token": {
+			basicAuth:        true,
+			mintToken:        true,
+			wantUnauthorized: false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			// GIVEN: an API with/without Basic Auth configured.
+			cfg := config.Config{}
+			if tc.basicAuth {
+				cfg.Settings.Web.BasicAuth = &config.WebSettingsBasicAuth{
+					Username: "test", Password: "123",
+				}
+				cfg.Settings.Web.BasicAuth.CheckValues()
+			}
+			api, wsRoute := NewAPI(&cfg)
+			api.SetupWebSocket(NewHub(), wsRoute)
+			ts := httptest.NewServer(api.BaseRouter)
+			t.Cleanup(ts.Close)
+
+			// AND: a request to the WebSocket endpoint.
+			token := tc.staticToken
+			if tc.mintToken {
+				token = api.wsTokens.New()
+			}
+			wsURL := ts.URL + "/ws"
+			if token != "" {
+				wsURL += "?token=" + token
+			}
+
+			// WHEN: that request is made.
+			resp, err := http.Get(wsURL)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer resp.Body.Close()
+
+			prefix := fmt.Sprintf(
+				"%s\nSetupWebSocket() %s",
+				packageName, name,
+			)
+
+			// THEN: the auth gate behaves as expected.
+			if tc.wantUnauthorized {
+				if resp.StatusCode != http.StatusUnauthorized {
+					t.Errorf(
+						"%s\nstatus code mismatch\ngot:  %d\nwant: %d",
+						prefix, resp.StatusCode, http.StatusUnauthorized,
+					)
+				}
+			} else if resp.StatusCode == http.StatusUnauthorized {
+				t.Errorf("%s\ngot 401, expected auth to pass", prefix)
+			}
+
+			// AND: the WWW-Authenticate header is absent (no Basic Auth re-prompt on the WebSocket handshake).
+			if got := resp.Header.Get("WWW-Authenticate"); got != "" {
+				t.Errorf(
+					"%s\nWWW-Authenticate should not be set, got %q",
+					prefix, got,
+				)
+			}
+
+			// AND: a valid token is single-use (a second request with it is rejected).
+			if tc.mintToken {
+				resp2, err := http.Get(wsURL)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer resp2.Body.Close()
+
+				if resp2.StatusCode != http.StatusUnauthorized {
+					t.Errorf(
+						"%s (re-use)\nstatus code mismatch\ngot:  %d\nwant: %d",
+						prefix, resp2.StatusCode, http.StatusUnauthorized,
+					)
+				}
 			}
 		})
 	}

--- a/web/api/v1/middleware_test.go
+++ b/web/api/v1/middleware_test.go
@@ -75,7 +75,7 @@ func TestHTTP_BasicAuthMiddleware(t *testing.T) {
 			if cfg.Settings.Web.BasicAuth != nil {
 				cfg.Settings.Web.BasicAuth.CheckValues()
 			}
-			api := NewAPI(&cfg)
+			api, _ := NewAPI(&cfg)
 			api.Router.HandleFunc("/test", func(rw http.ResponseWriter, req *http.Request) {
 				rw.WriteHeader(http.StatusOK)
 			})

--- a/web/api/v1/websocket-token.go
+++ b/web/api/v1/websocket-token.go
@@ -1,0 +1,112 @@
+// Copyright [2026] [Argus]
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package v1 provides the API for the webserver.
+package v1
+
+import (
+	"sync"
+	"time"
+
+	"github.com/release-argus/Argus/util"
+)
+
+// webSocketTokenLength is the number of characters in a minted WebSocket token.
+const webSocketTokenLength = 32
+
+// webSocketTokenTTL is how long a minted WebSocket token remains valid if unused.
+const webSocketTokenTTL = 15 * time.Second
+
+// webSocketTokenMaxSize is the maximum number of unexpired tokens held with a [webSocketTokenTTL].
+const webSocketTokenMaxSize = 100
+
+// webSocketTokenStore issues and validates short-lived, single-use tokens
+// used to authenticate the WebSocket handshake.
+type webSocketTokenStore struct {
+	mu     sync.Mutex
+	tokens map[string]time.Time // token -> expiry.
+}
+
+// newWebSocketTokenStore creates a new, empty [webSocketTokenStore].
+func newWebSocketTokenStore() *webSocketTokenStore {
+	return &webSocketTokenStore{
+		tokens: make(map[string]time.Time),
+	}
+}
+
+// New mints a new single-use token, valid for webSocketTokenTTL.
+func (s *webSocketTokenStore) New() string {
+	token := util.RandAlphaNumericLower(webSocketTokenLength)
+	expiry := time.Now().Add(webSocketTokenTTL)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.prune()
+	if len(s.tokens) >= webSocketTokenMaxSize {
+		s.evictOldest()
+	}
+	s.tokens[token] = expiry
+
+	return token
+}
+
+// Validate reports whether token is a valid, unexpired token, consuming it if so.
+func (s *webSocketTokenStore) Validate(token string) bool {
+	if token == "" {
+		return false
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.prune()
+
+	expiry, ok := s.tokens[token]
+	if !ok {
+		return false
+	}
+	delete(s.tokens, token)
+
+	return time.Now().Before(expiry)
+}
+
+// prune removes expired tokens.
+//
+// Callers must hold s.mu.
+func (s *webSocketTokenStore) prune() {
+	now := time.Now()
+	for token, expiry := range s.tokens {
+		if now.After(expiry) {
+			delete(s.tokens, token)
+		}
+	}
+}
+
+// evictOldest removes the token with the soonest expiry.
+//
+// Callers must hold s.mu.
+func (s *webSocketTokenStore) evictOldest() {
+	var oldestToken string
+	var oldestExpiry time.Time
+
+	for token, expiry := range s.tokens {
+		if oldestToken == "" || expiry.Before(oldestExpiry) {
+			oldestToken = token
+			oldestExpiry = expiry
+		}
+	}
+
+	delete(s.tokens, oldestToken)
+}

--- a/web/api/v1/websocket-token_test.go
+++ b/web/api/v1/websocket-token_test.go
@@ -1,0 +1,202 @@
+// Copyright [2026] [Argus]
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build unit
+
+package v1
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestWebSocketTokenStore_New(t *testing.T) {
+	// GIVEN: a webSocketTokenStore.
+	store := newWebSocketTokenStore()
+
+	// WHEN: New is called.
+	token := store.New()
+
+	prefix := fmt.Sprintf("%s\nwebSocketTokenStore.New()", packageName)
+
+	// THEN: a non-empty token is returned.
+	if token == "" {
+		t.Errorf("%s\ngot an empty token", prefix)
+	}
+
+	// AND: the token has the expected length.
+	if len(token) != webSocketTokenLength {
+		t.Errorf(
+			"%s\ntoken length mismatch\ngot:  %d\nwant: %d",
+			prefix, len(token), webSocketTokenLength,
+		)
+	}
+
+	// AND: two consecutive tokens are different.
+	other := store.New()
+	if token == other {
+		t.Errorf(
+			"%s\nexpected two different tokens, got the same one twice: %q",
+			prefix, token,
+		)
+	}
+}
+
+func TestWebSocketTokenStore_New_MaxSize(t *testing.T) {
+	// GIVEN: a store already at webSocketTokenMaxSize, with distinct
+	// (unexpired) expiries so the "oldest" (soonest-expiring) token is
+	// unambiguous.
+	store := newWebSocketTokenStore()
+	base := time.Now().Add(webSocketTokenTTL)
+
+	store.mu.Lock()
+	for i := range webSocketTokenMaxSize {
+		store.tokens[fmt.Sprintf("token-%d", i)] = base.Add(time.Duration(i) * time.Millisecond)
+	}
+	store.mu.Unlock()
+
+	prefix := fmt.Sprintf("%s\nwebSocketTokenStore.New() (max size)", packageName)
+
+	// WHEN: New is called, which would exceed webSocketTokenMaxSize.
+	newToken := store.New()
+
+	// THEN: the store does not grow beyond webSocketTokenMaxSize.
+	store.mu.Lock()
+	size := len(store.tokens)
+	_, oldestStillPresent := store.tokens["token-0"]
+	_, newestStillPresent := store.tokens[fmt.Sprintf("token-%d", webSocketTokenMaxSize-1)]
+	store.mu.Unlock()
+
+	if size != webSocketTokenMaxSize {
+		t.Errorf(
+			"%s\nstore size mismatch\ngot:  %d\nwant: %d",
+			prefix, size, webSocketTokenMaxSize,
+		)
+	}
+
+	// AND: the oldest (soonest-expiring) token was evicted to make room.
+	if oldestStillPresent {
+		t.Errorf("%s\noldest token should have been evicted", prefix)
+	}
+
+	// AND: the newest pre-existing token is retained.
+	if !newestStillPresent {
+		t.Errorf("%s\nnewest pre-existing token should not have been evicted", prefix)
+	}
+
+	// AND: the newly-minted token is itself valid.
+	if !store.Validate(newToken) {
+		t.Errorf("%s\nnewly minted token should be valid", prefix)
+	}
+}
+
+func TestWebSocketTokenStore_Validate(t *testing.T) {
+	// GIVEN: a webSocketTokenStore.
+	tests := map[string]struct {
+		setup func(store *webSocketTokenStore) string
+		want  bool
+	}{
+		"valid, unused token": {
+			setup: func(store *webSocketTokenStore) string {
+				return store.New()
+			},
+			want: true,
+		},
+		"empty token": {
+			setup: func(_ *webSocketTokenStore) string {
+				return ""
+			},
+			want: false,
+		},
+		"unknown token": {
+			setup: func(_ *webSocketTokenStore) string {
+				return "unknown-token-that-was-never-issued"
+			},
+			want: false,
+		},
+		"expired token": {
+			setup: func(store *webSocketTokenStore) string {
+				token := store.New()
+				// Force the token to have already expired.
+				store.mu.Lock()
+				store.tokens[token] = time.Now().Add(-time.Second)
+				store.mu.Unlock()
+				return token
+			},
+			want: false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			store := newWebSocketTokenStore()
+			token := tc.setup(store)
+
+			prefix := fmt.Sprintf("%s\nwebSocketTokenStore.Validate(%q)", packageName, name)
+
+			// WHEN: Validate is called.
+			got := store.Validate(token)
+
+			// THEN: the result matches expectations.
+			if got != tc.want {
+				t.Errorf(
+					"%s\nfirst call result mismatch\ngot:  %t\nwant: %t",
+					prefix, got, tc.want,
+				)
+			}
+
+			// AND: tokens are single-use - a second call always fails.
+			if gotTwo := store.Validate(token); gotTwo {
+				t.Errorf(
+					"%s\nsecond call (re-use) should always fail (tokens are single-use), got: %t",
+					prefix, gotTwo,
+				)
+			}
+		})
+	}
+}
+
+func TestWebSocketTokenStore_Prune(t *testing.T) {
+	// GIVEN: a store with an expired and a valid token.
+	store := newWebSocketTokenStore()
+	expired := store.New()
+	valid := store.New()
+
+	store.mu.Lock()
+	store.tokens[expired] = time.Now().Add(-time.Second)
+	store.mu.Unlock()
+
+	prefix := fmt.Sprintf("%s\nwebSocketTokenStore.prune()", packageName)
+
+	// WHEN: a New call triggers pruning.
+	_ = store.New()
+
+	// THEN: the expired token is removed.
+	store.mu.Lock()
+	_, expiredStillPresent := store.tokens[expired]
+	_, validStillPresent := store.tokens[valid]
+	store.mu.Unlock()
+
+	if expiredStillPresent {
+		t.Errorf("%s\nexpired token should have been pruned", prefix)
+	}
+
+	// AND: the valid token remains.
+	if !validStillPresent {
+		t.Errorf("%s\nvalid token should not have been pruned", prefix)
+	}
+}

--- a/web/ui/react-app/src/contexts/websocket.tsx
+++ b/web/ui/react-app/src/contexts/websocket.tsx
@@ -8,6 +8,7 @@ import { QUERY_KEYS } from '@/lib/query-keys';
 import type { WebSocketResponse } from '@/types/websocket';
 import { getBasename } from '@/utils';
 import approvalsQueryCacheUpdater from '@/utils/api/query-cache';
+import { API_BASE } from '@/utils/api/types/api-request';
 
 type WebSocketContextProps = {
 	/* The WebSocket connection. */
@@ -35,7 +36,37 @@ type WebSocketProviderProps = {
 	children: ReactNode;
 };
 
-const ws = new WebSocket(`${WS_ADDRESS}${getBasename()}/ws`);
+/**
+ * Resolves the URL for the "/ws" WebSocket endpoint.
+ *
+ * Safari/WebKit doesn't forward cached HTTP Basic Auth credentials on
+ * WebSocket handshake requests, so a short-lived token is fetched from the
+ * (Basic Auth protected) "/api/v1/ws-token" endpoint via a normal
+ * authenticated request, and passed as a "token" query parameter instead.
+ *
+ * 204 from "/ws-token" means Basic Auth is not configured.
+ *
+ * Called on every (re)connection attempt, so a fresh token is used each time.
+ */
+const getWebSocketURL = async (): Promise<string> => {
+	const wsURL = `${WS_ADDRESS}${getBasename()}/ws`;
+
+	try {
+		const resp = await fetch(`${API_BASE}/ws-token`);
+		// 204 = Basic Auth not configured; connect without a token.
+		if (resp.status === 204) return wsURL;
+		if (!resp.ok) {
+			throw new Error(`Failed to fetch WebSocket token: HTTP ${resp.status}`);
+		}
+		const { token } = (await resp.json()) as { token: string };
+		return `${wsURL}?token=${encodeURIComponent(token)}`;
+	} catch (error) {
+		console.error('Failed to fetch WebSocket token:', error);
+		return wsURL;
+	}
+};
+
+const ws = new WebSocket(getWebSocketURL);
 /**
  * @returns The WebSocket connection and monitor data.
  */

--- a/web/web.go
+++ b/web/web.go
@@ -77,23 +77,12 @@ func Run(ctx context.Context, cfg *config.Config) error {
 
 // newRouter serves Prometheus metrics, WebSocket, and Node.js frontend at RoutePrefix.
 func newRouter(cfg *config.Config, hub *v1.Hub) *mux.Router {
-	// Go
-	api := v1.NewAPI(cfg)
+	api, wsRoute := v1.NewAPI(cfg)
 
-	// Prometheus metrics
 	api.Router.Handle("/metrics", promhttp.Handler())
 
-	// WebSocket
-	api.Router.HandleFunc("/ws", func(w http.ResponseWriter, r *http.Request) {
-		// Connection header for the WebSocket handshake.
-		w.Header().Set("Connection", "keep-alive")
-		defer r.Body.Close()
-		v1.ServeWs(hub, w, r)
-	})
-
-	// HTTP API
+	api.SetupWebSocket(hub, wsRoute)
 	api.SetupRoutesAPI()
-	// Node.js
 	api.SetupRoutesNodeJS()
 
 	return api.BaseRouter

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -39,7 +39,6 @@ func TestWebSocketHandler(t *testing.T) {
 	url := fmt.Sprintf("ws://%s:%s/ws", host, port)
 
 	t.Run("ConnectWebSocket", func(t *testing.T) {
-
 		// WHEN: we attempt to connect.
 		ws, resp, err := websocket.DefaultDialer.Dial(url, nil)
 		if err != nil {


### PR DESCRIPTION
Safari/WebKit doesn't forward cached HTTP Basic Auth credentials on WebSocket handshake requests, so connecting to /ws would always fail when basic auth is configured.

Add a /api/v1/ws-token endpoint (protected by basic auth) that issues a single-use, 15-second-TTL token.

When basic auth is not configured, /ws-token returns 204 and the client connects without a token.

fixes #842