### PR TITLE
refactor(docker): make registry defaults auth-only

### DIFF
--- a/config/defaults_test.go
+++ b/config/defaults_test.go
@@ -448,24 +448,17 @@ func TestDefaults_String(t *testing.T) {
 								return docker.DecodeDefaults(
 									"yaml", []byte(test.TrimYAML(`
 										type: ghcr
-										image: imageFallback
 										tag: tagFallback
 										registry:
 											ghcr:
-												image: imageGHCR
-												tag: tagGHCR
 												auth:
 													username: usernameGHCR
 													token: tokenGHCR
 											hub:
-												image: imageHub
-												tag: tagHub
 												auth:
 													username: usernameHub
 													token: tokenHub
 											quay:
-												image: imageQuay
-												tag: tagQuay
 												auth:
 													username: usernameQuay
 													token: tokenQuay
@@ -475,18 +468,14 @@ func TestDefaults_String(t *testing.T) {
 											"yaml", []byte(test.TrimYAML(`
 												type: ghcr
 												ghcr:
-													image: imageGHCRother
 													auth:
 														username: usernameGHCRother
 														token: tokenGHCRother
 												hub:
-													image: imageHubOther
-													tag: tagHubOther
 													auth:
 														username: usernameHubOther
 														token: tokenHubOther
 												quay:
-													image: imageQuayOther
 													auth:
 														username: usernameQuayOther
 														token: tokenQuayOther
@@ -549,23 +538,16 @@ func TestDefaults_String(t *testing.T) {
 						require:
 							docker:
 								type: ghcr
-								image: imageFallback
 								tag: tagFallback
 								registry:
 									ghcr:
-										image: imageGHCR
-										tag: tagGHCR
 										auth:
 											token: tokenGHCR
 									hub:
-										image: imageHub
-										tag: tagHub
 										auth:
 											username: usernameHub
 											token: tokenHub
 									quay:
-										image: imageQuay
-										tag: tagQuay
 										auth:
 											token: tokenQuay
 					deployed_version:
@@ -792,23 +774,16 @@ func TestDefaults_MapEnvToStruct(t *testing.T) {
 								return docker.DecodeDefaults(
 									"yaml", []byte(test.TrimYAML(`
 										type: ghcr
-										image: imageFallback
 										tag: tagFallback
 										registry:
 											ghcr:
-												image: imageForGHCR
-												tag: tagForGHCR
 												auth:
 													token: tokenForGHCR
 											hub:
-												image: imageForHub
-												tag: tagForHub
 												auth:
 													username: usernameForHub
 													token: tokenForHub
 											quay:
-												image: imageForQuay
-												tag: tagForQuay
 												auth:
 													token: tokenForQuay
 									`)),

--- a/service/defaults_test.go
+++ b/service/defaults_test.go
@@ -545,19 +545,14 @@ func TestDefaults_String(t *testing.T) {
 									type: ghcr
 									registry:
 										ghcr:
-											image: imageGHCR
-											tag: tagGHCR
 											auth:
 												username: usernameGHCR
 												token: tokenGHCR
 										hub:
-											image: imageHub
-											tag: tagHub
 											auth:
 												username: usernameHub
 												token: tokenHub
 										quay:
-											image: imageQuay
 											auth:
 												username: usernameQuay
 												token: tokenQuay
@@ -568,19 +563,14 @@ func TestDefaults_String(t *testing.T) {
 											type: ghcr
 											registry:
 												ghcr:
-													image: imageGHCRother
-													tag: imageGHCRother
 													auth:
 														username: usernameGHCR_Other
 														token: tokenGHCR_Other
 												hub:
-													image: imageHub_Other
-													tag: tagHub_Other
 													auth:
 														username: usernameHub_Other
 														token: tokenHub_Other
 												quay:
-													image: imageQuay_Other
 													auth:
 														username: usernameQuay_Other
 														token: tokenQuay_Other
@@ -612,18 +602,13 @@ func TestDefaults_String(t *testing.T) {
 							type: ghcr
 							registry:
 								ghcr:
-									image: imageGHCR
-									tag: tagGHCR
 									auth:
 										token: tokenGHCR
 								hub:
-									image: imageHub
-									tag: tagHub
 									auth:
 										username: usernameHub
 										token: tokenHub
 								quay:
-									image: imageQuay
 									auth:
 										token: tokenQuay
 				deployed_version:
@@ -700,63 +685,27 @@ func TestDefaults_SetDefaults(t *testing.T) {
 	// THEN: the struct is populated with default values.
 	fieldTests := []test.FieldAssertion{
 		{
-			Name: "LatestVersion.Require.Docker.ContainerDetail.Defaults -> HardDefaults",
-			Got:  d.LatestVersion.Require.Docker.ContainerDetail.Defaults,
-			Want: &hd.LatestVersion.Require.Docker.ContainerDetail,
+			Name: "LatestVersion.Require.Docker.ContainerDetailDefaults.Defaults -> HardDefaults",
+			Got:  d.LatestVersion.Require.Docker.ContainerDetailDefaults.Defaults,
+			Want: &hd.LatestVersion.Require.Docker.ContainerDetailDefaults,
 			Mode: test.CompareSamePointer,
 		},
-		{ // Layer 1: Registry HardDefaults
-			Name: "L1: LatestVersion.Require.Docker.Registry.GHCR.ContainerDetail.Defaults -> HardDefaults...Registry.GHCR.ContainerDetail",
-			Got:  d.LatestVersion.Require.Docker.Registry.GHCR.ContainerDetail.Defaults,
-			Want: &hd.LatestVersion.Require.Docker.Registry.GHCR.ContainerDetail,
+		{
+			Name: "LatestVersion.Require.Docker.Registry.GHCR.Auth.Defaults -> HardDefaults...Registry.GHCR.Auth",
+			Got:  d.LatestVersion.Require.Docker.Registry.GHCR.GetAuth().Defaults(),
+			Want: hd.LatestVersion.Require.Docker.Registry.GHCR.GetAuth(),
 			Mode: test.CompareSamePointer,
 		},
-		{ // Layer 2: Root Defaults
-			Name: "L2: LatestVersion.Require.Docker.Registry.GHCR.ContainerDetail.Defaults.Defaults -> Defaults.ContainerDetail",
-			Got:  d.LatestVersion.Require.Docker.Registry.GHCR.ContainerDetail.Defaults.Defaults,
-			Want: &d.LatestVersion.Require.Docker.ContainerDetail,
+		{
+			Name: "LatestVersion.Require.Docker.Registry.Hub.Auth.Defaults -> HardDefaults...Registry.Hub.Auth",
+			Got:  d.LatestVersion.Require.Docker.Registry.Hub.GetAuth().Defaults(),
+			Want: hd.LatestVersion.Require.Docker.Registry.Hub.GetAuth(),
 			Mode: test.CompareSamePointer,
 		},
-		{ // Layer 3: Root HardDefaults
-			Name: "L3: LatestVersion.Require.Docker.Registry.GHCR.ContainerDetail.Defaults.Defaults.Defaults -> HardDefaults.ContainerDetail",
-			Got:  d.LatestVersion.Require.Docker.Registry.GHCR.ContainerDetail.Defaults.Defaults.Defaults,
-			Want: &hd.LatestVersion.Require.Docker.ContainerDetail,
-			Mode: test.CompareSamePointer,
-		},
-		{ // Layer 1: Registry HardDefaults
-			Name: "L1: LatestVersion.Require.Docker.Registry.Hub.ContainerDetail.Defaults -> HardDefaults...Registry.Hub.ContainerDetail",
-			Got:  d.LatestVersion.Require.Docker.Registry.Hub.ContainerDetail.Defaults,
-			Want: &hd.LatestVersion.Require.Docker.Registry.Hub.ContainerDetail,
-			Mode: test.CompareSamePointer,
-		},
-		{ // Layer 2: Root Defaults
-			Name: "L2: LatestVersion.Require.Docker.Registry.Hub.ContainerDetail.Defaults.Defaults -> Defaults.ContainerDetail",
-			Got:  d.LatestVersion.Require.Docker.Registry.Hub.ContainerDetail.Defaults.Defaults,
-			Want: &d.LatestVersion.Require.Docker.ContainerDetail,
-			Mode: test.CompareSamePointer,
-		},
-		{ // Layer 3: Root HardDefaults
-			Name: "L3: LatestVersion.Require.Docker.Registry.Hub.ContainerDetail.Defaults.Defaults.Defaults -> HardDefaults.ContainerDetail",
-			Got:  d.LatestVersion.Require.Docker.Registry.Hub.ContainerDetail.Defaults.Defaults.Defaults,
-			Want: &hd.LatestVersion.Require.Docker.ContainerDetail,
-			Mode: test.CompareSamePointer,
-		},
-		{ // Layer 1: Registry HardDefaults
-			Name: "L1: LatestVersion.Require.Docker.Registry.Quay.ContainerDetail.Defaults -> HardDefaults...Registry.Quay.ContainerDetail",
-			Got:  d.LatestVersion.Require.Docker.Registry.Quay.ContainerDetail.Defaults,
-			Want: &hd.LatestVersion.Require.Docker.Registry.Quay.ContainerDetail,
-			Mode: test.CompareSamePointer,
-		},
-		{ // Layer 2: Root Defaults
-			Name: "L2: LatestVersion.Require.Docker.Registry.Quay.ContainerDetail.Defaults.Defaults -> Defaults.ContainerDetail",
-			Got:  d.LatestVersion.Require.Docker.Registry.Quay.ContainerDetail.Defaults.Defaults,
-			Want: &d.LatestVersion.Require.Docker.ContainerDetail,
-			Mode: test.CompareSamePointer,
-		},
-		{ // Layer 3: Root HardDefaults
-			Name: "L3: LatestVersion.Require.Docker.Registry.Quay.ContainerDetail.Defaults.Defaults.Defaults -> HardDefaults.ContainerDetail",
-			Got:  d.LatestVersion.Require.Docker.Registry.Quay.ContainerDetail.Defaults.Defaults.Defaults,
-			Want: &hd.LatestVersion.Require.Docker.ContainerDetail,
+		{
+			Name: "LatestVersion.Require.Docker.Registry.Quay.Auth.Defaults -> HardDefaults...Registry.Quay.Auth",
+			Got:  d.LatestVersion.Require.Docker.Registry.Quay.GetAuth().Defaults(),
+			Want: hd.LatestVersion.Require.Docker.Registry.Quay.GetAuth(),
 			Mode: test.CompareSamePointer,
 		},
 		{

--- a/service/latest_version/filter/decode_test.go
+++ b/service/latest_version/filter/decode_test.go
@@ -478,7 +478,6 @@ func TestDecodeDefaults(t *testing.T) {
 				"command": ["ls", "-lah"],
 				"docker": {
 					"type": "hub",
-					"image": "test/app",
 					"tag": "{{ version }}"
 				}
 			}`),
@@ -486,7 +485,6 @@ func TestDecodeDefaults(t *testing.T) {
 			want: test.TrimYAML(`
 				docker:
 					type: hub
-					image: test/app
 					tag: '{{ version }}'
 			`),
 		},

--- a/service/latest_version/filter/docker/container_detail.go
+++ b/service/latest_version/filter/docker/container_detail.go
@@ -20,11 +20,17 @@ import "github.com/release-argus/Argus/util"
 // # TYPES #
 // #########
 
-// ContainerDetail holds details about a Docker container.
+// ContainerDetail holds the image and tag for a Docker registry query.
 type ContainerDetail struct {
-	Image    string           `json:"image,omitempty" yaml:"image,omitempty"` // Image of the container.
-	Tag      string           `json:"tag,omitempty" yaml:"tag,omitempty"`     // Tag of the Image.
-	Defaults *ContainerDetail `json:"-" yaml:"-"`                             // Default values for ContainerDetail.
+	Image    string                   `json:"image,omitempty" yaml:"image,omitempty"` // Image of the container.
+	Tag      string                   `json:"tag,omitempty" yaml:"tag,omitempty"`     // Tag of the Image.
+	Defaults *ContainerDetailDefaults `json:"-" yaml:"-"`                             // Tag default chain.
+}
+
+// ContainerDetailDefaults holds default container values.
+type ContainerDetailDefaults struct {
+	Tag      string                   `json:"tag,omitempty" yaml:"tag,omitempty"` // Default Tag template.
+	Defaults *ContainerDetailDefaults `json:"-" yaml:"-"`                         // Next link in the defaults chain.
 }
 
 // #########
@@ -35,6 +41,11 @@ type ContainerDetail struct {
 func (c *ContainerDetail) IsZero() bool {
 	return c.Image == "" &&
 		c.Tag == ""
+}
+
+// IsZero implements the yaml.IsZeroer interface.
+func (c *ContainerDetailDefaults) IsZero() bool {
+	return c == nil || c.Tag == ""
 }
 
 // Copy returns a deep copy of the receiver.
@@ -51,7 +62,7 @@ func (c *ContainerDetail) Copy() ContainerDetail {
 // ############
 
 // Default sets the values of the receiver to their default values.
-func (c *ContainerDetail) Default() {
+func (c *ContainerDetailDefaults) Default() {
 	c.Tag = "{{ version }}"
 }
 
@@ -59,19 +70,22 @@ func (c *ContainerDetail) Default() {
 // # VALUES #
 // ##########
 
-// GetImage returns the container image, resolving defaults and environment variables.
+// GetImage returns the container image, resolving environment variables.
 func (c *ContainerDetail) GetImage() string {
-	for detail := c; detail != nil; detail = detail.Defaults {
-		if detail.Image != "" {
-			return util.EvalEnvVars(detail.Image)
-		}
-	}
-
-	return ""
+	return util.EvalEnvVars(c.Image)
 }
 
 // GetTag returns the container tag, resolving defaults and environment variables.
 func (c *ContainerDetail) GetTag() string {
+	if c.Tag != "" {
+		return util.EvalEnvVars(c.Tag)
+	}
+
+	return c.Defaults.GetTag()
+}
+
+// GetTag returns the default container tag, resolving defaults and environment variables.
+func (c *ContainerDetailDefaults) GetTag() string {
 	for detail := c; detail != nil; detail = detail.Defaults {
 		if detail.Tag != "" {
 			return util.EvalEnvVars(detail.Tag)

--- a/service/latest_version/filter/docker/container_detail_test.go
+++ b/service/latest_version/filter/docker/container_detail_test.go
@@ -81,6 +81,48 @@ func TestContainerDetail_IsZero(t *testing.T) {
 	}
 }
 
+func TestContainerDetailDefaults_IsZero(t *testing.T) {
+	// GIVEN: a ContainerDetailDefaults.
+	tests := []struct {
+		name string
+		data *ContainerDetailDefaults
+		want bool
+	}{
+		{
+			name: "nil",
+			data: nil,
+			want: true,
+		},
+		{
+			name: "empty",
+			data: &ContainerDetailDefaults{},
+			want: true,
+		},
+		{
+			name: "non-empty/Tag",
+			data: &ContainerDetailDefaults{Tag: "t"},
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// WHEN: IsZero() is called on it.
+			got := tc.data.IsZero()
+
+			// THEN: the expected result is returned.
+			if got != tc.want {
+				t.Fatalf(
+					"%s\nContainerDetailDefaults.IsZero() value mismatch\ngot:  %t\nwant: %t",
+					tc.name, got, tc.want,
+				)
+			}
+		})
+	}
+}
+
 func TestContainerDetail_Copy(t *testing.T) {
 	// GIVEN: a ContainerDetails
 	tests := []struct {
@@ -148,16 +190,16 @@ func TestContainerDetail_Copy(t *testing.T) {
 // # DEFAULTS #
 // ############
 
-func TestContainerDetail_Default(t *testing.T) {
-	// GIVEN: a ContainerDetail.
-	detail := ContainerDetail{}
+func TestContainerDetailDefaults_Default(t *testing.T) {
+	// GIVEN: a ContainerDetailDefaults.
+	detail := ContainerDetailDefaults{}
 
 	// WHEN: Default() is called on it.
 	detail.Default()
 
 	// THEN: .Tag is given a value.
 	if detail.Tag == "" {
-		t.Fatalf("%s\nContainerDetail.Default() mismatch\nTag is empty", packageName)
+		t.Fatalf("%s\nContainerDetailDefaults.Default() mismatch\nTag is empty", packageName)
 	}
 }
 
@@ -266,6 +308,14 @@ func TestContainerDetail_GetTag(t *testing.T) {
 			},
 			want: "",
 		},
+		{
+			name: "Tag from defaults",
+			data: ContainerDetail{
+				Image:    "i",
+				Defaults: &ContainerDetailDefaults{Tag: "t-default"},
+			},
+			want: "t-default",
+		},
 	}
 
 	for _, tc := range tests {
@@ -280,6 +330,50 @@ func TestContainerDetail_GetTag(t *testing.T) {
 			if got != tc.want {
 				t.Fatalf(
 					"%s\nContainerDetail.GetTag() mismatch\ngot:  %q\nwant: %q",
+					tc.name, got, tc.want,
+				)
+			}
+		})
+	}
+}
+
+func TestContainerDetailDefaults_GetTag(t *testing.T) {
+	// GIVEN: a ContainerDetailDefaults chain.
+	tests := []struct {
+		name string
+		data *ContainerDetailDefaults
+		want string
+	}{
+		{
+			name: "nil",
+			data: nil,
+			want: "",
+		},
+		{
+			name: "own Tag",
+			data: &ContainerDetailDefaults{Tag: "t"},
+			want: "t",
+		},
+		{
+			name: "Tag from chain",
+			data: &ContainerDetailDefaults{
+				Defaults: &ContainerDetailDefaults{Tag: "t-deep"},
+			},
+			want: "t-deep",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// WHEN: GetTag() is called on it.
+			got := tc.data.GetTag()
+
+			// THEN: the expected tag is returned.
+			if got != tc.want {
+				t.Fatalf(
+					"%s\nContainerDetailDefaults.GetTag() mismatch\ngot:  %q\nwant: %q",
 					tc.name, got, tc.want,
 				)
 			}

--- a/service/latest_version/filter/docker/defaults.go
+++ b/service/latest_version/filter/docker/defaults.go
@@ -26,10 +26,10 @@ import (
 
 // Defaults are the default values for DockerCheck.
 type Defaults struct {
-	Type            string                          `json:"type,omitempty" yaml:"type,omitempty"` // Type of the Docker registry.
-	ContainerDetail `json:",inline" yaml:",inline"` // Details about the container.
-	Registry        RegistryDefaultsSet             `json:"registry,omitzero" yaml:"registry,omitzero"` // Registry-specific defaults.
-	Defaults        *Defaults                       `json:"-" yaml:"-"`                                 // Defaults to fall back on.
+	Type                    string                          `json:"type,omitempty" yaml:"type,omitempty"` // Type of the Docker registry.
+	ContainerDetailDefaults `json:",inline" yaml:",inline"` // Default Tag template.
+	Registry                RegistryDefaultsSet             `json:"registry,omitzero" yaml:"registry,omitzero"` // Registry-specific defaults.
+	Defaults                *Defaults                       `json:"-" yaml:"-"`                                 // Defaults to fall back on.
 }
 
 // RegistryDefaultsSet holds per-registry default configuration.
@@ -78,7 +78,7 @@ func DecodeDefaults(
 // IsZero implements the yaml.IsZeroer interface.
 func (d *Defaults) IsZero() bool {
 	return d.Type == "" &&
-		d.ContainerDetail.IsZero() &&
+		d.ContainerDetailDefaults.IsZero() &&
 		d.Registry.IsZero()
 }
 
@@ -110,7 +110,7 @@ func (d *Defaults) String(prefix string) string {
 func (d *Defaults) Default() {
 	d.Type = "hub"
 	d.initRegistries()
-	d.ContainerDetail.Default()
+	d.ContainerDetailDefaults.Default()
 }
 
 // SetDefaults assigns defaults to the receiver.
@@ -120,12 +120,12 @@ func (d *Defaults) SetDefaults(defaults *Defaults) {
 		return
 	}
 	d.Defaults = defaults
-	d.ContainerDetail.Defaults = &defaults.ContainerDetail
+	d.ContainerDetailDefaults.Defaults = &defaults.ContainerDetailDefaults
 
 	defaults.initRegistries()
-	setRegistryDefaults(d.Registry.GHCR, defaults.Registry.GHCR, &d.ContainerDetail, &defaults.ContainerDetail)
-	setRegistryDefaults(d.Registry.Hub, defaults.Registry.Hub, &d.ContainerDetail, &defaults.ContainerDetail)
-	setRegistryDefaults(d.Registry.Quay, defaults.Registry.Quay, &d.ContainerDetail, &defaults.ContainerDetail)
+	setRegistryDefaults(d.Registry.GHCR, defaults.Registry.GHCR)
+	setRegistryDefaults(d.Registry.Hub, defaults.Registry.Hub)
+	setRegistryDefaults(d.Registry.Quay, defaults.Registry.Quay)
 }
 
 // ##########
@@ -203,19 +203,11 @@ func getRegistryDefaults(dType string, defaults *Defaults) RegistryDefaults {
 	return nil
 }
 
-// setRegistryDefaults links registry defaults and auth defaults to their parent defaults.
-func setRegistryDefaults(
-	registry RegistryDefaults,
-	defaultRegistry RegistryDefaults,
-	defaultDetail, hardDefaultDetail *ContainerDetail,
-) {
+// setRegistryDefaults links a registry's auth defaults to its parent defaults.
+func setRegistryDefaults(registry, defaultRegistry RegistryDefaults) {
 	if registry == nil || defaultRegistry == nil {
 		return
 	}
 
-	registry.SetDefaults(defaultRegistry, defaultDetail, hardDefaultDetail)
-
-	auth := registry.GetAuth()
-	defaultAuth := defaultRegistry.GetAuth()
-	auth.SetDefaults(defaultAuth)
+	registry.GetAuth().SetDefaults(defaultRegistry.GetAuth())
 }

--- a/service/latest_version/filter/docker/defaults_test.go
+++ b/service/latest_version/filter/docker/defaults_test.go
@@ -87,27 +87,20 @@ func TestDecodeDefaults(t *testing.T) {
 			format: "json",
 			data: test.TrimJSON(`{
 				"type": "ghcr",
-				"image": "{{ service_id }}",
 				"tag": "{{ version }}",
 				"registry": {
 					"ghcr": {
-						"image": "ghcr/{{ service_id }}",
-						"tag": "foo/ghcr",
 						"auth": {
 							"token": "ghcr-secret"
 						}
 					},
 					"hub": {
-						"image": "hub/{{ service_id }}",
-						"tag": "bar/hub",
 						"auth": {
 							"username": "hub-user",
 							"token": "hub-secret"
 						}
 					},
 					"quay": {
-						"image": "quay/{{ service_id }}",
-						"tag": "baz/quay",
 						"auth": {
 							"token": "quay-secret"
 						}
@@ -117,23 +110,16 @@ func TestDecodeDefaults(t *testing.T) {
 			errRegex: `^$`,
 			want: test.TrimYAML(`
 				type: ghcr
-				image: '{{ service_id }}'
 				tag: '{{ version }}'
 				registry:
 					ghcr:
-						image: ghcr/{{ service_id }}
-						tag: foo/ghcr
 						auth:
 							token: ghcr-secret
 					hub:
-						image: hub/{{ service_id }}
-						tag: bar/hub
 						auth:
 							username: hub-user
 							token: hub-secret
 					quay:
-						image: quay/{{ service_id }}
-						tag: baz/quay
 						auth:
 							token: quay-secret
 			`),
@@ -143,46 +129,32 @@ func TestDecodeDefaults(t *testing.T) {
 			format: "yaml",
 			data: test.TrimYAML(`
 				type: ghcr
-				image: '{{ service_id }}'
 				tag: '{{ version }}'
 				registry:
 					ghcr:
-						image: ghcr/{{ service_id }}
-						tag: foo/ghcr
 						auth:
 							token: ghcr-secret
 					hub:
-						image: ghcr/{{ service_id }}
-						tag: bar/hub
 						auth:
 							username: hub-user
 							token: hub-secret
 					quay:
-						image: ghcr/{{ service_id }}
-						tag: baz/quay
 						auth:
 							token: ghcr-secret
 			`),
 			errRegex: `^$`,
 			want: test.TrimYAML(`
 				type: ghcr
-				image: '{{ service_id }}'
 				tag: '{{ version }}'
 				registry:
 					ghcr:
-						image: ghcr/{{ service_id }}
-						tag: foo/ghcr
 						auth:
 							token: ghcr-secret
 					hub:
-						image: ghcr/{{ service_id }}
-						tag: bar/hub
 						auth:
 							username: hub-user
 							token: hub-secret
 					quay:
-						image: ghcr/{{ service_id }}
-						tag: baz/quay
 						auth:
 							token: ghcr-secret
 			`),
@@ -262,7 +234,6 @@ func TestDecodeDefaults(t *testing.T) {
 			var defaults Defaults
 			defaults.Default()
 			defaults.Type = ""
-			defaults.Image = ""
 			defaults.Tag = ""
 
 			// WHEN: DecodeDefaults is called.
@@ -293,11 +264,8 @@ func TestDecodeDefaults(t *testing.T) {
 			// THEN: The Defaults were passed over correctly.
 			fieldTests := []test.FieldAssertion{
 				{Name: "Defaults", Got: got.Defaults, Want: &defaults, Mode: test.CompareSamePointer},
-				{Name: "GHCR.Defaults", Got: got.Registry.GHCR.defaults, Want: defaults.Registry.GHCR, Mode: test.CompareSamePointer},
 				{Name: "GHCR.Auth.Defaults", Got: got.Registry.GHCR.GetAuth().Defaults(), Want: defaults.Registry.GHCR.GetAuth(), Mode: test.CompareSamePointer},
-				{Name: "Hub.Defaults", Got: got.Registry.Hub.defaults, Want: defaults.Registry.Hub, Mode: test.CompareSamePointer},
 				{Name: "Hub.Auth.Defaults", Got: got.Registry.Hub.GetAuth().Defaults(), Want: defaults.Registry.Hub.GetAuth(), Mode: test.CompareSamePointer},
-				{Name: "Quay.Defaults", Got: got.Registry.Quay.defaults, Want: defaults.Registry.Quay, Mode: test.CompareSamePointer},
 				{Name: "Quay.Auth.Defaults", Got: got.Registry.Quay.GetAuth().Defaults(), Want: defaults.Registry.Quay.GetAuth(), Mode: test.CompareSamePointer},
 			}
 			if err := test.AssertFields(t, fieldTests, prefix, "Defaults"); err != nil {
@@ -325,14 +293,12 @@ func TestDefaults_MarshalYAML(t *testing.T) {
 			name: "static fields",
 			defaults: &Defaults{
 				Type: PossibleTypes[0],
-				ContainerDetail: ContainerDetail{
-					Image: "test/app",
-					Tag:   "1.2.3",
+				ContainerDetailDefaults: ContainerDetailDefaults{
+					Tag: "1.2.3",
 				},
 			},
 			want: test.TrimYAML(`
 				type: ` + PossibleTypes[0] + `
-				image: test/app
 				tag: 1.2.3
 			`),
 		},
@@ -342,10 +308,6 @@ func TestDefaults_MarshalYAML(t *testing.T) {
 				Registry: RegistryDefaultsSet{
 					GHCR: &GHCRRegistryDefaults{
 						CommonRegistryDefaults: CommonRegistryDefaults{
-							ContainerDetail: ContainerDetail{
-								Image: "test/app-ghcr",
-								Tag:   "1.ghcr.2",
-							},
 							Auth: &GHCRAuth{
 								GHCRAuthDefaults: GHCRAuthDefaults{
 									Token: "ghcr-token",
@@ -355,10 +317,6 @@ func TestDefaults_MarshalYAML(t *testing.T) {
 					},
 					Hub: &HubRegistryDefaults{
 						CommonRegistryDefaults: CommonRegistryDefaults{
-							ContainerDetail: ContainerDetail{
-								Image: "test/app-hub",
-								Tag:   "1.hub.2",
-							},
 							Auth: &HubAuthDefaults{
 								Username: "hub-username",
 								Token:    "hub-token",
@@ -367,10 +325,6 @@ func TestDefaults_MarshalYAML(t *testing.T) {
 					},
 					Quay: &QuayRegistryDefaults{
 						CommonRegistryDefaults: CommonRegistryDefaults{
-							ContainerDetail: ContainerDetail{
-								Image: "test/app-quay",
-								Tag:   "1.quay.2",
-							},
 							Auth: &QuayAuthDefaults{
 								Token: "quay-token",
 							},
@@ -381,19 +335,13 @@ func TestDefaults_MarshalYAML(t *testing.T) {
 			want: test.TrimYAML(`
 				registry:
 					ghcr:
-						image: test/app-ghcr
-						tag: 1.ghcr.2
 						auth:
 							token: ghcr-token
 					hub:
-						image: test/app-hub
-						tag: 1.hub.2
 						auth:
 							username: hub-username
 							token: hub-token
 					quay:
-						image: test/app-quay
-						tag: 1.quay.2
 						auth:
 							token: quay-token
 			`),
@@ -402,17 +350,12 @@ func TestDefaults_MarshalYAML(t *testing.T) {
 			name: "filled",
 			defaults: &Defaults{
 				Type: PossibleTypes[0],
-				ContainerDetail: ContainerDetail{
-					Image: "test/app",
-					Tag:   "1.2.3",
+				ContainerDetailDefaults: ContainerDetailDefaults{
+					Tag: "1.2.3",
 				},
 				Registry: RegistryDefaultsSet{
 					GHCR: &GHCRRegistryDefaults{
 						CommonRegistryDefaults: CommonRegistryDefaults{
-							ContainerDetail: ContainerDetail{
-								Image: "test/app-ghcr",
-								Tag:   "1.ghcr.2",
-							},
 							Auth: &GHCRAuth{
 								GHCRAuthDefaults: GHCRAuthDefaults{
 									Token: "ghcr-token",
@@ -422,10 +365,6 @@ func TestDefaults_MarshalYAML(t *testing.T) {
 					},
 					Hub: &HubRegistryDefaults{
 						CommonRegistryDefaults: CommonRegistryDefaults{
-							ContainerDetail: ContainerDetail{
-								Image: "test/app-hub",
-								Tag:   "1.hub.2",
-							},
 							Auth: &HubAuthDefaults{
 								Username: "hub-username",
 								Token:    "hub-token",
@@ -434,10 +373,6 @@ func TestDefaults_MarshalYAML(t *testing.T) {
 					},
 					Quay: &QuayRegistryDefaults{
 						CommonRegistryDefaults: CommonRegistryDefaults{
-							ContainerDetail: ContainerDetail{
-								Image: "test/app-quay",
-								Tag:   "1.quay.2",
-							},
 							Auth: &QuayAuthDefaults{
 								Token: "quay-token",
 							},
@@ -447,23 +382,16 @@ func TestDefaults_MarshalYAML(t *testing.T) {
 			},
 			want: test.TrimYAML(`
 				type: ` + PossibleTypes[0] + `
-				image: test/app
 				tag: 1.2.3
 				registry:
 					ghcr:
-						image: test/app-ghcr
-						tag: 1.ghcr.2
 						auth:
 							token: ghcr-token
 					hub:
-						image: test/app-hub
-						tag: 1.hub.2
 						auth:
 							username: hub-username
 							token: hub-token
 					quay:
-						image: test/app-quay
-						tag: 1.quay.2
 						auth:
 							token: quay-token
 			`),
@@ -535,10 +463,10 @@ func TestDefaults_IsZero(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "non-empty/ContainerDetail",
+			name: "non-empty/ContainerDetailDefaults",
 			data: &Defaults{
-				ContainerDetail: ContainerDetail{
-					Image: "a",
+				ContainerDetailDefaults: ContainerDetailDefaults{
+					Tag: "a",
 				},
 			},
 			want: false,
@@ -549,8 +477,8 @@ func TestDefaults_IsZero(t *testing.T) {
 				Registry: RegistryDefaultsSet{
 					GHCR: &GHCRRegistryDefaults{
 						CommonRegistryDefaults: CommonRegistryDefaults{
-							ContainerDetail: ContainerDetail{
-								Image: "a",
+							Auth: &GHCRAuthDefaults{
+								Token: "a",
 							},
 						},
 					},
@@ -600,8 +528,8 @@ func TestRegistryDefaults_IsZero(t *testing.T) {
 			data: &RegistryDefaultsSet{
 				GHCR: &GHCRRegistryDefaults{
 					CommonRegistryDefaults: CommonRegistryDefaults{
-						ContainerDetail: ContainerDetail{
-							Image: "ghcr-image",
+						Auth: &GHCRAuthDefaults{
+							Token: "ghcr-token",
 						},
 					},
 				},
@@ -613,8 +541,8 @@ func TestRegistryDefaults_IsZero(t *testing.T) {
 			data: &RegistryDefaultsSet{
 				Hub: &HubRegistryDefaults{
 					CommonRegistryDefaults: CommonRegistryDefaults{
-						ContainerDetail: ContainerDetail{
-							Image: "hub-image",
+						Auth: &HubAuthDefaults{
+							Token: "hub-token",
 						},
 					},
 				},
@@ -626,8 +554,8 @@ func TestRegistryDefaults_IsZero(t *testing.T) {
 			data: &RegistryDefaultsSet{
 				Quay: &QuayRegistryDefaults{
 					CommonRegistryDefaults: CommonRegistryDefaults{
-						ContainerDetail: ContainerDetail{
-							Image: "quay-image",
+						Auth: &QuayAuthDefaults{
+							Token: "quay-token",
 						},
 					},
 				},
@@ -639,22 +567,22 @@ func TestRegistryDefaults_IsZero(t *testing.T) {
 			data: &RegistryDefaultsSet{
 				GHCR: &GHCRRegistryDefaults{
 					CommonRegistryDefaults: CommonRegistryDefaults{
-						ContainerDetail: ContainerDetail{
-							Image: "ghcr-image",
+						Auth: &GHCRAuthDefaults{
+							Token: "ghcr-token",
 						},
 					},
 				},
 				Hub: &HubRegistryDefaults{
 					CommonRegistryDefaults: CommonRegistryDefaults{
-						ContainerDetail: ContainerDetail{
-							Image: "hub-image",
+						Auth: &HubAuthDefaults{
+							Token: "hub-token",
 						},
 					},
 				},
 				Quay: &QuayRegistryDefaults{
 					CommonRegistryDefaults: CommonRegistryDefaults{
-						ContainerDetail: ContainerDetail{
-							Image: "quay-image",
+						Auth: &QuayAuthDefaults{
+							Token: "quay-token",
 						},
 					},
 				},
@@ -706,17 +634,12 @@ func TestDefaults_String(t *testing.T) {
 			name: "filled",
 			rDefaults: &Defaults{
 				Type: "ghcr",
-				ContainerDetail: ContainerDetail{
-					Image: "test/app",
-					Tag:   "1.2.3",
+				ContainerDetailDefaults: ContainerDetailDefaults{
+					Tag: "1.2.3",
 				},
 				Registry: RegistryDefaultsSet{
 					GHCR: &GHCRRegistryDefaults{
 						CommonRegistryDefaults: CommonRegistryDefaults{
-							ContainerDetail: ContainerDetail{
-								Image: "a",
-								Tag:   "0",
-							},
 							Auth: &GHCRAuth{
 								GHCRAuthDefaults: GHCRAuthDefaults{
 									Token: "t1",
@@ -726,10 +649,6 @@ func TestDefaults_String(t *testing.T) {
 					},
 					Hub: &HubRegistryDefaults{
 						CommonRegistryDefaults: CommonRegistryDefaults{
-							ContainerDetail: ContainerDetail{
-								Image: "b",
-								Tag:   "1",
-							},
 							Auth: &HubAuthDefaults{
 								Username: "u1",
 								Token:    "t2",
@@ -738,10 +657,6 @@ func TestDefaults_String(t *testing.T) {
 					},
 					Quay: &QuayRegistryDefaults{
 						CommonRegistryDefaults: CommonRegistryDefaults{
-							ContainerDetail: ContainerDetail{
-								Image: "a",
-								Tag:   "0",
-							},
 							Auth: &QuayAuthDefaults{
 								Token: "t1",
 							},
@@ -750,31 +665,23 @@ func TestDefaults_String(t *testing.T) {
 				},
 				Defaults: &Defaults{
 					Type: "ghcr",
-					ContainerDetail: ContainerDetail{
-						Image: "foo",
-						Tag:   "Bar",
+					ContainerDetailDefaults: ContainerDetailDefaults{
+						Tag: "Bar",
 					},
 				},
 			},
 			want: test.TrimYAML(`
 				type: ghcr
-				image: test/app
 				tag: 1.2.3
 				registry:
 					ghcr:
-						image: a
-						tag: '0'
 						auth:
 							token: t1
 					hub:
-						image: b
-						tag: '1'
 						auth:
 							username: u1
 							token: t2
 					quay:
-						image: a
-						tag: '0'
 						auth:
 							token: t1
 			`),
@@ -830,9 +737,8 @@ func TestDefaults_Default(t *testing.T) {
 						},
 					},
 				},
-				ContainerDetail: ContainerDetail{
-					Image: "i",
-					Tag:   "t",
+				ContainerDetailDefaults: ContainerDetailDefaults{
+					Tag: "t",
 				},
 			},
 		},
@@ -878,10 +784,10 @@ func TestDefaults_Default(t *testing.T) {
 				)
 			}
 
-			// AND: the ContainerDetail Tag is defaulted.
-			if got := tc.data.ContainerDetail.Tag; got != defaultContainerDetailTag {
+			// AND: the ContainerDetailDefaults Tag is defaulted.
+			if got := tc.data.ContainerDetailDefaults.Tag; got != defaultContainerDetailTag {
 				t.Fatalf(
-					"%s .ContainerDetail.Tag value mismatch\ngot:  %q\nwant: %q",
+					"%s .ContainerDetailDefaults.Tag value mismatch\ngot:  %q\nwant: %q",
 					prefix, got, defaultContainerDetailTag,
 				)
 			}
@@ -945,11 +851,8 @@ func TestDefaults_Defaults(t *testing.T) {
 				return
 			}
 			fieldTests := []test.FieldAssertion{
-				{Name: "GHCR.Defaults", Got: defaults.Registry.GHCR.Defaults(), Want: tc.defaults.Registry.GHCR, Mode: test.CompareSamePointer},
 				{Name: "GHCR.Auth.Defaults", Got: defaults.Registry.GHCR.GetAuth().Defaults(), Want: tc.defaults.Registry.GHCR.GetAuth(), Mode: test.CompareSamePointer},
-				{Name: "Hub.Defaults", Got: defaults.Registry.Hub.Defaults(), Want: tc.defaults.Registry.Hub, Mode: test.CompareSamePointer},
 				{Name: "Hub.Auth.Defaults", Got: defaults.Registry.Hub.GetAuth().Defaults(), Want: tc.defaults.Registry.Hub.GetAuth(), Mode: test.CompareSamePointer},
-				{Name: "Quay.Defaults", Got: defaults.Registry.Quay.Defaults(), Want: tc.defaults.Registry.Quay, Mode: test.CompareSamePointer},
 				{Name: "Quay.Auth.Defaults", Got: defaults.Registry.Quay.GetAuth().Defaults(), Want: tc.defaults.Registry.Quay.GetAuth(), Mode: test.CompareSamePointer},
 			}
 			if err := test.AssertFields(t, fieldTests, prefix, "Defaults"); err != nil {
@@ -1280,34 +1183,20 @@ func TestSetRegistryDefaults(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			// ContainerDetail above the 'tc.registry'.
-			defaultDetail := &ContainerDetail{}
-			// ContainerDetail above the 'tc.defaultRegistry'.
-			hardDefaultDetail := &ContainerDetail{}
-
 			// WHEN: setRegistryDefaults is called with these.
-			setRegistryDefaults(
-				tc.registry,
-				tc.defaultRegistry,
-				defaultDetail,
-				hardDefaultDetail,
-			)
+			setRegistryDefaults(tc.registry, tc.defaultRegistry)
 
 			if tc.registry == nil || tc.defaultRegistry == nil {
 				return
 			}
 			prefix := fmt.Sprintf(
-				"%s\nsetRegistryDefaults(registry=%p, defaultRegistry=%p, defaultDetail=%p, hardDefaultDetail=%p)",
-				packageName, tc.registry, tc.defaultRegistry, defaultDetail, hardDefaultDetail,
+				"%s\nsetRegistryDefaults(registry=%p, defaultRegistry=%p)",
+				packageName, tc.registry, tc.defaultRegistry,
 			)
 
-			// THEN: the defaults have been updated as expected.
+			// THEN: the auth defaults have been linked as expected.
 			fieldTests := []test.FieldAssertion{
-				{Name: "Defaults", Got: tc.registry.Defaults(), Want: tc.defaultRegistry, Mode: test.CompareSamePointer},
 				{Name: "Auth.Defaults", Got: tc.registry.GetAuth().Defaults(), Want: tc.defaultRegistry.GetAuth(), Mode: test.CompareSamePointer},
-				{Name: "Detail.Default (Registry defaults)", Got: tc.registry.GetContainerDetail().Defaults, Want: tc.defaultRegistry.GetContainerDetail(), Mode: test.CompareSamePointer},
-				{Name: "Detail.Default.Default (Root defaults)", Got: tc.registry.GetContainerDetail().Defaults.Defaults, Want: defaultDetail, Mode: test.CompareSamePointer},
-				{Name: "Detail.Default.Default.Default (Root hardDefaults)", Got: tc.registry.GetContainerDetail().Defaults.Defaults.Defaults, Want: hardDefaultDetail, Mode: test.CompareSamePointer},
 			}
 			if testErr := test.AssertFields(t, fieldTests, prefix, ""); testErr != nil {
 				t.Fatal(testErr)

--- a/service/latest_version/filter/docker/interfaces.go
+++ b/service/latest_version/filter/docker/interfaces.go
@@ -70,17 +70,7 @@ type RegistryDefaults interface {
 	// GetType returns the fixed registry kind (e.g. "hub", "ghcr", "quay").
 	GetType() string
 
-	GetContainerDetail() *ContainerDetail
 	GetAuth() RegistryAuthDefaults
-	GetImage() string
-	GetTag() string
-
-	// Defaults returns the next link in the registry defaults chain.
-	Defaults() RegistryDefaults
-
-	// SetDefaults applies defaults to the receiver.
-	// receiver -> rDefaults -> defaultDetail -> hardDefaultDetail.
-	SetDefaults(rDefaults RegistryDefaults, defaultDetail, hardDefaultDetail *ContainerDetail)
 
 	// String returns a YAML string representation of the receiver.
 	String(prefix string) string

--- a/service/latest_version/filter/docker/registry_common.go
+++ b/service/latest_version/filter/docker/registry_common.go
@@ -33,9 +33,7 @@ import (
 
 // CommonRegistryDefaults holds shared default fields for registry checkers.
 type CommonRegistryDefaults struct {
-	ContainerDetail `json:",inline" yaml:",inline"`
-	Auth            RegistryAuthDefaults `json:"auth,omitempty" yaml:"auth,omitempty"`
-	defaults        RegistryDefaults
+	Auth RegistryAuthDefaults `json:"auth,omitempty" yaml:"auth,omitempty"`
 }
 
 // CommonRegistry holds shared fields for a registry checkers.
@@ -74,11 +72,6 @@ func (r *CommonRegistryDefaults) UnmarshalYAML(data []byte) error {
 
 // unmarshal implements the format.Unmarshaler interface.
 func (r *CommonRegistryDefaults) unmarshal(format string, data []byte) error {
-	// ContainerDetail.
-	if err := decode.Unmarshal(format, data, &r.ContainerDetail); err != nil {
-		return err //nolint:wrapcheck
-	}
-
 	// Auth.
 	if err := polymorphic.Unmarshal(format, data, "auth", r.Auth); err != nil {
 		return err //nolint:wrapcheck
@@ -110,7 +103,8 @@ func (r *CommonRegistry) unmarshal(format string, data []byte) error {
 		return err //nolint:wrapcheck
 	}
 	r.Type = aux.Type
-	r.ContainerDetail = aux.ContainerDetail
+	r.Image = aux.ContainerDetail.Image
+	r.Tag = aux.ContainerDetail.Tag
 
 	// Auth.
 	if err := polymorphic.Unmarshal(format, data, "auth", r.Auth); err != nil {
@@ -171,50 +165,6 @@ func (r *CommonRegistry) String(prefix string) string {
 // #######################
 
 // Defaults returns the defaults for the registry.
-func (r *CommonRegistryDefaults) Defaults() RegistryDefaults {
-	if r.defaults == nil {
-		return nil
-	}
-
-	return r.defaults
-}
-
-// SetDefaults applies defaults to the receiver.
-// receiver -> rDefaults -> defaultDetail -> hardDefaultDetail.
-func (r *CommonRegistryDefaults) SetDefaults(rDefaults RegistryDefaults, defaultDetail, hardDefaultDetail *ContainerDetail) {
-	if rDefaults == nil {
-		return
-	}
-
-	r.defaults = rDefaults
-
-	// ContainerDetail linking.
-	linkContainerDetails(
-		r.GetContainerDetail(),
-		rDefaults.GetContainerDetail(),
-		defaultDetail,
-		hardDefaultDetail,
-	)
-}
-
-// linkContainerDetails builds the ContainerDetail inheritance chain.
-//
-// hierarchy:
-//
-//	registry
-//	    ↓
-//	registry defaults
-//	    ↓
-//	root
-//	    ↓
-//	root defaults
-func linkContainerDetails(registry, registryDefaults, root, rootDefaults *ContainerDetail) {
-	registry.Defaults = registryDefaults
-	registryDefaults.Defaults = root
-	root.Defaults = rootDefaults
-}
-
-// Defaults returns the defaults for the registry.
 func (r *CommonRegistry) Defaults() RegistryDefaults {
 	if r.defaults == nil {
 		return nil
@@ -235,7 +185,7 @@ func (r *CommonRegistry) SetDefaults(dType string, defaults *Defaults) {
 	}
 
 	r.defaults = rDefaults
-	r.ContainerDetail.Defaults = rDefaults.GetContainerDetail()
+	r.ContainerDetail.Defaults = &defaults.ContainerDetailDefaults
 	r.Auth.SetDefaults(r.defaults.GetAuth())
 }
 
@@ -253,19 +203,9 @@ func (r *CommonRegistry) GetImageSelf() string {
 	return r.Image
 }
 
-// GetImage returns the Image to use for this registry (include defaults).
+// GetImage returns the Image to query on.
 func (r *CommonRegistry) GetImage() string {
-	if image := r.ContainerDetail.GetImage(); image != "" {
-		return image
-	}
-
-	for registry := r.defaults; registry != nil; registry = registry.Defaults() {
-		if image := registry.GetImage(); image != "" {
-			return image
-		}
-	}
-
-	return ""
+	return r.ContainerDetail.GetImage()
 }
 
 // GetTagSelf returns the Tag to query for.
@@ -273,19 +213,9 @@ func (r *CommonRegistry) GetTagSelf() string {
 	return r.Tag
 }
 
-// GetTag returns the Tag.
+// GetTag returns the Tag to query for.
 func (r *CommonRegistry) GetTag() string {
-	if tag := r.ContainerDetail.GetTag(); tag != "" {
-		return tag
-	}
-
-	for registry := r.defaults; registry != nil; registry = registry.Defaults() {
-		if tag := registry.GetTag(); tag != "" {
-			return tag
-		}
-	}
-
-	return ""
+	return r.ContainerDetail.GetTag()
 }
 
 // #########################
@@ -385,11 +315,6 @@ func (r *CommonRegistry) parseBody(tag string, resp *http.Response) error {
 	}
 
 	return nil
-}
-
-// GetContainerDetail returns a pointer to the container detail on these defaults.
-func (r *CommonRegistryDefaults) GetContainerDetail() *ContainerDetail {
-	return &r.ContainerDetail
 }
 
 // Detail returns the resolved image and tag used for registry queries.

--- a/service/latest_version/filter/docker/registry_common_test.go
+++ b/service/latest_version/filter/docker/registry_common_test.go
@@ -48,11 +48,8 @@ func TestCommonRegistryDefaults_Unmarshal(t *testing.T) {
 			format:   "json",
 			data:     "",
 			registry: &CommonRegistryDefaults{},
-			errRegex: test.TrimYAML(`
-				^jsontext:
-					unexpected EOF$`,
-			),
-			want: "",
+			errRegex: `^$`,
+			want:     "{}\n",
 		},
 		{
 			name:     "JSON/empty object",
@@ -83,20 +80,6 @@ func TestCommonRegistryDefaults_Unmarshal(t *testing.T) {
 			data:     "foo",
 			registry: &CommonRegistryDefaults{},
 			errRegex: `string was used where mapping is expected`,
-		},
-		{
-			name:     "JSON/invalid ContainerDetail",
-			format:   "json",
-			data:     `{"image": []}`,
-			registry: &CommonRegistryDefaults{},
-			errRegex: `^json: .*unmarshal.*`,
-		},
-		{
-			name:     "YAML/invalid ContainerDetail",
-			format:   "yaml",
-			data:     `image: []`,
-			registry: &CommonRegistryDefaults{},
-			errRegex: `^[^\s]+ .*unmarshal .*`,
 		},
 		{
 			name:   "JSON/auth invalid data type",
@@ -138,8 +121,6 @@ func TestCommonRegistryDefaults_Unmarshal(t *testing.T) {
 			},
 			errRegex: `^$`,
 			want: test.TrimYAML(`
-				image: i
-				tag: t
 				auth:
 					token: tOKEn
 			`),
@@ -148,8 +129,6 @@ func TestCommonRegistryDefaults_Unmarshal(t *testing.T) {
 			name:   "YAML/auth-ghcr",
 			format: "yaml",
 			data: test.TrimYAML(`
-				image: i
-				tag: t
 				auth:
 					username: ghcr-username
 					token: tOKEn
@@ -159,8 +138,6 @@ func TestCommonRegistryDefaults_Unmarshal(t *testing.T) {
 			},
 			errRegex: `^$`,
 			want: test.TrimYAML(`
-				image: i
-				tag: t
 				auth:
 					token: tOKEn
 			`),
@@ -181,8 +158,6 @@ func TestCommonRegistryDefaults_Unmarshal(t *testing.T) {
 			},
 			errRegex: `^$`,
 			want: test.TrimYAML(`
-				image: i
-				tag: t
 				auth:
 					username: hub-username
 					token: tOKEn
@@ -192,8 +167,6 @@ func TestCommonRegistryDefaults_Unmarshal(t *testing.T) {
 			name:   "YAML/auth-hub",
 			format: "yaml",
 			data: test.TrimYAML(`
-				image: i
-				tag: t
 				auth:
 					username: hub-username
 					token: tOKEn
@@ -203,8 +176,6 @@ func TestCommonRegistryDefaults_Unmarshal(t *testing.T) {
 			},
 			errRegex: `^$`,
 			want: test.TrimYAML(`
-				image: i
-				tag: t
 				auth:
 					username: hub-username
 					token: tOKEn
@@ -226,8 +197,6 @@ func TestCommonRegistryDefaults_Unmarshal(t *testing.T) {
 			},
 			errRegex: `^$`,
 			want: test.TrimYAML(`
-				image: i
-				tag: t
 				auth:
 					token: tOKEn
 			`),
@@ -236,8 +205,6 @@ func TestCommonRegistryDefaults_Unmarshal(t *testing.T) {
 			name:   "YAML/auth-quay",
 			format: "yaml",
 			data: test.TrimYAML(`
-				image: i
-				tag: t
 				auth:
 					username: quay-username
 					token: tOKEn
@@ -247,8 +214,6 @@ func TestCommonRegistryDefaults_Unmarshal(t *testing.T) {
 			},
 			errRegex: `^$`,
 			want: test.TrimYAML(`
-				image: i
-				tag: t
 				auth:
 					token: tOKEn
 			`),
@@ -328,20 +293,6 @@ func TestCommonRegistry_Unmarshal(t *testing.T) {
 			data:     "foo",
 			registry: &CommonRegistry{},
 			errRegex: `string was used where mapping is expected`,
-		},
-		{
-			name:     "JSON/invalid ContainerDetail",
-			format:   "json",
-			data:     `{"image": []}`,
-			registry: &CommonRegistry{},
-			errRegex: `^json: .*unmarshal.*`,
-		},
-		{
-			name:     "YAML/invalid ContainerDetail",
-			format:   "yaml",
-			data:     `image: []`,
-			registry: &CommonRegistry{},
-			errRegex: `^[^\s]+ .*unmarshal .*`,
 		},
 		{
 			name:   "JSON/invalid Auth",
@@ -497,6 +448,20 @@ func TestCommonRegistry_Unmarshal(t *testing.T) {
 				auth:
 					token: tOKEn
 			`),
+		},
+		{
+			name:     "JSON/invalid ContainerDetail",
+			format:   "json",
+			data:     `{"image": []}`,
+			registry: &CommonRegistry{},
+			errRegex: `^json: .*unmarshal.*`,
+		},
+		{
+			name:     "YAML/invalid ContainerDetail",
+			format:   "yaml",
+			data:     `image: []`,
+			registry: &CommonRegistry{},
+			errRegex: `^[^\s]+ .*unmarshal .*`,
 		},
 	}
 
@@ -790,201 +755,6 @@ func TestCommonRegistry_String(t *testing.T) {
 // # REGISTRY | DEFAULTS #
 // #######################
 
-func TestCommonRegistryDefaults_Defaults(t *testing.T) {
-	// GIVEN: a fresh CommonRegistryDefaults.
-	var registry CommonRegistryDefaults
-
-	// WHEN: Defaults is called on it.
-	got := registry.Defaults()
-
-	// THEN: nil is received.
-	if got != nil {
-		t.Errorf(
-			"%s\nfresh CommonRegistryDefaults\ngot:  %v\nwant: nil",
-			packageName, got,
-		)
-	}
-
-	for _, dType := range PossibleTypes {
-		t.Run(dType, func(t *testing.T) {
-			// GIVEN: Defaults.
-			defaults := Defaults{
-				Registry: RegistryDefaultsSet{
-					GHCR: &GHCRRegistryDefaults{
-						CommonRegistryDefaults: CommonRegistryDefaults{
-							Auth: &HubAuthDefaults{
-								Token: "ghcr-token",
-							},
-						},
-					},
-					Hub: &HubRegistryDefaults{
-						CommonRegistryDefaults: CommonRegistryDefaults{
-							Auth: &HubAuthDefaults{
-								Token:    "hub-token",
-								Username: "hub-username",
-							},
-						},
-					},
-					Quay: &QuayRegistryDefaults{
-						CommonRegistryDefaults: CommonRegistryDefaults{
-							Auth: &HubAuthDefaults{
-								Token: "hub-token",
-							},
-						},
-					},
-				},
-			}
-			registry.Auth = RegistryMap[dType]().GetAuth()
-			rDefaults := getRegistryDefaults(dType, &defaults)
-			rootContainerDetail := ContainerDetail{}
-
-			// WHEN: SetDefaults is called with them.
-			registry.SetDefaults(rDefaults, &rootContainerDetail, &defaults.ContainerDetail)
-
-			prefix := fmt.Sprintf(
-				"%s\nSetDefaults(type=%q, defaults=%+v)\n",
-				packageName, dType, defaults,
-			)
-
-			// THEN: Defaults is set to the corresponding type defaults.
-			got := registry.Defaults()
-			var want RegistryDefaults
-			if want = getRegistryDefaults(dType, &defaults); want == nil {
-				t.Fatalf(
-					"%s expected defaults for registry type %q, but none found in %+v",
-					prefix, dType, defaults,
-				)
-			}
-			if got != want {
-				t.Fatalf(
-					"%s .Defaults() pointer mismatch\ngot:  %p\nwant: %p",
-					prefix, got, want,
-				)
-			}
-
-			// AND: Defaults are handed out as expected.
-			fieldTests := []test.FieldAssertion{
-				{Name: "GetContainerDetail()", Got: got.GetContainerDetail(), Want: want.GetContainerDetail(), Mode: test.CompareSamePointer},
-				{Name: "GetContainerDetail().Defaults", Got: got.GetContainerDetail().Defaults, Want: want.GetContainerDetail().Defaults, Mode: test.CompareSamePointer},
-				{Name: "GetAuth()", Got: got.GetAuth(), Want: want.GetAuth(), Mode: test.CompareSamePointer},
-			}
-			if err := test.AssertFields(t, fieldTests, prefix, "CommonRegistryDefaults"); err != nil {
-				t.Fatal(err)
-			}
-
-			// AND: ContainerDetail is chained as expected.
-			fieldTests = []test.FieldAssertion{
-				{ // Layer 1: Registry HardDefaults
-					Name: "L1: Registry.ContainerDetail.Defaults -> HardDefaults.Registry.ContainerDetail",
-					Got:  registry.ContainerDetail.Defaults,
-					Want: rDefaults.GetContainerDetail(),
-					Mode: test.CompareSamePointer,
-				},
-				{ // Layer 2: Root Defaults
-					Name: "L2: LatestVersion.Require.Docker.Registry.GHCR.ContainerDetail.Defaults.Defaults -> Defaults.ContainerDetail",
-					Got:  registry.ContainerDetail.Defaults.Defaults,
-					Want: &rootContainerDetail,
-					Mode: test.CompareSamePointer,
-				},
-				{ // Layer 3: Root HardDefaults
-					Name: "L3: LatestVersion.Require.Docker.Registry.GHCR.ContainerDetail.Defaults.Defaults.Defaults -> HardDefaults.ContainerDetail",
-					Got:  registry.ContainerDetail.Defaults.Defaults.Defaults,
-					Want: &defaults.ContainerDetail,
-					Mode: test.CompareSamePointer,
-				},
-			}
-			if err := test.AssertFields(t, fieldTests, prefix, "CommonRegistryDefaults.ContainerDetail"); err != nil {
-				t.Fatal(err)
-			}
-		})
-	}
-}
-
-func TestCommonRegistryDefaults_Defaults__nil(t *testing.T) {
-	// GIVEN: a fresh CommonRegistryDefaults.
-	var registry CommonRegistryDefaults
-
-	// WHEN: Defaults is called on it.
-	got := registry.Defaults()
-
-	// THEN: nil is received.
-	if got != nil {
-		t.Errorf(
-			"%s\nfresh CommonRegistryDefaults\ngot:  %v\nwant: nil",
-			packageName, got,
-		)
-	}
-
-	// ---
-
-	// GIVEN: nil Defaults.
-	var defaults *Defaults
-
-	for _, dType := range PossibleTypes {
-		var rDefaults RegistryDefaults
-		registry.Auth = RegistryMap[dType]().GetAuth()
-
-		// WHEN: SetDefaults is called with them.
-		registry.SetDefaults(
-			rDefaults,
-			&ContainerDetail{},
-			&ContainerDetail{},
-		)
-
-		prefix := fmt.Sprintf(
-			"%s\nSetDefaults(%q)",
-			packageName, dType,
-		)
-
-		// THEN: Defaults remain nil.
-		if registry.Defaults(); got != nil {
-			t.Fatalf(
-				"%s Registry defaults mismatch\ngot:  %v\nwant: nil",
-				prefix, got,
-			)
-		}
-	}
-
-	// ---
-
-	// GIVEN: Defaults with nil Registry.* values.
-	defaults = &Defaults{
-		Registry: RegistryDefaultsSet{
-			GHCR: nil,
-			Hub:  nil,
-			Quay: nil,
-		},
-	}
-	for _, dType := range PossibleTypes {
-		registry.Auth = RegistryMap[dType]().GetAuth()
-
-		rDefaults := getRegistryDefaults(dType, defaults)
-
-		// WHEN: SetDefaults is called with them.
-		registry.SetDefaults(
-			rDefaults,
-			&ContainerDetail{},
-			&ContainerDetail{},
-		)
-
-		// THEN: Defaults is set to the corresponding type defaults.
-		if got := registry.Defaults(); got != nil {
-			t.Fatalf(
-				"%s\nDefaults mismatch after SetDefaults(%q)\ngot:  %v\nwant: nil",
-				packageName, dType, got,
-			)
-		}
-
-		// AND: Defaults of Auth are set to the corresponding type defaults.
-		if got := registry.Auth.Defaults(); got != nil {
-			t.Fatalf(
-				"%s\nAuth defaults mismatch after SetDefaults(%q)\ngot:  %v\nwant: nil",
-				packageName, dType, got,
-			)
-		}
-	}
-}
-
 func TestCommonRegistry_Defaults(t *testing.T) {
 	// GIVEN: a fresh CommonRegistry.
 	var registry CommonRegistry
@@ -1211,49 +981,15 @@ func TestCommonRegistry_GetImageSelf(t *testing.T) {
 		want     string
 	}{
 		{
-			name: "GHCR",
-			registry: CommonRegistry{
-				ContainerDetail: ContainerDetail{
-					Image: "image-here",
-				},
-				defaults: &GHCRRegistryDefaults{
-					CommonRegistryDefaults: CommonRegistryDefaults{
-						ContainerDetail: ContainerDetail{
-							Image: "other-image-here",
-						},
-					},
-				},
-			},
-			want: "image-here",
+			name:     "empty",
+			registry: CommonRegistry{},
+			want:     "",
 		},
 		{
-			name: "Hub",
+			name: "image set",
 			registry: CommonRegistry{
 				ContainerDetail: ContainerDetail{
 					Image: "image-here",
-				},
-				defaults: &HubRegistryDefaults{
-					CommonRegistryDefaults: CommonRegistryDefaults{
-						ContainerDetail: ContainerDetail{
-							Image: "other-image-here",
-						},
-					},
-				},
-			},
-			want: "image-here",
-		},
-		{
-			name: "Quay",
-			registry: CommonRegistry{
-				ContainerDetail: ContainerDetail{
-					Image: "image-here",
-				},
-				defaults: &QuayRegistryDefaults{
-					CommonRegistryDefaults: CommonRegistryDefaults{
-						ContainerDetail: ContainerDetail{
-							Image: "other-image-here",
-						},
-					},
 				},
 			},
 			want: "image-here",
@@ -1279,135 +1015,25 @@ func TestCommonRegistry_GetImageSelf(t *testing.T) {
 }
 
 func TestCommonRegistry_GetImage(t *testing.T) {
-	// GIVEN: a DockerCheck with an image.
+	// GIVEN: a CommonRegistry with an image.
 	tests := []struct {
 		name     string
 		registry CommonRegistry
 		want     string
 	}{
 		{
-			name: "empty image",
-			registry: CommonRegistry{
-				ContainerDetail: ContainerDetail{
-					Image: "",
-				},
-				defaults: &GHCRRegistryDefaults{
-					CommonRegistryDefaults: CommonRegistryDefaults{
-						ContainerDetail: ContainerDetail{
-							Image: "",
-						},
-					},
-				},
-			},
-			want: "",
+			name:     "empty image",
+			registry: CommonRegistry{},
+			want:     "",
 		},
 		{
-			name: "Image from root",
+			name: "image set",
 			registry: CommonRegistry{
 				ContainerDetail: ContainerDetail{
-					Image: "test/app-root",
-				},
-				defaults: &GHCRRegistryDefaults{
-					CommonRegistryDefaults: CommonRegistryDefaults{
-						ContainerDetail: ContainerDetail{
-							Image: "",
-						},
-					},
+					Image: "test/app",
 				},
 			},
-			want: "test/app-root",
-		},
-		{
-			name: "Image from defaults",
-			registry: CommonRegistry{
-				ContainerDetail: ContainerDetail{
-					Image: "",
-				},
-				defaults: &GHCRRegistryDefaults{
-					CommonRegistryDefaults: CommonRegistryDefaults{
-						ContainerDetail: ContainerDetail{
-							Image: "test/app-defaults",
-						},
-						defaults: &GHCRRegistryDefaults{
-							CommonRegistryDefaults: CommonRegistryDefaults{
-								ContainerDetail: ContainerDetail{
-									Image: "",
-								},
-							},
-						},
-					},
-				},
-			},
-			want: "test/app-defaults",
-		},
-		{
-			name: "Image from hardDefaults",
-			registry: CommonRegistry{
-				ContainerDetail: ContainerDetail{
-					Image: "",
-				},
-				defaults: &GHCRRegistryDefaults{
-					CommonRegistryDefaults: CommonRegistryDefaults{
-						ContainerDetail: ContainerDetail{
-							Image: "",
-						},
-						defaults: &GHCRRegistryDefaults{
-							CommonRegistryDefaults: CommonRegistryDefaults{
-								ContainerDetail: ContainerDetail{
-									Image: "test/app-hardDefaults",
-								},
-							},
-						},
-					},
-				},
-			},
-			want: "test/app-hardDefaults",
-		},
-		{
-			name: "Image from root, ignore defaults and hardDefaults",
-			registry: CommonRegistry{
-				ContainerDetail: ContainerDetail{
-					Image: "test/app-root",
-				},
-				defaults: &GHCRRegistryDefaults{
-					CommonRegistryDefaults: CommonRegistryDefaults{
-						ContainerDetail: ContainerDetail{
-							Image: "test/app-defaults",
-						},
-						defaults: &GHCRRegistryDefaults{
-							CommonRegistryDefaults: CommonRegistryDefaults{
-								ContainerDetail: ContainerDetail{
-									Image: "test/app-hardDefaults",
-								},
-							},
-						},
-					},
-				},
-			},
-			want: "test/app-root",
-		},
-		{
-			name: "Image from defaults, ignore hardDefaults",
-			registry: CommonRegistry{
-				ContainerDetail: ContainerDetail{
-					Image: "",
-				},
-				defaults: &GHCRRegistryDefaults{
-					CommonRegistryDefaults: CommonRegistryDefaults{
-						ContainerDetail: ContainerDetail{
-							Image: "test/app-defaults",
-						},
-						defaults: &GHCRRegistryDefaults{
-							CommonRegistryDefaults: CommonRegistryDefaults{
-								ContainerDetail: ContainerDetail{
-									Image: "test/app-hardDefaults",
-								},
-							},
-						},
-					},
-				},
-			},
-			want: "test/app-defaults",
+			want: "test/app",
 		},
 	}
 
@@ -1418,7 +1044,7 @@ func TestCommonRegistry_GetImage(t *testing.T) {
 			// WHEN: GetImage is called on it.
 			got := tc.registry.GetImage()
 
-			// THEN: the expected Tag is returned.
+			// THEN: the expected image is returned.
 			if got != tc.want {
 				t.Errorf(
 					"%s\nCommonRegistry.GetImage() mismatch\ngot:  %q\nwant: %q",
@@ -1437,52 +1063,29 @@ func TestCommonRegistry_GetTagSelf(t *testing.T) {
 		want     string
 	}{
 		{
-			name: "GHCR",
+			name:     "empty",
+			registry: CommonRegistry{},
+			want:     "",
+		},
+		{
+			name: "tag set",
 			registry: CommonRegistry{
 				ContainerDetail: ContainerDetail{
 					Tag: "tag-here",
-				},
-				defaults: &GHCRRegistryDefaults{
-					CommonRegistryDefaults: CommonRegistryDefaults{
-						ContainerDetail: ContainerDetail{
-							Tag: "other-tag-here",
-						},
-					},
 				},
 			},
 			want: "tag-here",
 		},
 		{
-			name: "Hub",
+			name: "tag ignored in defaults",
 			registry: CommonRegistry{
 				ContainerDetail: ContainerDetail{
-					Tag: "tag-here",
-				},
-				defaults: &HubRegistryDefaults{
-					CommonRegistryDefaults: CommonRegistryDefaults{
-						ContainerDetail: ContainerDetail{
-							Tag: "other-tag-here",
-						},
+					Defaults: &ContainerDetailDefaults{
+						Tag: "tag-defaults",
 					},
 				},
 			},
-			want: "tag-here",
-		},
-		{
-			name: "Quay",
-			registry: CommonRegistry{
-				ContainerDetail: ContainerDetail{
-					Tag: "tag-here",
-				},
-				defaults: &QuayRegistryDefaults{
-					CommonRegistryDefaults: CommonRegistryDefaults{
-						ContainerDetail: ContainerDetail{
-							Tag: "other-tag-here",
-						},
-					},
-				},
-			},
-			want: "tag-here",
+			want: "",
 		},
 	}
 
@@ -1505,135 +1108,78 @@ func TestCommonRegistry_GetTagSelf(t *testing.T) {
 }
 
 func TestCommonRegistry_GetTag(t *testing.T) {
-	// GIVEN: a DockerCheck with a tag.
+	// GIVEN: a CommonRegistry with a tag default chain.
 	tests := []struct {
 		name     string
 		registry CommonRegistry
 		want     string
 	}{
 		{
-			name: "empty tag",
-			registry: CommonRegistry{
-				ContainerDetail: ContainerDetail{
-					Tag: "",
-				},
-				defaults: &GHCRRegistryDefaults{
-					CommonRegistryDefaults: CommonRegistryDefaults{
-						ContainerDetail: ContainerDetail{
-							Tag: "",
-						},
-					},
-				},
-			},
-			want: "",
+			name:     "empty tag",
+			registry: CommonRegistry{},
+			want:     "",
 		},
 		{
-			name: "Tag from root",
+			name: "Tag from instance",
 			registry: CommonRegistry{
 				ContainerDetail: ContainerDetail{
-					Tag: "test/app-root",
-				},
-				defaults: &GHCRRegistryDefaults{
-					CommonRegistryDefaults: CommonRegistryDefaults{
-						ContainerDetail: ContainerDetail{
-							Tag: "",
-						},
-					},
+					Tag: "t-instance",
 				},
 			},
-			want: "test/app-root",
+			want: "t-instance",
 		},
 		{
 			name: "Tag from defaults",
 			registry: CommonRegistry{
 				ContainerDetail: ContainerDetail{
-					Tag: "",
-				},
-				defaults: &GHCRRegistryDefaults{
-					CommonRegistryDefaults: CommonRegistryDefaults{
-						ContainerDetail: ContainerDetail{
-							Tag: "test/app-defaults",
-						},
-						defaults: &GHCRRegistryDefaults{
-							CommonRegistryDefaults: CommonRegistryDefaults{
-								ContainerDetail: ContainerDetail{
-									Tag: "",
-								},
-							},
-						},
+					Defaults: &ContainerDetailDefaults{
+						Tag: "t-defaults",
 					},
 				},
 			},
-			want: "test/app-defaults",
+			want: "t-defaults",
 		},
 		{
 			name: "Tag from hardDefaults",
 			registry: CommonRegistry{
 				ContainerDetail: ContainerDetail{
-					Tag: "",
-				},
-				defaults: &GHCRRegistryDefaults{
-					CommonRegistryDefaults: CommonRegistryDefaults{
-						ContainerDetail: ContainerDetail{
-							Tag: "",
-						},
-						defaults: &GHCRRegistryDefaults{
-							CommonRegistryDefaults: CommonRegistryDefaults{
-								ContainerDetail: ContainerDetail{
-									Tag: "test/app-hardDefaults",
-								},
-							},
+					Defaults: &ContainerDetailDefaults{
+						Defaults: &ContainerDetailDefaults{
+							Tag: "t-hardDefaults",
 						},
 					},
 				},
 			},
-			want: "test/app-hardDefaults",
+			want: "t-hardDefaults",
 		},
 		{
-			name: "Tag from root, ignore defaults and hardDefaults",
+			name: "Tag from instance, ignore defaults and hardDefaults",
 			registry: CommonRegistry{
 				ContainerDetail: ContainerDetail{
-					Tag: "test/app-root",
-				},
-				defaults: &GHCRRegistryDefaults{
-					CommonRegistryDefaults: CommonRegistryDefaults{
-						ContainerDetail: ContainerDetail{
-							Tag: "test/app-defaults",
-						},
-						defaults: &GHCRRegistryDefaults{
-							CommonRegistryDefaults: CommonRegistryDefaults{
-								ContainerDetail: ContainerDetail{
-									Tag: "test/app-hardDefaults",
-								},
-							},
+					Tag: "t-instance",
+					Defaults: &ContainerDetailDefaults{
+						Tag: "t-defaults",
+						Defaults: &ContainerDetailDefaults{
+							Tag: "t-hardDefaults",
 						},
 					},
 				},
 			},
-			want: "test/app-root",
+			want: "t-instance",
 		},
 		{
 			name: "Tag from defaults, ignore hardDefaults",
 			registry: CommonRegistry{
 				ContainerDetail: ContainerDetail{
-					Tag: "",
-				},
-				defaults: &GHCRRegistryDefaults{
-					CommonRegistryDefaults: CommonRegistryDefaults{
-						ContainerDetail: ContainerDetail{
-							Tag: "test/app-defaults",
-						},
-						defaults: &GHCRRegistryDefaults{
-							CommonRegistryDefaults: CommonRegistryDefaults{
-								ContainerDetail: ContainerDetail{
-									Tag: "test/app-hardDefaults",
-								},
-							},
+					Defaults: &ContainerDetailDefaults{
+						Tag: "t-defaults",
+						Defaults: &ContainerDetailDefaults{
+							Tag: "t-hardDefaults",
 						},
 					},
 				},
 			},
-			want: "test/app-defaults",
+			want: "t-defaults",
 		},
 	}
 
@@ -1676,23 +1222,6 @@ func TestCommonRegistry_CheckValues(t *testing.T) {
 					Tag:   "1.2.3",
 				},
 				defaults: nil,
-			},
-		},
-		{
-			name:     "image in defaults",
-			errRegex: `^$`,
-			input: &CommonRegistry{
-				ContainerDetail: ContainerDetail{
-					Image: "",
-					Tag:   "1.2.3",
-				},
-				defaults: &GHCRRegistryDefaults{
-					CommonRegistryDefaults: CommonRegistryDefaults{
-						ContainerDetail: ContainerDetail{
-							Image: "test/app",
-						},
-					},
-				},
 			},
 		},
 		{
@@ -1768,12 +1297,8 @@ func TestCommonRegistry_CheckValues(t *testing.T) {
 				ContainerDetail: ContainerDetail{
 					Image: "test/app",
 					Tag:   "",
-				},
-				defaults: &GHCRRegistryDefaults{
-					CommonRegistryDefaults: CommonRegistryDefaults{
-						ContainerDetail: ContainerDetail{
-							Tag: "1.2.3",
-						},
+					Defaults: &ContainerDetailDefaults{
+						Tag: "1.2.3",
 					},
 				},
 			},
@@ -1827,13 +1352,6 @@ func TestCommonRegistry_GetTagForVersion(t *testing.T) {
 				ContainerDetail: ContainerDetail{
 					Tag: "",
 				},
-				defaults: &GHCRRegistryDefaults{
-					CommonRegistryDefaults: CommonRegistryDefaults{
-						ContainerDetail: ContainerDetail{
-							Tag: "",
-						},
-					},
-				},
 			},
 			version: "3.2.1",
 			want:    "",
@@ -1844,13 +1362,6 @@ func TestCommonRegistry_GetTagForVersion(t *testing.T) {
 				ContainerDetail: ContainerDetail{
 					Tag: "1.2.3",
 				},
-				defaults: &GHCRRegistryDefaults{
-					CommonRegistryDefaults: CommonRegistryDefaults{
-						ContainerDetail: ContainerDetail{
-							Tag: "1.2.3",
-						},
-					},
-				},
 			},
 			version: "3.2.1",
 			want:    "1.2.3",
@@ -1860,13 +1371,6 @@ func TestCommonRegistry_GetTagForVersion(t *testing.T) {
 			registry: CommonRegistry{
 				ContainerDetail: ContainerDetail{
 					Tag: "{{ version }}.1",
-				},
-				defaults: &GHCRRegistryDefaults{
-					CommonRegistryDefaults: CommonRegistryDefaults{
-						ContainerDetail: ContainerDetail{
-							Tag: "{{ version }}.1",
-						},
-					},
 				},
 			},
 			version: "3.2",
@@ -1952,49 +1456,6 @@ func TestCommonRegistry_ParseBody(t *testing.T) {
 	}
 }
 
-func TestCommonRegistryDefaults_GetContainerDetail(t *testing.T) {
-	// GIVEN: a ContainerDetail.
-	tests := []struct {
-		name   string
-		detail ContainerDetail
-	}{
-		{
-			name:   "empty",
-			detail: ContainerDetail{},
-		},
-		{
-			name: "image and tag",
-			detail: ContainerDetail{
-				Image: "foo",
-				Tag:   "bar",
-			},
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			// AND: a CommonRegistryDefaults with this ContainerDetail.
-			defaults := CommonRegistryDefaults{
-				ContainerDetail: tc.detail,
-			}
-			want := &defaults.ContainerDetail
-
-			// WHEN: GetContainerDetail is called on it.
-			got := defaults.GetContainerDetail()
-
-			// THEN: a pointer to this ContainerDetail is returned.
-			if got != want {
-				t.Errorf(
-					"%s\nCommonRegistryDefaults.GetContainerDetail() pointer mismatch\ngot:  %p\nwant: %p",
-					packageName, got, want,
-				)
-			}
-		})
-	}
-}
-
 func TestCommonRegistry_Detail(t *testing.T) {
 	// GIVEN: a CommonRegistry.
 	tests := []struct {
@@ -2027,14 +1488,8 @@ func TestCommonRegistry_Detail(t *testing.T) {
 			registry: CommonRegistry{
 				ContainerDetail: ContainerDetail{
 					Image: "foo",
-					Tag:   "",
-				},
-				defaults: &GHCRRegistryDefaults{
-					CommonRegistryDefaults: CommonRegistryDefaults{
-						ContainerDetail: ContainerDetail{
-							Image: "default-foo",
-							Tag:   "default-bar",
-						},
+					Defaults: &ContainerDetailDefaults{
+						Tag: "default-bar",
 					},
 				},
 			},
@@ -2044,103 +1499,51 @@ func TestCommonRegistry_Detail(t *testing.T) {
 			},
 		},
 		{
-			name: "image from defaults/tag from root",
+			name: "tag from root, no image",
 			registry: CommonRegistry{
 				ContainerDetail: ContainerDetail{
-					Image: "",
-					Tag:   "bar",
-				},
-				defaults: &GHCRRegistryDefaults{
-					CommonRegistryDefaults: CommonRegistryDefaults{
-						ContainerDetail: ContainerDetail{
-							Image: "default-foo",
-							Tag:   "default-bar",
-						},
+					Tag: "bar",
+					Defaults: &ContainerDetailDefaults{
+						Tag: "default-bar",
 					},
 				},
 			},
 			want: ContainerDetail{
-				Image: "default-foo",
+				Image: "",
 				Tag:   "bar",
 			},
 		},
 		{
-			name: "image from defaults/tag from defaults",
-			registry: CommonRegistry{
-				ContainerDetail: ContainerDetail{
-					Image: "",
-					Tag:   "",
-				},
-				defaults: &GHCRRegistryDefaults{
-					CommonRegistryDefaults: CommonRegistryDefaults{
-						ContainerDetail: ContainerDetail{
-							Image: "default-foo",
-							Tag:   "default-bar",
-						},
-					},
-				},
-			},
-			want: ContainerDetail{
-				Image: "default-foo",
-				Tag:   "default-bar",
-			},
-		},
-		{
-			name: "image from defaults of defaults, tag from defaults",
-			registry: CommonRegistry{
-				ContainerDetail: ContainerDetail{
-					Image: "",
-					Tag:   "",
-				},
-				defaults: &GHCRRegistryDefaults{
-					CommonRegistryDefaults: CommonRegistryDefaults{
-						ContainerDetail: ContainerDetail{
-							Image: "default-foo",
-							Tag:   "",
-						},
-						defaults: &GHCRRegistryDefaults{
-							CommonRegistryDefaults: CommonRegistryDefaults{
-								ContainerDetail: ContainerDetail{
-									Image: "",
-									Tag:   "default-default-bar",
-								},
-							},
-						},
-					},
-				},
-			},
-			want: ContainerDetail{
-				Image: "default-foo",
-				Tag:   "default-default-bar",
-			},
-		},
-		{
-			name: "ignore defaults when found value",
+			name: "tag from defaults of defaults",
 			registry: CommonRegistry{
 				ContainerDetail: ContainerDetail{
 					Image: "foo",
-					Tag:   "",
-				},
-				defaults: &GHCRRegistryDefaults{
-					CommonRegistryDefaults: CommonRegistryDefaults{
-						ContainerDetail: ContainerDetail{
-							Image: "default-foo",
-							Tag:   "default-bar",
-						},
-						defaults: &GHCRRegistryDefaults{
-							CommonRegistryDefaults: CommonRegistryDefaults{
-								ContainerDetail: ContainerDetail{
-									Image: "default-default-foo",
-									Tag:   "default-default-bar",
-								},
-							},
+					Defaults: &ContainerDetailDefaults{
+						Defaults: &ContainerDetailDefaults{
+							Tag: "default-default-bar",
 						},
 					},
 				},
 			},
 			want: ContainerDetail{
 				Image: "foo",
-				Tag:   "default-bar",
+				Tag:   "default-default-bar",
+			},
+		},
+		{
+			name: "root tag wins over defaults",
+			registry: CommonRegistry{
+				ContainerDetail: ContainerDetail{
+					Image: "foo",
+					Tag:   "bar",
+					Defaults: &ContainerDetailDefaults{
+						Tag: "default-bar",
+					},
+				},
+			},
+			want: ContainerDetail{
+				Image: "foo",
+				Tag:   "bar",
 			},
 		},
 	}

--- a/service/latest_version/filter/docker/registry_ghcr.go
+++ b/service/latest_version/filter/docker/registry_ghcr.go
@@ -149,9 +149,7 @@ func (r *GHCRRegistryDefaults) IsZero() bool {
 		return true
 	}
 
-	return r.Image == "" &&
-		r.Tag == "" &&
-		(r.Auth == nil || r.Auth.IsZero())
+	return r.Auth == nil || r.Auth.IsZero()
 }
 
 // IsZero implements the yaml.IsZeroer interface.

--- a/service/latest_version/filter/docker/registry_ghcr_test.go
+++ b/service/latest_version/filter/docker/registry_ghcr_test.go
@@ -81,28 +81,6 @@ func TestGHCRRegistryDefaults_Unmarshal(t *testing.T) {
 			errRegex: `string was used where mapping is expected`,
 		},
 		{
-			name:   "JSON/invalid ContainerDetail",
-			format: "json",
-			data:   `{"image": []}`,
-			registry: &GHCRRegistryDefaults{
-				CommonRegistryDefaults: CommonRegistryDefaults{
-					Auth: &GHCRAuth{},
-				},
-			},
-			errRegex: `^json: .*unmarshal .*$`,
-		},
-		{
-			name:   "YAML/invalid ContainerDetail",
-			format: "yaml",
-			data:   `image: []`,
-			registry: &GHCRRegistryDefaults{
-				CommonRegistryDefaults: CommonRegistryDefaults{
-					Auth: &GHCRAuth{},
-				},
-			},
-			errRegex: `^[^\s]+ .*unmarshal .*`,
-		},
-		{
 			name:   "JSON/invalid Auth",
 			format: "json",
 			data:   `{"auth": []}`,
@@ -156,8 +134,6 @@ func TestGHCRRegistryDefaults_Unmarshal(t *testing.T) {
 			},
 			errRegex: `^$`,
 			want: test.TrimYAML(`
-				image: i
-				tag: t
 				auth:
 					token: tOKEn
 			`),
@@ -166,8 +142,6 @@ func TestGHCRRegistryDefaults_Unmarshal(t *testing.T) {
 			name:   "YAML/auth-ghcr",
 			format: "yaml",
 			data: test.TrimYAML(`
-				image: i
-				tag: t
 				auth:
 					username: ghcr-username
 					token: tOKEn
@@ -179,8 +153,6 @@ func TestGHCRRegistryDefaults_Unmarshal(t *testing.T) {
 			},
 			errRegex: `^$`,
 			want: test.TrimYAML(`
-				image: i
-				tag: t
 				auth:
 					token: tOKEn
 			`),
@@ -678,47 +650,9 @@ func TestGHCRRegistryDefaults_IsZero(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "non-empty/Image",
-			registry: &GHCRRegistryDefaults{
-				CommonRegistryDefaults: CommonRegistryDefaults{
-					ContainerDetail: ContainerDetail{
-						Image: "i",
-					},
-				},
-			},
-			want: false,
-		},
-		{
-			name: "non-empty/Tag",
-			registry: &GHCRRegistryDefaults{
-				CommonRegistryDefaults: CommonRegistryDefaults{
-					ContainerDetail: ContainerDetail{
-						Tag: "t",
-					},
-				},
-			},
-			want: false,
-		},
-		{
-			name: "non-empty/ContainerDetail",
-			registry: &GHCRRegistryDefaults{
-				CommonRegistryDefaults: CommonRegistryDefaults{
-					ContainerDetail: ContainerDetail{
-						Image: "i",
-						Tag:   "t",
-					},
-				},
-			},
-			want: false,
-		},
-		{
 			name: "non-empty/all",
 			registry: &GHCRRegistryDefaults{
 				CommonRegistryDefaults: CommonRegistryDefaults{
-					ContainerDetail: ContainerDetail{
-						Image: "i",
-						Tag:   "t",
-					},
 					Auth: &GHCRAuth{
 						GHCRAuthDefaults: GHCRAuthDefaults{
 							Token:      "foo",
@@ -935,14 +869,6 @@ func TestGHCRRegistryDefaults_String(t *testing.T) {
 			name: "filled",
 			data: &GHCRRegistryDefaults{
 				CommonRegistryDefaults: CommonRegistryDefaults{
-					ContainerDetail: ContainerDetail{
-						Image: "i1",
-						Tag:   "t1",
-						Defaults: &ContainerDetail{
-							Image: "i2",
-							Tag:   "t2",
-						},
-					},
 					Auth: &GHCRAuth{
 						GHCRAuthDefaults: GHCRAuthDefaults{
 							Token: "token1",
@@ -951,31 +877,9 @@ func TestGHCRRegistryDefaults_String(t *testing.T) {
 							},
 						},
 					},
-					defaults: &GHCRRegistryDefaults{
-						CommonRegistryDefaults: CommonRegistryDefaults{
-							ContainerDetail: ContainerDetail{
-								Image: "i2",
-								Tag:   "t2",
-								Defaults: &ContainerDetail{
-									Image: "i3",
-									Tag:   "t3",
-								},
-							},
-							Auth: &GHCRAuth{
-								GHCRAuthDefaults: GHCRAuthDefaults{
-									Token: "token2",
-									defaults: &GHCRAuthDefaults{
-										Token: "token3",
-									},
-								},
-							},
-						},
-					},
 				},
 			},
 			want: test.TrimYAML(`
-				image: i1
-				tag: t1
 				auth:
 					token: token1
 			`),
@@ -1021,9 +925,8 @@ func TestGHCRRegistry_String(t *testing.T) {
 					ContainerDetail: ContainerDetail{
 						Image: "i1",
 						Tag:   "t1",
-						Defaults: &ContainerDetail{
-							Image: "i2",
-							Tag:   "t2",
+						Defaults: &ContainerDetailDefaults{
+							Tag: "t2",
 						},
 					},
 					Auth: &GHCRAuth{
@@ -1199,76 +1102,6 @@ func TestGHCRRegistry_NewRequest(t *testing.T) {
 						got, value,
 					)
 				}
-			}
-		})
-	}
-}
-
-// #######################
-// # REGISTRY | DEFAULTS #
-// #######################
-
-func TestGHCRRegistryDefaults_Defaults(t *testing.T) {
-	// GIVEN: a GHCRRegistryDefaults with defaults.
-	tests := []struct {
-		name     string
-		registry GHCRRegistryDefaults
-		wantNil  bool
-	}{
-		{
-			name:     "nil defaults",
-			registry: GHCRRegistryDefaults{},
-			wantNil:  true,
-		},
-		{
-			name: "GHCRRegistryDefaults",
-			registry: GHCRRegistryDefaults{
-				CommonRegistryDefaults: CommonRegistryDefaults{
-					defaults: &GHCRRegistryDefaults{},
-				},
-			},
-			wantNil: false,
-		},
-		{
-			name: "HubRegistryDefaults",
-			registry: GHCRRegistryDefaults{
-				CommonRegistryDefaults: CommonRegistryDefaults{
-					defaults: &HubRegistryDefaults{},
-				},
-			},
-			wantNil: false,
-		},
-		{
-			name: "QuayRegistryDefaults",
-			registry: GHCRRegistryDefaults{
-				CommonRegistryDefaults: CommonRegistryDefaults{
-					defaults: &QuayRegistryDefaults{},
-				},
-			},
-			wantNil: false,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			// WHEN: Defaults is called on it.
-			got := tc.registry.Defaults()
-
-			// THEN: a pointer to the defaults is returned.
-			if got == nil != tc.wantNil {
-				want := "nil"
-				got := "nil"
-				if tc.wantNil {
-					want = "non-nil"
-				} else {
-					got = "non-nil"
-				}
-				t.Errorf(
-					"%s\nGHCRRegistryDefaults.Defaults() mismatch\ngot:  %s\nwant: %s",
-					packageName, got, want,
-				)
 			}
 		})
 	}

--- a/service/latest_version/filter/docker/registry_hub.go
+++ b/service/latest_version/filter/docker/registry_hub.go
@@ -154,9 +154,7 @@ func (r *HubRegistryDefaults) IsZero() bool {
 		return true
 	}
 
-	return r.Image == "" &&
-		r.Tag == "" &&
-		(r.Auth == nil || r.Auth.IsZero())
+	return r.Auth == nil || r.Auth.IsZero()
 }
 
 // IsZero implements the yaml.IsZeroer interface.

--- a/service/latest_version/filter/docker/registry_hub_test.go
+++ b/service/latest_version/filter/docker/registry_hub_test.go
@@ -46,11 +46,8 @@ func TestHubRegistryDefaults_Unmarshal(t *testing.T) {
 			format:   "json",
 			data:     "",
 			registry: &HubRegistryDefaults{},
-			errRegex: test.TrimYAML(`
-				^jsontext:
-					unexpected EOF$`,
-			),
-			want: "",
+			errRegex: `^$`,
+			want:     "{}\n",
 		},
 		{
 			name:     "JSON/empty object",
@@ -81,28 +78,6 @@ func TestHubRegistryDefaults_Unmarshal(t *testing.T) {
 			data:     "foo",
 			registry: &HubRegistryDefaults{},
 			errRegex: `string was used where mapping is expected`,
-		},
-		{
-			name:   "JSON/invalid ContainerDetail",
-			format: "json",
-			data:   `{"image": []}`,
-			registry: &HubRegistryDefaults{
-				CommonRegistryDefaults: CommonRegistryDefaults{
-					Auth: &HubAuthDefaults{},
-				},
-			},
-			errRegex: `^json: .*unmarshal .*$`,
-		},
-		{
-			name:   "YAML/invalid ContainerDetail",
-			format: "yaml",
-			data:   `image: []`,
-			registry: &HubRegistryDefaults{
-				CommonRegistryDefaults: CommonRegistryDefaults{
-					Auth: &HubAuthDefaults{},
-				},
-			},
-			errRegex: `^[^\s]+ .*unmarshal .*`,
 		},
 		{
 			name:   "JSON/invalid Auth",
@@ -158,8 +133,6 @@ func TestHubRegistryDefaults_Unmarshal(t *testing.T) {
 			},
 			errRegex: `^$`,
 			want: test.TrimYAML(`
-				image: i
-				tag: t
 				auth:
 					username: hub-username
 					token: tOKEn
@@ -169,8 +142,6 @@ func TestHubRegistryDefaults_Unmarshal(t *testing.T) {
 			name:   "YAML/auth-hub",
 			format: "yaml",
 			data: test.TrimYAML(`
-				image: i
-				tag: t
 				auth:
 					username: hub-username
 					token: tOKEn
@@ -182,8 +153,6 @@ func TestHubRegistryDefaults_Unmarshal(t *testing.T) {
 			},
 			errRegex: `^$`,
 			want: test.TrimYAML(`
-				image: i
-				tag: t
 				auth:
 					username: hub-username
 					token: tOKEn
@@ -698,47 +667,9 @@ func TestHubRegistryDefaults_IsZero(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "non-empty/Image",
-			registry: &HubRegistryDefaults{
-				CommonRegistryDefaults: CommonRegistryDefaults{
-					ContainerDetail: ContainerDetail{
-						Image: "i",
-					},
-				},
-			},
-			want: false,
-		},
-		{
-			name: "non-empty/Tag",
-			registry: &HubRegistryDefaults{
-				CommonRegistryDefaults: CommonRegistryDefaults{
-					ContainerDetail: ContainerDetail{
-						Tag: "t",
-					},
-				},
-			},
-			want: false,
-		},
-		{
-			name: "non-empty/ContainerDetail",
-			registry: &HubRegistryDefaults{
-				CommonRegistryDefaults: CommonRegistryDefaults{
-					ContainerDetail: ContainerDetail{
-						Image: "i",
-						Tag:   "t",
-					},
-				},
-			},
-			want: false,
-		},
-		{
 			name: "non-empty/all",
 			registry: &HubRegistryDefaults{
 				CommonRegistryDefaults: CommonRegistryDefaults{
-					ContainerDetail: ContainerDetail{
-						Image: "i",
-						Tag:   "t",
-					},
 					Auth: &HubAuthDefaults{
 						Username:   "u",
 						Token:      "foo",
@@ -957,14 +888,6 @@ func TestHubRegistryDefaults_String(t *testing.T) {
 			name: "filled",
 			data: &HubRegistryDefaults{
 				CommonRegistryDefaults: CommonRegistryDefaults{
-					ContainerDetail: ContainerDetail{
-						Image: "i1",
-						Tag:   "t1",
-						Defaults: &ContainerDetail{
-							Image: "i2",
-							Tag:   "t2",
-						},
-					},
 					Auth: &HubAuth{
 						HubAuthDefaults: HubAuthDefaults{
 							Username: "u1",
@@ -975,33 +898,9 @@ func TestHubRegistryDefaults_String(t *testing.T) {
 							},
 						},
 					},
-					defaults: &HubRegistryDefaults{
-						CommonRegistryDefaults: CommonRegistryDefaults{
-							ContainerDetail: ContainerDetail{
-								Image: "i2",
-								Tag:   "t2",
-								Defaults: &ContainerDetail{
-									Image: "i3",
-									Tag:   "t3",
-								},
-							},
-							Auth: &HubAuth{
-								HubAuthDefaults: HubAuthDefaults{
-									Username: "u2",
-									Token:    "token2",
-									defaults: &HubAuthDefaults{
-										Username: "u3",
-										Token:    "token3",
-									},
-								},
-							},
-						},
-					},
 				},
 			},
 			want: test.TrimYAML(`
-				image: i1
-				tag: t1
 				auth:
 					username: u1
 					token: token1
@@ -1048,9 +947,8 @@ func TestHubRegistry_String(t *testing.T) {
 					ContainerDetail: ContainerDetail{
 						Image: "i1",
 						Tag:   "t1",
-						Defaults: &ContainerDetail{
-							Image: "i2",
-							Tag:   "t2",
+						Defaults: &ContainerDetailDefaults{
+							Tag: "t2",
 						},
 					},
 					Auth: &HubAuth{
@@ -1086,76 +984,6 @@ func TestHubRegistry_String(t *testing.T) {
 				tc.data.String,
 				tc.want,
 			)
-		})
-	}
-}
-
-// #######################
-// # REGISTRY | DEFAULTS #
-// #######################
-
-func TestHubRegistryDefaults_Defaults(t *testing.T) {
-	// GIVEN: a HubRegistryDefaults with defaults.
-	tests := []struct {
-		name     string
-		registry HubRegistryDefaults
-		wantNil  bool
-	}{
-		{
-			name:     "nil defaults",
-			registry: HubRegistryDefaults{},
-			wantNil:  true,
-		},
-		{
-			name: "GHCRRegistryDefaults",
-			registry: HubRegistryDefaults{
-				CommonRegistryDefaults: CommonRegistryDefaults{
-					defaults: &GHCRRegistryDefaults{},
-				},
-			},
-			wantNil: false,
-		},
-		{
-			name: "HubRegistryDefaults",
-			registry: HubRegistryDefaults{
-				CommonRegistryDefaults: CommonRegistryDefaults{
-					defaults: &HubRegistryDefaults{},
-				},
-			},
-			wantNil: false,
-		},
-		{
-			name: "QuayRegistryDefaults",
-			registry: HubRegistryDefaults{
-				CommonRegistryDefaults: CommonRegistryDefaults{
-					defaults: &QuayRegistryDefaults{},
-				},
-			},
-			wantNil: false,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			// WHEN: Defaults is called on it.
-			got := tc.registry.Defaults()
-
-			// THEN: a pointer to the defaults is returned.
-			if got == nil != tc.wantNil {
-				want := "nil"
-				got := "nil"
-				if tc.wantNil {
-					want = "non-nil"
-				} else {
-					got = "non-nil"
-				}
-				t.Errorf(
-					"%s\nHubRegistryDefaults Defaults() mismatch\ngot:  %s\nwant: %s",
-					packageName, got, want,
-				)
-			}
 		})
 	}
 }

--- a/service/latest_version/filter/docker/registry_quay.go
+++ b/service/latest_version/filter/docker/registry_quay.go
@@ -134,9 +134,7 @@ func (r *QuayRegistryDefaults) IsZero() bool {
 		return true
 	}
 
-	return r.Image == "" &&
-		r.Tag == "" &&
-		(r.Auth == nil || r.Auth.IsZero())
+	return r.Auth == nil || r.Auth.IsZero()
 }
 
 // IsZero implements the yaml.IsZeroer interface.

--- a/service/latest_version/filter/docker/registry_quay_test.go
+++ b/service/latest_version/filter/docker/registry_quay_test.go
@@ -72,28 +72,6 @@ func TestQuayRegistryDefaults_Unmarshal(t *testing.T) {
 			errRegex: `string was used where mapping is expected`,
 		},
 		{
-			name:   "JSON/invalid ContainerDetail",
-			format: "json",
-			data:   `{"image": []}`,
-			registry: &QuayRegistryDefaults{
-				CommonRegistryDefaults: CommonRegistryDefaults{
-					Auth: &QuayAuthDefaults{},
-				},
-			},
-			errRegex: `^json: .*unmarshal .*$`,
-		},
-		{
-			name:   "YAML/invalid ContainerDetail",
-			format: "yaml",
-			data:   `image: []`,
-			registry: &QuayRegistryDefaults{
-				CommonRegistryDefaults: CommonRegistryDefaults{
-					Auth: &QuayAuthDefaults{},
-				},
-			},
-			errRegex: `^[^\s]+ .*unmarshal`,
-		},
-		{
 			name:   "JSON/invalid Auth",
 			format: "json",
 			data:   `{"auth": []}`,
@@ -147,8 +125,6 @@ func TestQuayRegistryDefaults_Unmarshal(t *testing.T) {
 			},
 			errRegex: `^$`,
 			want: test.TrimYAML(`
-				image: i
-				tag: t
 				auth:
 					token: tOKEn
 			`),
@@ -157,8 +133,6 @@ func TestQuayRegistryDefaults_Unmarshal(t *testing.T) {
 			name:   "YAML/auth-quay",
 			format: "yaml",
 			data: test.TrimYAML(`
-				image: i
-				tag: t
 				auth:
 					username: quay-username
 					token: tOKEn
@@ -170,8 +144,6 @@ func TestQuayRegistryDefaults_Unmarshal(t *testing.T) {
 			},
 			errRegex: `^$`,
 			want: test.TrimYAML(`
-				image: i
-				tag: t
 				auth:
 					token: tOKEn
 			`),
@@ -640,47 +612,9 @@ func TestQuayRegistryDefaults_IsZero(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "non-empty/Image",
-			registry: &QuayRegistryDefaults{
-				CommonRegistryDefaults: CommonRegistryDefaults{
-					ContainerDetail: ContainerDetail{
-						Image: "i",
-					},
-				},
-			},
-			want: false,
-		},
-		{
-			name: "non-empty/Tag",
-			registry: &QuayRegistryDefaults{
-				CommonRegistryDefaults: CommonRegistryDefaults{
-					ContainerDetail: ContainerDetail{
-						Tag: "t",
-					},
-				},
-			},
-			want: false,
-		},
-		{
-			name: "non-empty/ContainerDetail",
-			registry: &QuayRegistryDefaults{
-				CommonRegistryDefaults: CommonRegistryDefaults{
-					ContainerDetail: ContainerDetail{
-						Image: "i",
-						Tag:   "t",
-					},
-				},
-			},
-			want: false,
-		},
-		{
 			name: "non-empty/all",
 			registry: &QuayRegistryDefaults{
 				CommonRegistryDefaults: CommonRegistryDefaults{
-					ContainerDetail: ContainerDetail{
-						Image: "i",
-						Tag:   "t",
-					},
 					Auth: &QuayAuthDefaults{
 						Token: "foo",
 					},
@@ -891,14 +825,6 @@ func TestQuayRegistryDefaults_String(t *testing.T) {
 			name: "filled",
 			data: &QuayRegistryDefaults{
 				CommonRegistryDefaults: CommonRegistryDefaults{
-					ContainerDetail: ContainerDetail{
-						Image: "i1",
-						Tag:   "t1",
-						Defaults: &ContainerDetail{
-							Image: "i2",
-							Tag:   "t2",
-						},
-					},
 					Auth: &QuayAuth{
 						QuayAuthDefaults: QuayAuthDefaults{
 							Token: "token1",
@@ -907,31 +833,9 @@ func TestQuayRegistryDefaults_String(t *testing.T) {
 							},
 						},
 					},
-					defaults: &QuayRegistryDefaults{
-						CommonRegistryDefaults: CommonRegistryDefaults{
-							ContainerDetail: ContainerDetail{
-								Image: "i2",
-								Tag:   "t2",
-								Defaults: &ContainerDetail{
-									Image: "i3",
-									Tag:   "t3",
-								},
-							},
-							Auth: &QuayAuth{
-								QuayAuthDefaults: QuayAuthDefaults{
-									Token: "token2",
-									defaults: &QuayAuthDefaults{
-										Token: "token3",
-									},
-								},
-							},
-						},
-					},
 				},
 			},
 			want: test.TrimYAML(`
-				image: i1
-				tag: t1
 				auth:
 					token: token1
 			`),
@@ -977,9 +881,8 @@ func TestQuayRegistry_String(t *testing.T) {
 					ContainerDetail: ContainerDetail{
 						Image: "i1",
 						Tag:   "t1",
-						Defaults: &ContainerDetail{
-							Image: "i2",
-							Tag:   "t2",
+						Defaults: &ContainerDetailDefaults{
+							Tag: "t2",
 						},
 					},
 					Auth: &QuayAuth{
@@ -1042,76 +945,6 @@ func TestQuayRegistry_GetType(t *testing.T) {
 	// THEN: the type is returned.
 	if want := "quay"; got != want {
 		t.Errorf("got %q, want %q", got, want)
-	}
-}
-
-// #######################
-// # REGISTRY | DEFAULTS #
-// #######################
-
-func TestQuayRegistryDefaults_Defaults(t *testing.T) {
-	// GIVEN: a QuayRegistryDefaults with defaults.
-	tests := []struct {
-		name     string
-		registry RegistryDefaults
-		wantNil  bool
-	}{
-		{
-			name:     "nil registry defaults",
-			registry: &QuayRegistryDefaults{},
-			wantNil:  true,
-		},
-		{
-			name: "GHCRRegistryDefaults",
-			registry: &GHCRRegistryDefaults{
-				CommonRegistryDefaults: CommonRegistryDefaults{
-					defaults: &GHCRRegistryDefaults{},
-				},
-			},
-			wantNil: false,
-		},
-		{
-			name: "HubRegistryDefaults",
-			registry: &HubRegistryDefaults{
-				CommonRegistryDefaults: CommonRegistryDefaults{
-					defaults: &HubRegistryDefaults{},
-				},
-			},
-			wantNil: false,
-		},
-		{
-			name: "QuayRegistryDefaults",
-			registry: &QuayRegistryDefaults{
-				CommonRegistryDefaults: CommonRegistryDefaults{
-					defaults: &QuayRegistryDefaults{},
-				},
-			},
-			wantNil: false,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			// WHEN: Defaults is called on it.
-			got := tc.registry.Defaults()
-
-			// THEN: a pointer to the defaults is returned.
-			if got == nil != tc.wantNil {
-				want := "nil"
-				got := "nil"
-				if tc.wantNil {
-					want = "non-nil"
-				} else {
-					got = "non-nil"
-				}
-				t.Errorf(
-					"%s\nQuayRegistryDefaults Defaults() mismatch\ngot:  %s\nwant: %s",
-					packageName, got, want,
-				)
-			}
-		})
 	}
 }
 

--- a/service/latest_version/filter/require_defaults_test.go
+++ b/service/latest_version/filter/require_defaults_test.go
@@ -78,11 +78,8 @@ func TestRequireDefaults_SetDefaults(t *testing.T) {
 	// THEN: defaults are set.
 	fieldTests := []test.FieldAssertion{
 		{Name: "Docker.Defaults", Got: req.Docker.Defaults, Want: &defaults.Docker, Mode: test.CompareSamePointer},
-		{Name: "Docker.Registry.GHCR.Defaults", Got: req.Docker.Registry.GHCR.Defaults(), Want: defaults.Docker.Registry.GHCR, Mode: test.CompareSamePointer},
 		{Name: "Docker.Registry.GHCR.Auth.Defaults", Got: req.Docker.Registry.GHCR.Auth.Defaults(), Want: defaults.Docker.Registry.GHCR.Auth, Mode: test.CompareSamePointer},
-		{Name: "Docker.Registry.Hub.Defaults", Got: req.Docker.Registry.Hub.Defaults(), Want: defaults.Docker.Registry.Hub, Mode: test.CompareSamePointer},
 		{Name: "Docker.Registry.Hub.Auth.Defaults", Got: req.Docker.Registry.Hub.Auth.Defaults(), Want: defaults.Docker.Registry.Hub.Auth, Mode: test.CompareSamePointer},
-		{Name: "Docker.Registry.Quay.Defaults", Got: req.Docker.Registry.Quay.Defaults(), Want: defaults.Docker.Registry.Quay, Mode: test.CompareSamePointer},
 		{Name: "Docker.Registry.Quay.Auth.Defaults", Got: req.Docker.Registry.Quay.Auth.Defaults(), Want: defaults.Docker.Registry.Quay.Auth, Mode: test.CompareSamePointer},
 	}
 	if err := test.AssertFields(t, fieldTests, prefix, "RequireDefaults"); err != nil {

--- a/service/latest_version/filter/require_test.go
+++ b/service/latest_version/filter/require_test.go
@@ -72,35 +72,6 @@ func TestRequire_IsZero(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "non-empty/Docker/.Image from defaults, no .Tag",
-			req: test.Must(t, func() (*Require, error) {
-				data := []byte(test.TrimYAML(`
-					docker:
-						type: hub
-						image: foo
-				`))
-				defaults, _ := DecodeDefaults("yaml", data)
-				hardDefaults, _ := DecodeDefaults("yaml", nil)
-				defaults.SetDefaults(hardDefaults)
-				svcStatus, _ := statustest.New("yaml", nil)
-
-				req, err := Decode(
-					"yaml", []byte(test.TrimYAML(`
-						docker: {}
-					`)),
-					svcStatus,
-					defaults,
-				)
-				req.Docker.(*docker.HubRegistry).Tag = ""
-
-				if req.Docker.GetImage() == "" {
-					t.Fatal("non-empty/Docker/.Image should not be empty")
-				}
-				return req, err
-			}),
-			want: true,
-		},
-		{
 			name: "non-empty/Docker/.Tag from defaults, no .Image",
 			req: test.Must(t, func() (*Require, error) {
 				data := []byte(test.TrimYAML(`

--- a/service/latest_version/types/base/defaults_test.go
+++ b/service/latest_version/types/base/defaults_test.go
@@ -173,7 +173,6 @@ func TestDecodeDefaults(t *testing.T) {
 				foo: bar
 				require:
 					docker:
-						image: i
 						tag: t
 			`),
 			want: test.TrimYAML(`
@@ -183,7 +182,6 @@ func TestDecodeDefaults(t *testing.T) {
 				use_prerelease: true
 				require:
 					docker:
-						image: i
 						tag: t
 			`),
 			errRegex: `^$`,
@@ -220,7 +218,7 @@ func TestDefaults_Default(t *testing.T) {
 		Require: filter.RequireDefaults{
 			Docker: docker.Defaults{
 				Type: "hub",
-				ContainerDetail: docker.ContainerDetail{
+				ContainerDetailDefaults: docker.ContainerDetailDefaults{
 					Tag: "{{ version }}",
 				},
 			},

--- a/web/api/types/argus.go
+++ b/web/api/types/argus.go
@@ -542,42 +542,26 @@ func (r RequireDockerRegistryDefaultsAuthWithUsername) IsZero() bool {
 		r.Token == ""
 }
 
-// RequireDockerRegistryDefaultsBase are the base default values for a RequireDocker.
-type RequireDockerRegistryDefaultsBase struct {
-	Image string `json:"image,omitempty" yaml:"image,omitempty"` // Image to check.
-	Tag   string `json:"tag,omitempty" yaml:"tag,omitempty"`     // Tag to check for.
-}
-
-// IsZero implements the yaml.IsZeroer interface.
-func (r RequireDockerRegistryDefaultsBase) IsZero() bool {
-	return r.Image == "" &&
-		r.Tag == ""
-}
-
 // RequireDockerRegistryDefaultsToken are the default values for a RequireDocker with just Token auth.
 type RequireDockerRegistryDefaultsToken struct {
-	RequireDockerRegistryDefaultsBase `json:",inline" yaml:",inline"`
 	RequireDockerRegistryDefaultsAuth `json:"auth" yaml:"auth"`
 }
 
 // IsZero implements the yaml.IsZeroer interface.
 func (r *RequireDockerRegistryDefaultsToken) IsZero() bool {
-	return r.RequireDockerRegistryDefaultsAuth.IsZero() &&
-		r.RequireDockerRegistryDefaultsBase.IsZero()
+	return r.RequireDockerRegistryDefaultsAuth.IsZero()
 }
 
 func (r *RequireDockerRegistryDefaultsToken) GetToken() string { return r.Token }
 
 // RequireDockerCheckRegistryDefaultsTokenWithUsername are the default values for a RequireDocker with Token+Username auth.
 type RequireDockerCheckRegistryDefaultsTokenWithUsername struct {
-	RequireDockerRegistryDefaultsBase             `json:",inline" yaml:",inline"`
 	RequireDockerRegistryDefaultsAuthWithUsername `json:"auth" yaml:"auth"`
 }
 
 // IsZero implements the yaml.IsZeroer interface.
 func (r *RequireDockerCheckRegistryDefaultsTokenWithUsername) IsZero() bool {
-	return r.RequireDockerRegistryDefaultsBase.IsZero() &&
-		r.RequireDockerRegistryDefaultsAuthWithUsername.IsZero()
+	return r.RequireDockerRegistryDefaultsAuthWithUsername.IsZero()
 }
 
 func (r *RequireDockerCheckRegistryDefaultsTokenWithUsername) GetToken() string { return r.Token }
@@ -585,7 +569,6 @@ func (r *RequireDockerCheckRegistryDefaultsTokenWithUsername) GetToken() string 
 // RequireDockerDefaults are default values for a RequireDocker.
 type RequireDockerDefaults struct {
 	Type     string                          `json:"type,omitempty" yaml:"type,omitempty"`       // Default DockerCheck Type.
-	Image    string                          `json:"image,omitempty" yaml:"image,omitempty"`     // Default Image template.
 	Tag      string                          `json:"tag,omitempty" yaml:"tag,omitempty"`         // Default Tag template.
 	Registry RequireDockerRegistriesDefaults `json:"registry,omitzero" yaml:"registry,omitzero"` // GHCR | Hub | Quay.
 }
@@ -593,7 +576,6 @@ type RequireDockerDefaults struct {
 // IsZero implements the yaml.IsZeroer interface.
 func (r RequireDockerDefaults) IsZero() bool {
 	return r.Type == "" &&
-		r.Image == "" &&
 		r.Tag == "" &&
 		r.Registry.IsZero()
 }

--- a/web/api/types/argus_test.go
+++ b/web/api/types/argus_test.go
@@ -2020,7 +2020,7 @@ func TestLatestVersionDefaults_IsZero(t *testing.T) {
 			defaults: LatestVersionDefaults{
 				Require: &LatestVersionRequireDefaults{
 					Docker: RequireDockerDefaults{
-						Image: "a",
+						Tag: "a",
 					},
 				},
 			},
@@ -2035,7 +2035,7 @@ func TestLatestVersionDefaults_IsZero(t *testing.T) {
 				UsePreRelease:     test.Ptr(false),
 				Require: &LatestVersionRequireDefaults{
 					Docker: RequireDockerDefaults{
-						Image: "a",
+						Tag: "a",
 					},
 				},
 			},
@@ -2146,7 +2146,7 @@ func TestLatestVersionRequireDefaults_IsZero(t *testing.T) {
 			name: "non-empty",
 			defaults: LatestVersionRequireDefaults{
 				Docker: RequireDockerDefaults{
-					Image: "a",
+					Tag: "a",
 				},
 			},
 			want: false,
@@ -2278,10 +2278,6 @@ func TestRequireDockerRegistriesDefaults_IsZero(t *testing.T) {
 			name: "non-empty",
 			defaults: RequireDockerRegistriesDefaults{
 				GHCR: &RequireDockerRegistryDefaultsToken{
-					RequireDockerRegistryDefaultsBase: RequireDockerRegistryDefaultsBase{
-						Image: "image",
-						Tag:   "tag",
-					},
 					RequireDockerRegistryDefaultsAuth: RequireDockerRegistryDefaultsAuth{
 						Token: "token",
 					},
@@ -2403,45 +2399,6 @@ func TestRequireDockerRegistryDefaultsAuthWithUsername_IsZero(t *testing.T) {
 	}
 }
 
-func TestRequireDockerRegistryDefaultsBase_IsZero(t *testing.T) {
-	// GIVEN: RequireDockerRegistryDefaultsBase.
-	tests := []struct {
-		name     string
-		defaults RequireDockerRegistryDefaultsBase
-		want     bool
-	}{
-		{
-			name:     "empty",
-			defaults: RequireDockerRegistryDefaultsBase{},
-			want:     true,
-		},
-		{
-			name: "non-empty",
-			defaults: RequireDockerRegistryDefaultsBase{
-				Image: "image",
-				Tag:   "tag",
-			},
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			// WHEN: IsZero() is called on it.
-			got := tc.defaults.IsZero()
-
-			// THEN: the result is as expected.
-			if got != tc.want {
-				t.Errorf(
-					"%s\nRequireDockerRegistryDefaultsBase.IsZero() value mismatch\ngot:  %t\nwant: %t",
-					packageName, got, tc.want,
-				)
-			}
-		})
-	}
-}
-
 func TestRequireDockerRegistryDefaultsToken_IsZero(t *testing.T) {
 	// GIVEN: RequireDockerRegistryDefaultsToken.
 	tests := []struct {
@@ -2459,29 +2416,6 @@ func TestRequireDockerRegistryDefaultsToken_IsZero(t *testing.T) {
 			defaults: RequireDockerRegistryDefaultsToken{
 				RequireDockerRegistryDefaultsAuth: RequireDockerRegistryDefaultsAuth{
 					Token: "t",
-				},
-			},
-			want: false,
-		},
-		{
-			name: "non-empty/RequireDockerRegistryDefaultsBase",
-			defaults: RequireDockerRegistryDefaultsToken{
-				RequireDockerRegistryDefaultsBase: RequireDockerRegistryDefaultsBase{
-					Image: "image",
-					Tag:   "tag",
-				},
-			},
-			want: false,
-		},
-		{
-			name: "non-empty",
-			defaults: RequireDockerRegistryDefaultsToken{
-				RequireDockerRegistryDefaultsAuth: RequireDockerRegistryDefaultsAuth{
-					Token: "t",
-				},
-				RequireDockerRegistryDefaultsBase: RequireDockerRegistryDefaultsBase{
-					Image: "image",
-					Tag:   "tag",
 				},
 			},
 			want: false,
@@ -2560,34 +2494,8 @@ func TestRequireDockerCheckRegistryDefaultsTokenWithUsername_IsZero(t *testing.T
 			want:     true,
 		},
 		{
-			name: "non-empty/RequireDockerRegistryDefaultsBase",
-			defaults: RequireDockerCheckRegistryDefaultsTokenWithUsername{
-				RequireDockerRegistryDefaultsBase: RequireDockerRegistryDefaultsBase{
-					Image: "i",
-					Tag:   "t",
-				},
-			},
-			want: false,
-		},
-		{
 			name: "non-empty/RequireDockerRegistryDefaultsAuthWithUsername",
 			defaults: RequireDockerCheckRegistryDefaultsTokenWithUsername{
-				RequireDockerRegistryDefaultsAuthWithUsername: RequireDockerRegistryDefaultsAuthWithUsername{
-					Username: "u",
-					RequireDockerRegistryDefaultsAuth: RequireDockerRegistryDefaultsAuth{
-						Token: "t",
-					},
-				},
-			},
-			want: false,
-		},
-		{
-			name: "non-empty",
-			defaults: RequireDockerCheckRegistryDefaultsTokenWithUsername{
-				RequireDockerRegistryDefaultsBase: RequireDockerRegistryDefaultsBase{
-					Image: "i",
-					Tag:   "t",
-				},
 				RequireDockerRegistryDefaultsAuthWithUsername: RequireDockerRegistryDefaultsAuthWithUsername{
 					Username: "u",
 					RequireDockerRegistryDefaultsAuth: RequireDockerRegistryDefaultsAuth{
@@ -2632,10 +2540,6 @@ func TestRequireDockerCheckRegistryDefaultsTokenWithUsername_GetToken(t *testing
 		{
 			name: "non-empty",
 			defaults: RequireDockerCheckRegistryDefaultsTokenWithUsername{
-				RequireDockerRegistryDefaultsBase: RequireDockerRegistryDefaultsBase{
-					Image: "i",
-					Tag:   "t",
-				},
 				RequireDockerRegistryDefaultsAuthWithUsername: RequireDockerRegistryDefaultsAuthWithUsername{
 					Username: "u",
 					RequireDockerRegistryDefaultsAuth: RequireDockerRegistryDefaultsAuth{
@@ -2685,13 +2589,6 @@ func TestRequireDockerDefaults_IsZero(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "non-empty/Image",
-			d: RequireDockerDefaults{
-				Image: "i",
-			},
-			want: false,
-		},
-		{
 			name: "non-empty/Tag",
 			d: RequireDockerDefaults{
 				Tag: "t",
@@ -2703,10 +2600,6 @@ func TestRequireDockerDefaults_IsZero(t *testing.T) {
 			d: RequireDockerDefaults{
 				Registry: RequireDockerRegistriesDefaults{
 					GHCR: &RequireDockerRegistryDefaultsToken{
-						RequireDockerRegistryDefaultsBase: RequireDockerRegistryDefaultsBase{
-							Image: "i",
-							Tag:   "t",
-						},
 						RequireDockerRegistryDefaultsAuth: RequireDockerRegistryDefaultsAuth{
 							Token: "token",
 						},
@@ -2718,15 +2611,10 @@ func TestRequireDockerDefaults_IsZero(t *testing.T) {
 		{
 			name: "non-empty/all",
 			d: RequireDockerDefaults{
-				Type:  "t",
-				Image: "i",
-				Tag:   "t",
+				Type: "t",
+				Tag:  "t",
 				Registry: RequireDockerRegistriesDefaults{
 					GHCR: &RequireDockerRegistryDefaultsToken{
-						RequireDockerRegistryDefaultsBase: RequireDockerRegistryDefaultsBase{
-							Image: "i",
-							Tag:   "t",
-						},
 						RequireDockerRegistryDefaultsAuth: RequireDockerRegistryDefaultsAuth{
 							Token: "token",
 						},

--- a/web/api/v1/convert.go
+++ b/web/api/v1/convert.go
@@ -174,9 +174,8 @@ func convertAndCensorLatestVersionRequireDefaults(input *filter.RequireDefaults)
 
 	apiRequire := &apitype.LatestVersionRequireDefaults{
 		Docker: apitype.RequireDockerDefaults{
-			Type:  input.Docker.Type,
-			Image: input.Docker.Image,
-			Tag:   input.Docker.Tag,
+			Type: input.Docker.Type,
+			Tag:  input.Docker.Tag,
 		},
 	}
 
@@ -208,10 +207,6 @@ func convertAndCensorRequireDockerRegistryDefaults(input docker.RegistryDefaults
 	case *docker.GHCRRegistryDefaults:
 		if auth, ok := v.GetAuth().(*docker.GHCRAuthDefaults); ok {
 			return &apitype.RequireDockerRegistryDefaultsToken{
-				RequireDockerRegistryDefaultsBase: apitype.RequireDockerRegistryDefaultsBase{
-					Image: v.Image,
-					Tag:   v.Tag,
-				},
 				RequireDockerRegistryDefaultsAuth: apitype.RequireDockerRegistryDefaultsAuth{
 					Token: util.ValueUnlessZero(auth.GetTokenSelf(), util.SecretValue),
 				},
@@ -220,10 +215,6 @@ func convertAndCensorRequireDockerRegistryDefaults(input docker.RegistryDefaults
 	case *docker.QuayRegistryDefaults:
 		if auth, ok := v.GetAuth().(*docker.QuayAuthDefaults); ok {
 			return &apitype.RequireDockerRegistryDefaultsToken{
-				RequireDockerRegistryDefaultsBase: apitype.RequireDockerRegistryDefaultsBase{
-					Image: v.Image,
-					Tag:   v.Tag,
-				},
 				RequireDockerRegistryDefaultsAuth: apitype.RequireDockerRegistryDefaultsAuth{
 					Token: util.ValueUnlessZero(auth.GetTokenSelf(), util.SecretValue),
 				},
@@ -232,10 +223,6 @@ func convertAndCensorRequireDockerRegistryDefaults(input docker.RegistryDefaults
 	case *docker.HubRegistryDefaults:
 		if auth, ok := v.GetAuth().(*docker.HubAuthDefaults); ok {
 			return &apitype.RequireDockerCheckRegistryDefaultsTokenWithUsername{
-				RequireDockerRegistryDefaultsBase: apitype.RequireDockerRegistryDefaultsBase{
-					Image: v.Image,
-					Tag:   v.Tag,
-				},
 				RequireDockerRegistryDefaultsAuthWithUsername: apitype.RequireDockerRegistryDefaultsAuthWithUsername{
 					Username: auth.GetUsernameSelf(),
 					RequireDockerRegistryDefaultsAuth: apitype.RequireDockerRegistryDefaultsAuth{

--- a/web/api/v1/convert_test.go
+++ b/web/api/v1/convert_test.go
@@ -238,24 +238,17 @@ func TestConvertAndCensorDefaults(t *testing.T) {
 								"yaml", []byte(test.TrimYAML(`
 									docker:
 										type: hub
-										image: i
 										tag: t
 										registry:
 											ghcr:
-												image: iGHCR
-												tag: tGHCR
 												auth:
 													username: something
 													token: ghp_X
 											hub:
-												image: iHub
-												tag: tHub
 												auth:
 													username: something
 													token: hub_X
 											quay:
-												image: iQuay
-												tag: tQuay
 												auth:
 													username: something
 													token: quay_X
@@ -272,24 +265,15 @@ func TestConvertAndCensorDefaults(t *testing.T) {
 						AccessToken: util.SecretValue,
 						Require: &apitype.LatestVersionRequireDefaults{
 							Docker: apitype.RequireDockerDefaults{
-								Type:  "hub",
-								Image: "i",
-								Tag:   "t",
+								Type: "hub",
+								Tag:  "t",
 								Registry: apitype.RequireDockerRegistriesDefaults{
 									GHCR: &apitype.RequireDockerRegistryDefaultsToken{
-										RequireDockerRegistryDefaultsBase: apitype.RequireDockerRegistryDefaultsBase{
-											Image: "iGHCR",
-											Tag:   "tGHCR",
-										},
 										RequireDockerRegistryDefaultsAuth: apitype.RequireDockerRegistryDefaultsAuth{
 											Token: util.SecretValue,
 										},
 									},
 									Hub: &apitype.RequireDockerCheckRegistryDefaultsTokenWithUsername{
-										RequireDockerRegistryDefaultsBase: apitype.RequireDockerRegistryDefaultsBase{
-											Image: "iHub",
-											Tag:   "tHub",
-										},
 										RequireDockerRegistryDefaultsAuthWithUsername: apitype.RequireDockerRegistryDefaultsAuthWithUsername{
 											Username: "something",
 											RequireDockerRegistryDefaultsAuth: apitype.RequireDockerRegistryDefaultsAuth{
@@ -298,10 +282,6 @@ func TestConvertAndCensorDefaults(t *testing.T) {
 										},
 									},
 									Quay: &apitype.RequireDockerRegistryDefaultsToken{
-										RequireDockerRegistryDefaultsBase: apitype.RequireDockerRegistryDefaultsBase{
-											Image: "iQuay",
-											Tag:   "tQuay",
-										},
 										RequireDockerRegistryDefaultsAuth: apitype.RequireDockerRegistryDefaultsAuth{
 											Token: util.SecretValue,
 										},
@@ -746,16 +726,14 @@ func TestConvertAndCensorLatestVersionRequireDefaults(t *testing.T) {
 					"yaml", []byte(test.TrimYAML(`
 						docker:
 							type: hub
-							image: i
 							tag: t
 					`)),
 				)
 			}),
 			want: &apitype.LatestVersionRequireDefaults{
 				Docker: apitype.RequireDockerDefaults{
-					Type:  "hub",
-					Image: "i",
-					Tag:   "t",
+					Type: "hub",
+					Tag:  "t",
 				},
 			},
 		},
@@ -767,8 +745,6 @@ func TestConvertAndCensorLatestVersionRequireDefaults(t *testing.T) {
 						docker:
 							registry:
 								ghcr:
-									image: iGHCR
-									tag: tGHCR
 									auth:
 										username: something
 										token: ghp_X
@@ -779,10 +755,6 @@ func TestConvertAndCensorLatestVersionRequireDefaults(t *testing.T) {
 				Docker: apitype.RequireDockerDefaults{
 					Registry: apitype.RequireDockerRegistriesDefaults{
 						GHCR: &apitype.RequireDockerRegistryDefaultsToken{
-							RequireDockerRegistryDefaultsBase: apitype.RequireDockerRegistryDefaultsBase{
-								Image: "iGHCR",
-								Tag:   "tGHCR",
-							},
 							RequireDockerRegistryDefaultsAuth: apitype.RequireDockerRegistryDefaultsAuth{
 								Token: util.SecretValue,
 							},
@@ -799,8 +771,6 @@ func TestConvertAndCensorLatestVersionRequireDefaults(t *testing.T) {
 						docker:
 							registry:
 								hub:
-									image: iHub
-									tag: tHub
 									auth:
 										username: something
 										token: hub_X
@@ -811,10 +781,6 @@ func TestConvertAndCensorLatestVersionRequireDefaults(t *testing.T) {
 				Docker: apitype.RequireDockerDefaults{
 					Registry: apitype.RequireDockerRegistriesDefaults{
 						Hub: &apitype.RequireDockerCheckRegistryDefaultsTokenWithUsername{
-							RequireDockerRegistryDefaultsBase: apitype.RequireDockerRegistryDefaultsBase{
-								Image: "iHub",
-								Tag:   "tHub",
-							},
 							RequireDockerRegistryDefaultsAuthWithUsername: apitype.RequireDockerRegistryDefaultsAuthWithUsername{
 								Username: "something",
 								RequireDockerRegistryDefaultsAuth: apitype.RequireDockerRegistryDefaultsAuth{
@@ -834,8 +800,6 @@ func TestConvertAndCensorLatestVersionRequireDefaults(t *testing.T) {
 						docker:
 							registry:
 								quay:
-									image: iQuay
-									tag: tQuay
 									auth:
 										username: something
 										token: ghp_X
@@ -846,10 +810,6 @@ func TestConvertAndCensorLatestVersionRequireDefaults(t *testing.T) {
 				Docker: apitype.RequireDockerDefaults{
 					Registry: apitype.RequireDockerRegistriesDefaults{
 						Quay: &apitype.RequireDockerRegistryDefaultsToken{
-							RequireDockerRegistryDefaultsBase: apitype.RequireDockerRegistryDefaultsBase{
-								Image: "iQuay",
-								Tag:   "tQuay",
-							},
 							RequireDockerRegistryDefaultsAuth: apitype.RequireDockerRegistryDefaultsAuth{
 								Token: util.SecretValue,
 							},
@@ -865,24 +825,17 @@ func TestConvertAndCensorLatestVersionRequireDefaults(t *testing.T) {
 					"yaml", []byte(test.TrimYAML(`
 						docker:
 							type: hub
-							image: i
 							tag: t
 							registry:
 								ghcr:
-									image: iGHCR
-									tag: tGHCR
 									auth:
 										username: something
 										token: ghp_X
 								hub:
-									image: iHub
-									tag: tHub
 									auth:
 										username: something
 										token: hub_X
 								quay:
-									image: iQuay
-									tag: tQuay
 									auth:
 										username: something
 										token: quay_X
@@ -891,24 +844,15 @@ func TestConvertAndCensorLatestVersionRequireDefaults(t *testing.T) {
 			}),
 			want: &apitype.LatestVersionRequireDefaults{
 				Docker: apitype.RequireDockerDefaults{
-					Type:  "hub",
-					Image: "i",
-					Tag:   "t",
+					Type: "hub",
+					Tag:  "t",
 					Registry: apitype.RequireDockerRegistriesDefaults{
 						GHCR: &apitype.RequireDockerRegistryDefaultsToken{
-							RequireDockerRegistryDefaultsBase: apitype.RequireDockerRegistryDefaultsBase{
-								Image: "iGHCR",
-								Tag:   "tGHCR",
-							},
 							RequireDockerRegistryDefaultsAuth: apitype.RequireDockerRegistryDefaultsAuth{
 								Token: util.SecretValue,
 							},
 						},
 						Hub: &apitype.RequireDockerCheckRegistryDefaultsTokenWithUsername{
-							RequireDockerRegistryDefaultsBase: apitype.RequireDockerRegistryDefaultsBase{
-								Image: "iHub",
-								Tag:   "tHub",
-							},
 							RequireDockerRegistryDefaultsAuthWithUsername: apitype.RequireDockerRegistryDefaultsAuthWithUsername{
 								Username: "something",
 								RequireDockerRegistryDefaultsAuth: apitype.RequireDockerRegistryDefaultsAuth{
@@ -917,10 +861,6 @@ func TestConvertAndCensorLatestVersionRequireDefaults(t *testing.T) {
 							},
 						},
 						Quay: &apitype.RequireDockerRegistryDefaultsToken{
-							RequireDockerRegistryDefaultsBase: apitype.RequireDockerRegistryDefaultsBase{
-								Image: "iQuay",
-								Tag:   "tQuay",
-							},
 							RequireDockerRegistryDefaultsAuth: apitype.RequireDockerRegistryDefaultsAuth{
 								Token: util.SecretValue,
 							},
@@ -1166,20 +1106,12 @@ func TestConvertAndCensorRequireDockerRegistryDefaults(t *testing.T) {
 			name: "docker/ghcr/converted",
 			input: &docker.GHCRRegistryDefaults{
 				CommonRegistryDefaults: docker.CommonRegistryDefaults{
-					ContainerDetail: docker.ContainerDetail{
-						Image: "test/app",
-						Tag:   "{{ version }}",
-					},
 					Auth: &docker.GHCRAuthDefaults{
 						Token: "ghcr_X",
 					},
 				},
 			},
 			want: &apitype.RequireDockerRegistryDefaultsToken{
-				RequireDockerRegistryDefaultsBase: apitype.RequireDockerRegistryDefaultsBase{
-					Image: "test/app",
-					Tag:   "{{ version }}",
-				},
 				RequireDockerRegistryDefaultsAuth: apitype.RequireDockerRegistryDefaultsAuth{
 					Token: util.SecretValue,
 				},
@@ -1194,10 +1126,6 @@ func TestConvertAndCensorRequireDockerRegistryDefaults(t *testing.T) {
 			name: "docker/hub/converted",
 			input: &docker.HubRegistryDefaults{
 				CommonRegistryDefaults: docker.CommonRegistryDefaults{
-					ContainerDetail: docker.ContainerDetail{
-						Image: "test/app",
-						Tag:   "{{ version }}",
-					},
 					Auth: &docker.HubAuthDefaults{
 						Username: "something",
 						Token:    "ghcr_X",
@@ -1205,10 +1133,6 @@ func TestConvertAndCensorRequireDockerRegistryDefaults(t *testing.T) {
 				},
 			},
 			want: &apitype.RequireDockerCheckRegistryDefaultsTokenWithUsername{
-				RequireDockerRegistryDefaultsBase: apitype.RequireDockerRegistryDefaultsBase{
-					Image: "test/app",
-					Tag:   "{{ version }}",
-				},
 				RequireDockerRegistryDefaultsAuthWithUsername: apitype.RequireDockerRegistryDefaultsAuthWithUsername{
 					Username: "something",
 					RequireDockerRegistryDefaultsAuth: apitype.RequireDockerRegistryDefaultsAuth{
@@ -1226,20 +1150,12 @@ func TestConvertAndCensorRequireDockerRegistryDefaults(t *testing.T) {
 			name: "docker/quay/converted",
 			input: &docker.QuayRegistryDefaults{
 				CommonRegistryDefaults: docker.CommonRegistryDefaults{
-					ContainerDetail: docker.ContainerDetail{
-						Image: "test/app",
-						Tag:   "{{ version }}",
-					},
 					Auth: &docker.QuayAuthDefaults{
 						Token: "quay_X",
 					},
 				},
 			},
 			want: &apitype.RequireDockerRegistryDefaultsToken{
-				RequireDockerRegistryDefaultsBase: apitype.RequireDockerRegistryDefaultsBase{
-					Image: "test/app",
-					Tag:   "{{ version }}",
-				},
 				RequireDockerRegistryDefaultsAuth: apitype.RequireDockerRegistryDefaultsAuth{
 					Token: util.SecretValue,
 				},

--- a/web/api/v1/http-api-config_test.go
+++ b/web/api/v1/http-api-config_test.go
@@ -98,24 +98,17 @@ func TestHTTP_Config(t *testing.T) {
 								"yaml", []byte(test.TrimYAML(`
 									docker:
 										type: hub
-										image: i
 										tag: t
 										registry:
 											ghcr:
-												image: iGHCR
-												tag: tGHCR
 												auth:
 													username: something
 													token: ghp_X
 											hub:
-												image: iHub
-												tag: tHub
 												auth:
 													username: something
 													token: hub_X
 											quay:
-												image: iQuay
-												tag: tQuay
 												auth:
 													username: something
 													token: quay_X
@@ -144,27 +137,20 @@ func TestHTTP_Config(t *testing.T) {
 								"require": {
 									"docker": {
 										"type": "hub",
-										"image": "i",
 										"tag": "t",
 										"registry": {
 											"ghcr": {
-												"image": "iGHCR",
-												"tag": "tGHCR",
 												"auth": {
 													"token": ` + secretValueMarshalled + `
 												}
 											},
 											"hub": {
-												"image": "iHub",
-												"tag": "tHub",
 												"auth": {
 													"username": "something",
 													"token": ` + secretValueMarshalled + `
 												}
 											},
 											"quay": {
-												"image": "iQuay",
-												"tag": "tQuay",
 												"auth": {
 													"token": ` + secretValueMarshalled + `
 												}
@@ -202,24 +188,17 @@ func TestHTTP_Config(t *testing.T) {
 								"yaml", []byte(test.TrimYAML(`
 									docker:
 										type: hub
-										image: i
 										tag: t
 										registry:
 											ghcr:
-												image: iGHCR
-												tag: tGHCR
 												auth:
 													username: something
 													token: ghp_X
 											hub:
-												image: iHub
-												tag: tHub
 												auth:
 													username: something
 													token: hub_X
 											quay:
-												image: iQuay
-												tag: tQuay
 												auth:
 													username: something
 													token: quay_X
@@ -260,27 +239,20 @@ func TestHTTP_Config(t *testing.T) {
 								"require": {
 									"docker": {
 										"type": "hub",
-										"image": "i",
 										"tag": "t",
 										"registry": {
 											"ghcr": {
-												"image": "iGHCR",
-												"tag": "tGHCR",
 												"auth": {
 													"token": ` + secretValueMarshalled + `
 												}
 											},
 											"hub": {
-												"image": "iHub",
-												"tag": "tHub",
 												"auth": {
 													"username": "something",
 													"token": ` + secretValueMarshalled + `
 												}
 											},
 											"quay": {
-												"image": "iQuay",
-												"tag": "tQuay",
 												"auth": {
 													"token": ` + secretValueMarshalled + `
 												}
@@ -328,24 +300,17 @@ func TestHTTP_Config(t *testing.T) {
 								"yaml", []byte(test.TrimYAML(`
 									docker:
 										type: hub
-										image: i
 										tag: t
 										registry:
 											ghcr:
-												image: iGHCR
-												tag: tGHCR
 												auth:
 													username: something
 													token: ghp_X
 											hub:
-												image: iHub
-												tag: tHub
 												auth:
 													username: something
 													token: hub_X
 											quay:
-												image: iQuay
-												tag: tQuay
 												auth:
 													username: something
 													token: quay_X
@@ -400,27 +365,20 @@ func TestHTTP_Config(t *testing.T) {
 								"require": {
 									"docker": {
 										"type": "hub",
-										"image": "i",
 										"tag": "t",
 										"registry": {
 											"ghcr": {
-												"image": "iGHCR",
-												"tag": "tGHCR",
 												"auth": {
 													"token": ` + secretValueMarshalled + `
 												}
 											},
 											"hub": {
-												"image": "iHub",
-												"tag": "tHub",
 												"auth": {
 													"username": "something",
 													"token": ` + secretValueMarshalled + `
 												}
 											},
 											"quay": {
-												"image": "iQuay",
-												"tag": "tQuay",
 												"auth": {
 													"token": ` + secretValueMarshalled + `
 												}
@@ -494,27 +452,20 @@ func TestHTTP_Config(t *testing.T) {
 								"require": {
 									"docker": {
 										"type": "hub",
-										"image": "i",
 										"tag": "t",
 										"registry": {
 											"ghcr": {
-												"image": "iGHCR",
-												"tag": "tGHCR",
 												"auth": {
 													"token": ` + secretValueMarshalled + `
 												}
 											},
 											"hub": {
-												"image": "iHub",
-												"tag": "tHub",
 												"auth": {
 													"username": "something",
 													"token": ` + secretValueMarshalled + `
 												}
 											},
 											"quay": {
-												"image": "iQuay",
-												"tag": "tQuay",
 												"auth": {
 													"token": ` + secretValueMarshalled + `
 												}
@@ -618,27 +569,20 @@ func TestHTTP_Config(t *testing.T) {
 								"require": {
 									"docker": {
 										"type": "hub",
-										"image": "i",
 										"tag": "t",
 										"registry": {
 											"ghcr": {
-												"image": "iGHCR",
-												"tag": "tGHCR",
 												"auth": {
 													"token": ` + secretValueMarshalled + `
 												}
 											},
 											"hub": {
-												"image": "iHub",
-												"tag": "tHub",
 												"auth": {
 													"username": "something",
 													"token": ` + secretValueMarshalled + `
 												}
 											},
 											"quay": {
-												"image": "iQuay",
-												"tag": "tQuay",
 												"auth": {
 													"token": ` + secretValueMarshalled + `
 												}

--- a/web/ui/package-lock.json
+++ b/web/ui/package-lock.json
@@ -3908,9 +3908,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001799",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
-			"integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+			"version": "1.0.30001800",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001800.tgz",
+			"integrity": "sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==",
 			"dev": true,
 			"funding": [
 				{

--- a/web/ui/react-app/src/components/modals/service-edit/latest-version-require.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/latest-version-require.tsx
@@ -99,7 +99,7 @@ const EditServiceLatestVersionRequire = () => {
 		type: 'string',
 	};
 	const hasContainer =
-		(!!values.docker.image.trim() || !!dockerDefaults?.image?.trim()) &&
+		!!values.docker.image.trim() &&
 		(!!values.docker.tag.trim() || !!dockerDefaults?.tag?.trim());
 
 	return (
@@ -154,7 +154,6 @@ const EditServiceLatestVersionRequire = () => {
 						/>
 						<FieldText
 							colSize={{ xs: 6 }}
-							defaultVal={dockerDefaults?.image}
 							label="Image"
 							name={`${name}.docker.image`}
 							required={values?.docker?.tag}

--- a/web/ui/react-app/src/utils/api/types/config-edit/service/form/builder--latest-version.ts
+++ b/web/ui/react-app/src/utils/api/types/config-edit/service/form/builder--latest-version.ts
@@ -134,11 +134,11 @@ export const buildDockerFilterSchemaWithFallbacks = (
 	const combinedDefaults = {
 		registry: [dockerHubValue, ghcrValue, quayValue].reduce(
 			(acc, type) => {
-				acc[type] = applyDefaultsRecursive(
-					defaults?.registry?.[type] ?? null,
-					{ image: defaults?.image, tag: defaults?.tag },
-					hardDefaults?.registry?.[type],
-					{ image: hardDefaults?.image, tag: hardDefaults?.tag },
+				acc[type] = applyDefaultsRecursive<Partial<DockerFilter>>(
+					(defaults?.registry?.[type] as Partial<DockerFilter>) ?? null,
+					{ tag: defaults?.tag },
+					hardDefaults?.registry?.[type] as Partial<DockerFilter> | undefined,
+					{ tag: hardDefaults?.tag },
 				);
 				return acc;
 			},
@@ -191,12 +191,11 @@ export const buildDockerFilterSchemaWithFallbacks = (
 		const schemaType = arg.type === nullString ? defaultType : arg.type;
 		const schemaDefaults = schemaType && combinedDefaults.registry[schemaType];
 		const hasImage = !!arg.image?.trim();
-		const hasImageDefaulted = hasImage || !!schemaDefaults?.image?.trim();
 		const hasTag = !!arg.tag?.trim();
 		const hasTagDefaulted = hasTag || !!schemaDefaults?.tag?.trim();
 
-		// If we have an image, we must have a tag, and vice versa.
-		if (hasImage !== hasTag && hasImageDefaulted !== hasTagDefaulted) {
+		// If we have an image/tag defined for this instance, we must have values for both.
+		if (hasImage !== hasTag && hasImage !== hasTagDefaulted) {
 			ctx.addIssue({
 				code: CUSTOM_ISSUE_CODE,
 				message: REQUIRED_MESSAGE,
@@ -206,7 +205,7 @@ export const buildDockerFilterSchemaWithFallbacks = (
 
 		// If we have an image:tag specified and have a username field.
 		if (
-			hasImageDefaulted &&
+			hasImage &&
 			hasTagDefaulted &&
 			schemaType &&
 			usernameTypes.has(schemaType)

--- a/web/ui/react-app/src/utils/api/types/config-edit/service/types/latest-version.ts
+++ b/web/ui/react-app/src/utils/api/types/config-edit/service/types/latest-version.ts
@@ -168,13 +168,29 @@ export const dockerFilterSchema = z.discriminatedUnion('type', [
 export type DockerTypeDockerHub = z.infer<
 	typeof latestVersionLookupRequireDockerTypeSchemaDockerHub
 >;
+export const latestVersionLookupRequireDockerDefaultsSchemaBase = z.object({
+	tag: stringDefault,
+});
+export const latestVersionLookupRequireDockerRegistryDefaultsSchema =
+	latestVersionLookupRequireDockerDefaultsSchemaBase.extend({
+		auth: latestVersionLookupRequireDockerAuthSchemaBase.default({
+			token: '',
+		}),
+	});
+export const latestVersionLookupRequireDockerRegistryDefaultsSchemaDockerHub =
+	latestVersionLookupRequireDockerDefaultsSchemaBase.extend({
+		auth: latestVersionLookupRequireDockerAuthSchemaDockerHubBase.default({
+			token: '',
+			username: '',
+		}),
+	});
 export const dockerFilterSchemaDefaults =
-	latestVersionLookupRequireDockerTypeSchemaBase.extend({
+	latestVersionLookupRequireDockerDefaultsSchemaBase.extend({
 		registry: z
 			.object({
-				ghcr: latestVersionLookupRequireDockerTypeSchema.partial(),
-				hub: latestVersionLookupRequireDockerTypeSchemaDockerHub.partial(),
-				quay: latestVersionLookupRequireDockerTypeSchema.partial(),
+				ghcr: latestVersionLookupRequireDockerRegistryDefaultsSchema.partial(),
+				hub: latestVersionLookupRequireDockerRegistryDefaultsSchemaDockerHub.partial(),
+				quay: latestVersionLookupRequireDockerRegistryDefaultsSchema.partial(),
 			})
 			.optional(),
 		type: z.literal(dockerFilterSchemaBase).optional(),

--- a/web/ui/react-app/src/utils/api/types/config/service/latest-version.ts
+++ b/web/ui/react-app/src/utils/api/types/config/service/latest-version.ts
@@ -116,19 +116,22 @@ export type DockerType =
 	| NullString;
 
 export type DockerFilter = DockerFilterBase | DockerFilterUsername;
-export type DockerFilterDefaults =
-	| Partial<DockerFilterBase>
-	| DockerFilterUsernameDefaults;
+
+export type DockerRegistryDefaults = {
+	auth?: { token?: string };
+};
+export type DockerRegistryUsernameDefaults = {
+	auth?: { token?: string; username?: string };
+};
 
 export type RequireDockerFilterDefaults = {
 	type?: DockerFilterType;
-	image?: string;
 	tag?: string;
 
 	registry?: {
-		ghcr?: DockerFilterDefaults;
-		hub?: DockerFilterUsernameDefaults;
-		quay?: DockerFilterDefaults;
+		ghcr?: DockerRegistryDefaults;
+		hub?: DockerRegistryUsernameDefaults;
+		quay?: DockerRegistryDefaults;
 	};
 };
 


### PR DESCRIPTION
Per-registry docker require-defaults (ghcr/hub/quay) no longer carry image/tag - only auth. (registry image/tag defaults were only introduced in #cf217a5. No releases were made/docs updated with this change)

ContainerDetail keeps its image+tag fields, but its defaults chain is now tag-only - image is never inherited.