### PR TITLE
fix(lv-github): gate /tags fallback on use_prerelease/regex_content

### DIFF
--- a/service/latest_version/types/github/gets.go
+++ b/service/latest_version/types/github/gets.go
@@ -38,32 +38,31 @@ func (l *Lookup) accessToken() string {
 
 // url returns a GitHub API URL for the repository.
 func (l *Lookup) url(page int) string {
-	url := util.EvalEnvVars(l.URL)
-	// Convert "owner/repo" to the API path.
-	if strings.Count(url, "/") == 1 {
-		apiTarget := "releases"
-		if l.data.TagFallback() {
-			apiTarget = "tags"
-		}
-		url = fmt.Sprintf(
-			"https://api.github.com/repos/%s/%s",
-			url, apiTarget,
-		)
-
-		// Query params
-		params := make([]string, 0, 2)
-		if page > 1 {
-			params = append(params, fmt.Sprintf("page=%d", page))
-		}
-		if perPage := l.data.PerPage(); perPage != 0 {
-			params = append(params, fmt.Sprintf("per_page=%d", perPage))
-		}
-		if len(params) > 0 {
-			url += "?" + strings.Join(params, "&")
-		}
+	rawURL := util.EvalEnvVars(l.URL)
+	if strings.Count(rawURL, "/") != 1 {
+		return rawURL
 	}
 
-	return url
+	apiTarget := "releases"
+	if l.data.TagFallback() {
+		apiTarget = "tags"
+	}
+	base := fmt.Sprintf(
+		"https://api.github.com/repos/%s/%s",
+		rawURL, apiTarget,
+	)
+
+	params := make([]string, 0, 2)
+	if page > 1 {
+		params = append(params, fmt.Sprintf("page=%d", page))
+	}
+	if perPage := l.data.PerPage(); perPage != 0 {
+		params = append(params, fmt.Sprintf("per_page=%d", perPage))
+	}
+	if len(params) == 0 {
+		return base
+	}
+	return base + "?" + strings.Join(params, "&")
 }
 
 // usePreRelease resolves whether to consider GitHub PreReleases for new versions.
@@ -73,6 +72,15 @@ func (l *Lookup) usePreRelease() bool {
 		l.Defaults.UsePreRelease,
 		l.HardDefaults.UsePreRelease,
 	)
+}
+
+// useTagsAPI returns whether the /tags API may be used as a fallback.
+//
+// Cannot use /tags when:
+//   - filtering out pre-releases (tags have no pre-release labeling)
+//   - filtering on regex_content (tags have no release assets to match against)
+func (l *Lookup) useTagsAPI() bool {
+	return !l.usePreRelease() && (l.Require == nil || l.Require.RegexContent == "")
 }
 
 // ServiceURL translates possible `owner/repo` URLs, adding the github.com/ prefix.

--- a/service/latest_version/types/github/gets_test.go
+++ b/service/latest_version/types/github/gets_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/release-argus/Argus/internal/test"
+	"github.com/release-argus/Argus/service/latest_version/filter"
 )
 
 func TestLookup_GetType(t *testing.T) {
@@ -256,6 +257,87 @@ func TestLookup_UsePreRelease(t *testing.T) {
 				t.Errorf(
 					"%s\nLookup.usePreRelease() mismatch\ngot:  %q\nwant: %q",
 					packageName, wantStr, got,
+				)
+			}
+		})
+	}
+}
+
+func TestLookup_UseTagsAPI(t *testing.T) {
+	// GIVEN: a Lookup with various combinations of use_prerelease and require.
+	tests := []struct {
+		name          string
+		usePreRelease *bool
+		require       *filter.Require
+		want          bool
+	}{
+		{
+			name:    "require/nil - allowed",
+			require: nil,
+			want:    true,
+		},
+		{
+			name:    "require/empty - allowed",
+			require: &filter.Require{},
+			want:    true,
+		},
+		{
+			name:    "require/regex_content=empty - allowed",
+			require: &filter.Require{RegexContent: ""},
+			want:    true,
+		},
+		{
+			name:    "require/regex_content=set - blocked",
+			require: &filter.Require{RegexContent: "some-pattern"},
+			want:    false,
+		},
+		{
+			name:          "use_prerelease/false - allowed",
+			usePreRelease: test.Ptr(false),
+			want:          true,
+		},
+		{
+			name:          "use_prerelease/true - blocked",
+			usePreRelease: test.Ptr(true),
+			want:          false,
+		},
+		{
+			name:          "use_prerelease=false, regex_content=set - blocked",
+			usePreRelease: test.Ptr(false),
+			require:       &filter.Require{RegexContent: "some-pattern"},
+			want:          false,
+		},
+		{
+			name:          "use_prerelease=true, regex_content=empty - blocked",
+			usePreRelease: test.Ptr(true),
+			require:       &filter.Require{RegexContent: ""},
+			want:          false,
+		},
+		{
+			name:          "use_prerelease=true, regex_content=set - blocked",
+			usePreRelease: test.Ptr(true),
+			require:       &filter.Require{RegexContent: "some-pattern"},
+			want:          false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// AND: a Lookup with the specified use_prerelease and require.
+			lookup := testLookup(t, false)
+			lookup.UsePreRelease = tc.usePreRelease
+			lookup.Require = tc.require
+
+			// WHEN: useTagsAPI is called.
+			got := lookup.useTagsAPI()
+
+			// THEN: the result is as expected.
+			if got != tc.want {
+				t.Errorf(
+					"%s\nLookup.useTagsAPI() result mismatch\ngot:  %t\nwant: %t",
+					packageName, got, tc.want,
 				)
 			}
 		})

--- a/service/latest_version/types/github/query.go
+++ b/service/latest_version/types/github/query.go
@@ -172,8 +172,8 @@ func (l *Lookup) getResponse(req *http.Request, logFrom logx.LogFrom) (*http.Res
 
 // handleResponse processes the HTTP response based on the status code and takes appropriate action.
 //   - 200 OK, if the response body contains one or more releases, it returns the body.
-//     Otherwise, it flips the 'tags' flag and performs a query on the "/tags" endpoint and returns that body.
-//   - 304 Not Modified, it flips the 'tags' flag, performs a query on the "/tags" endpoint, and returns that body.
+//     Otherwise, it conditionally falls back to the "/tags" endpoint (see [Lookup.useTagsAPI]).
+//   - 304 Not Modified, conditionally falls back to "/tags" when there are no cached releases.
 //   - 401 Unauthorized, 403 Forbidden, and 429 Too Many Requests, it logs the error and returns a nil body.
 //   - Unknown status code, it logs the error and returns a nil body along with an error.
 func (l *Lookup) handleResponse(resp *http.Response, body []byte, logFrom logx.LogFrom) ([]byte, int, error) {
@@ -221,15 +221,17 @@ func (l *Lookup) handleStatusOK(resp *http.Response, body []byte, logFrom logx.L
 		if firstPage && (l.AccessToken == "" || l.accessToken() == defaultAccessToken) {
 			setEmptyListETag(newETag)
 		}
-		// Flip the fallback flag.
-		l.data.SetTagFallback()
-		if l.data.TagFallback() {
-			logx.Verbose(
-				fmt.Sprintf("/releases gave %s, trying /tags", body),
-				logFrom,
-				true,
-			)
-			return l.httpRequest(0, logFrom)
+
+		if l.useTagsAPI() {
+			l.data.SetTagFallback()
+			if l.data.TagFallback() {
+				logx.Verbose(
+					fmt.Sprintf("/releases gave %s, trying /tags", body),
+					logFrom,
+					true,
+				)
+				return l.httpRequest(0, logFrom)
+			}
 		}
 
 		// Has tags/releases.
@@ -276,11 +278,13 @@ func getNextPage(linkHeader string) int {
 func (l *Lookup) handleStatusNotModified(logFrom logx.LogFrom) ([]byte, int, error) {
 	// Didn't find any releases before and nothing has changed?
 	if !l.data.hasReleases() {
-		// Flip the fallback flag for next time.
-		l.data.SetTagFallback()
-		if l.data.TagFallback() {
-			logx.Verbose("no tags found on /releases, trying /tags", logFrom, true)
-			return l.httpRequest(0, logFrom)
+		if l.useTagsAPI() {
+			// Flip the fallback flag for next time.
+			l.data.SetTagFallback()
+			if l.data.TagFallback() {
+				logx.Verbose("no tags found on /releases, trying /tags", logFrom, true)
+				return l.httpRequest(0, logFrom)
+			}
 		}
 		return nil, 0, nil
 	}

--- a/service/latest_version/types/github/query_test.go
+++ b/service/latest_version/types/github/query_test.go
@@ -158,6 +158,7 @@ func TestLookup_HandleResponse(t *testing.T) {
 		nilBody          bool
 		nextPage         int
 		setEmptyListETag bool
+		tagFallback      bool
 		errRegex         string
 	}
 	type conditions struct {
@@ -167,11 +168,12 @@ func TestLookup_HandleResponse(t *testing.T) {
 
 	// GIVEN: a HTTP Response and an accompanying body.
 	tests := []struct {
-		name       string
-		conditions conditions
-		statusCode int
-		body       []byte
-		want       wants
+		name        string
+		conditions  conditions
+		lookupSetup func(*Lookup)
+		statusCode  int
+		body        []byte
+		want        wants
 	}{
 		{
 			name: "200 OK/EmptyListETag set if default access_token",
@@ -183,6 +185,7 @@ func TestLookup_HandleResponse(t *testing.T) {
 			want: wants{
 				nextPage:         2,
 				setEmptyListETag: true,
+				tagFallback:      true,
 				errRegex:         `^$`,
 			},
 		},
@@ -196,6 +199,7 @@ func TestLookup_HandleResponse(t *testing.T) {
 			want: wants{
 				nextPage:         2,
 				setEmptyListETag: false,
+				tagFallback:      true,
 				errRegex:         `^$`,
 			},
 		},
@@ -204,17 +208,73 @@ func TestLookup_HandleResponse(t *testing.T) {
 			statusCode: http.StatusOK,
 			body:       []byte(`[{"tag_name":"v1.0.0"}]`),
 			want: wants{
-				nextPage: 0,
-				errRegex: `^$`,
+				nextPage:    0,
+				tagFallback: false,
+				errRegex:    `^$`,
+			},
+		},
+		{
+			name:       "200 OK/use_prerelease blocks tag fallback on empty list",
+			statusCode: http.StatusOK,
+			body:       []byte(`[]`),
+			lookupSetup: func(l *Lookup) {
+				l.UsePreRelease = test.Ptr(true)
+			},
+			want: wants{
+				nilBody:     false,
+				nextPage:    0,
+				tagFallback: false,
+				errRegex:    `^$`,
+			},
+		},
+		{
+			name:       "200 OK/require.regex_content blocks tag fallback on empty list",
+			statusCode: http.StatusOK,
+			body:       []byte(`[]`),
+			lookupSetup: func(l *Lookup) {
+				l.Require = &filter.Require{RegexContent: "some-pattern"}
+			},
+			want: wants{
+				nilBody:     false,
+				nextPage:    0,
+				tagFallback: false,
+				errRegex:    `^$`,
+			},
+		},
+		{
+			name:       "304 Not Modified/use_prerelease blocks tag fallback",
+			statusCode: http.StatusNotModified,
+			lookupSetup: func(l *Lookup) {
+				l.UsePreRelease = test.Ptr(true)
+			},
+			want: wants{
+				nilBody:     true,
+				nextPage:    0,
+				tagFallback: false,
+				errRegex:    `^$`,
+			},
+		},
+		{
+			name:       "304 Not Modified/require.regex_content blocks tag fallback",
+			statusCode: http.StatusNotModified,
+			lookupSetup: func(l *Lookup) {
+				l.Require = &filter.Require{RegexContent: "some-pattern"}
+			},
+			want: wants{
+				nilBody:     true,
+				nextPage:    0,
+				tagFallback: false,
+				errRegex:    `^$`,
 			},
 		},
 		{
 			name:       "304 Not Modified/Tag fallback request",
 			statusCode: http.StatusNotModified,
 			want: wants{
-				nilBody:  false,
-				nextPage: 2,
-				errRegex: `^$`,
+				nilBody:     false,
+				nextPage:    2,
+				tagFallback: true,
+				errRegex:    `^$`,
 			},
 		},
 		{
@@ -224,9 +284,10 @@ func TestLookup_HandleResponse(t *testing.T) {
 			},
 			statusCode: http.StatusNotModified,
 			want: wants{
-				nilBody:  true,
-				nextPage: 2,
-				errRegex: `^$`,
+				nilBody:     true,
+				nextPage:    2,
+				tagFallback: false,
+				errRegex:    `^$`,
 			},
 		},
 		{
@@ -288,8 +349,8 @@ func TestLookup_HandleResponse(t *testing.T) {
 			statusCode: http.StatusTooManyRequests,
 			body:       []byte(`{"message":}`),
 			want: wants{
-				errRegex: `^too many requests made to GitHub$`,
 				nilBody:  true,
+				errRegex: `^too many requests made to GitHub$`,
 			},
 		},
 		{
@@ -297,8 +358,8 @@ func TestLookup_HandleResponse(t *testing.T) {
 			statusCode: http.StatusTeapot,
 			body:       []byte(`{"message":"I'm a teapot"}`),
 			want: wants{
-				errRegex: `unknown status code 418`,
 				nilBody:  true,
+				errRegex: `unknown status code 418`,
 			},
 		},
 	}
@@ -339,6 +400,9 @@ func TestLookup_HandleResponse(t *testing.T) {
 				if !tc.conditions.hadDefaultAccessToken {
 					lookup.Defaults.AccessToken = ""
 					lookup.HardDefaults.AccessToken = "Something"
+				}
+				if tc.lookupSetup != nil {
+					tc.lookupSetup(lookup)
 				}
 
 				logFrom := logx.LogFrom{Primary: "TestHandleResponse", Secondary: tc.name}
@@ -392,6 +456,14 @@ func TestLookup_HandleResponse(t *testing.T) {
 					t.Errorf(
 						"%s nextPage mismatch\ngot:  %d\nwant: %d",
 						prefix, nextPage, tc.want.nextPage,
+					)
+				}
+
+				// AND: TagFallback is as expected.
+				if got := lookup.data.TagFallback(); got != tc.want.tagFallback {
+					t.Errorf(
+						"%s TagFallback mismatch\ngot:  %t\nwant: %t",
+						prefix, got, tc.want.tagFallback,
 					)
 				}
 				break


### PR DESCRIPTION
The /releases -> /tags fallback could return a pre-release tag when use_prerelease=false (tags carry no pre-release labeling), or silently fail to match when regex_content is set (tags have no release assets).

Adds `useTagsAPI()` to gate both fallback paths

fixes #864.