### PR TITLE
fix(notify): don't error on CheckValues of old-type Teams

### DIFF
--- a/notify/shoutrrr/verify.go
+++ b/notify/shoutrrr/verify.go
@@ -959,7 +959,8 @@ func (s *Shoutrrr) checkValuesParams() error {
 		}
 	case "teams":
 		// teams://?host=fullPowerAutomateURL
-		if s.GetParam("host") == "" {
+		// don't fail on old, no-longer functional instances.
+		if s.GetParam("host") == "" && s.GetURLField("group") == "" {
 			errs = append(
 				errs,
 				&decode.FieldError{

--- a/notify/shoutrrr/verify_test.go
+++ b/notify/shoutrrr/verify_test.go
@@ -2837,11 +2837,12 @@ func TestShoutrrr_CheckValuesURLFields(t *testing.T) {
 func TestShoutrrr_CheckValuesParams(t *testing.T) {
 	// GIVEN: a Shoutrrr with Params.
 	tests := []struct {
-		name     string
-		sType    string
-		params   map[string]string
-		main     *Defaults
-		errRegex string
+		name      string
+		sType     string
+		params    map[string]string
+		urlFields map[string]string
+		main      *Defaults
+		errRegex  string
 	}{
 		{
 			name:     "no params",
@@ -2971,6 +2972,19 @@ func TestShoutrrr_CheckValuesParams(t *testing.T) {
 			errRegex: `^host: <required>.*$`,
 		},
 		{
+			name:  "teams/old-style (no host) - no error",
+			sType: "teams",
+			urlFields: map[string]string{
+				"group":      "GROUP",
+				"tenant":     "TENANT",
+				"altid":      "ALTID",
+				"groupowner": "GROUPOWNER",
+				"extraid":    "EXTRAID",
+			},
+			params:   map[string]string{},
+			errRegex: `^$`,
+		},
+		{
 			name:  "teams/valid (Power Automate URL)",
 			sType: "teams",
 			params: map[string]string{
@@ -3058,6 +3072,7 @@ func TestShoutrrr_CheckValuesParams(t *testing.T) {
 			input := testShoutrrr(false, false)
 			input.Type = tc.sType
 			input.Params = tc.params
+			input.URLFields = tc.urlFields
 			svcStatus, _ := statustest.New("yaml", nil)
 			svcStatus.Init(
 				0, 1, 0,


### PR DESCRIPTION
Shoutrrr's Teams support moved from the legacy Office 365 Connector format (group/tenant/etc. URL fields) to the Power Automate workflow format (host param). The new validation requires host unconditionally, so existing old-style configs (with group, no host) now fail `CheckValues` at load despite being unchanged.

Since Office 365 Connectors are retired upstream, those instances are dead regardless; hard-failing them just blocks the rest of the config from loading.

Change: only require host when the legacy group field is also absent