### PR TITLE
feat(ui): add approve/skip actions for manual deployed_version services

### DIFF
--- a/service/types.go
+++ b/service/types.go
@@ -273,19 +273,22 @@ func (s *Service) Summary() *apitype.ServiceSummary {
 	if s.LatestVersion != nil {
 		latestVersionType = s.LatestVersion.GetType()
 	}
-	hasDeployedVersionLookup := s.DeployedVersionLookup != nil
+	var deployedVersionType string
+	if s.DeployedVersionLookup != nil {
+		deployedVersionType = s.DeployedVersionLookup.GetType()
+	}
 
 	svcInfo := s.Status.GetServiceInfo()
 	summary := &apitype.ServiceSummary{
-		ID:                       s.ID,
-		Name:                     util.PtrIfNotZero(s.Name),
-		Active:                   s.Options.Active,
-		Comment:                  util.PtrIfNotZero(svcInfo.Comment),
-		Type:                     latestVersionType,
-		WebURL:                   util.PtrIfNotZero(svcInfo.WebURL),
-		Icon:                     util.PtrIfNotZero(svcInfo.Icon),
-		IconLinkTo:               util.PtrIfNotZero(svcInfo.IconLinkTo),
-		HasDeployedVersionLookup: &hasDeployedVersionLookup,
+		ID:                  s.ID,
+		Name:                util.PtrIfNotZero(s.Name),
+		Active:              s.Options.Active,
+		Comment:             util.PtrIfNotZero(svcInfo.Comment),
+		Type:                latestVersionType,
+		WebURL:              util.PtrIfNotZero(svcInfo.WebURL),
+		Icon:                util.PtrIfNotZero(svcInfo.Icon),
+		IconLinkTo:          util.PtrIfNotZero(svcInfo.IconLinkTo),
+		DeployedVersionType: &deployedVersionType,
 		Status: &apitype.Status{
 			ApprovedVersion:          svcInfo.ApprovedVersion,
 			DeployedVersion:          svcInfo.DeployedVersion,

--- a/service/types_test.go
+++ b/service/types_test.go
@@ -1075,15 +1075,15 @@ func TestService_Summary(t *testing.T) {
 				)
 			}),
 			want: &apitype.ServiceSummary{
-				ID:                       "",
-				Name:                     nil,
-				Type:                     "",
-				Icon:                     nil,
-				IconLinkTo:               nil,
-				HasDeployedVersionLookup: test.Ptr(false),
-				Command:                  nil,
-				WebHook:                  nil,
-				Status:                   &apitype.Status{},
+				ID:                  "",
+				Name:                nil,
+				Type:                "",
+				Icon:                nil,
+				IconLinkTo:          nil,
+				DeployedVersionType: test.Ptr(""),
+				Command:             nil,
+				WebHook:             nil,
+				Status:              &apitype.Status{},
 			},
 		},
 		{
@@ -1096,9 +1096,9 @@ func TestService_Summary(t *testing.T) {
 				)
 			}),
 			want: &apitype.ServiceSummary{
-				ID:                       "foo",
-				HasDeployedVersionLookup: test.Ptr(false),
-				Status:                   &apitype.Status{},
+				ID:                  "foo",
+				DeployedVersionType: test.Ptr(""),
+				Status:              &apitype.Status{},
 			},
 		},
 		{
@@ -1113,9 +1113,9 @@ func TestService_Summary(t *testing.T) {
 				)
 			}),
 			want: &apitype.ServiceSummary{
-				Name:                     test.Ptr("bar"),
-				HasDeployedVersionLookup: test.Ptr(false),
-				Status:                   &apitype.Status{},
+				Name:                test.Ptr("bar"),
+				DeployedVersionType: test.Ptr(""),
+				Status:              &apitype.Status{},
 			},
 		},
 		{
@@ -1131,9 +1131,9 @@ func TestService_Summary(t *testing.T) {
 				)
 			}),
 			want: &apitype.ServiceSummary{
-				Active:                   test.Ptr(false),
-				HasDeployedVersionLookup: test.Ptr(false),
-				Status:                   &apitype.Status{},
+				Active:              test.Ptr(false),
+				DeployedVersionType: test.Ptr(""),
+				Status:              &apitype.Status{},
 			},
 		},
 		{
@@ -1149,9 +1149,9 @@ func TestService_Summary(t *testing.T) {
 				)
 			}),
 			want: &apitype.ServiceSummary{
-				Type:                     "github",
-				HasDeployedVersionLookup: test.Ptr(false),
-				Status:                   &apitype.Status{},
+				Type:                "github",
+				DeployedVersionType: test.Ptr(""),
+				Status:              &apitype.Status{},
 			},
 		},
 		{
@@ -1167,9 +1167,9 @@ func TestService_Summary(t *testing.T) {
 				)
 			}),
 			want: &apitype.ServiceSummary{
-				Icon:                     test.Ptr("https://example.com/icon.png"),
-				HasDeployedVersionLookup: test.Ptr(false),
-				Status:                   &apitype.Status{},
+				Icon:                test.Ptr("https://example.com/icon.png"),
+				DeployedVersionType: test.Ptr(""),
+				Status:              &apitype.Status{},
 			},
 		},
 		{
@@ -1185,9 +1185,9 @@ func TestService_Summary(t *testing.T) {
 				)
 			}),
 			want: &apitype.ServiceSummary{
-				Icon:                     test.Ptr("smile"),
-				HasDeployedVersionLookup: test.Ptr(false),
-				Status:                   &apitype.Status{},
+				Icon:                test.Ptr("smile"),
+				DeployedVersionType: test.Ptr(""),
+				Status:              &apitype.Status{},
 			},
 		},
 		{
@@ -1206,9 +1206,9 @@ func TestService_Summary(t *testing.T) {
 				)
 			}),
 			want: &apitype.ServiceSummary{
-				Icon:                     test.Ptr("https://example.com/notify.png"),
-				HasDeployedVersionLookup: test.Ptr(false),
-				Status:                   &apitype.Status{},
+				Icon:                test.Ptr("https://example.com/notify.png"),
+				DeployedVersionType: test.Ptr(""),
+				Status:              &apitype.Status{},
 			},
 		},
 		{
@@ -1229,9 +1229,9 @@ func TestService_Summary(t *testing.T) {
 				)
 			}),
 			want: &apitype.ServiceSummary{
-				Icon:                     test.Ptr("https://example.com/icon.png"),
-				HasDeployedVersionLookup: test.Ptr(false),
-				Status:                   &apitype.Status{},
+				Icon:                test.Ptr("https://example.com/icon.png"),
+				DeployedVersionType: test.Ptr(""),
+				Status:              &apitype.Status{},
 			},
 		},
 		{
@@ -1247,9 +1247,9 @@ func TestService_Summary(t *testing.T) {
 				)
 			}),
 			want: &apitype.ServiceSummary{
-				IconLinkTo:               test.Ptr("https://example.com"),
-				HasDeployedVersionLookup: test.Ptr(false),
-				Status:                   &apitype.Status{},
+				IconLinkTo:          test.Ptr("https://example.com"),
+				DeployedVersionType: test.Ptr(""),
+				Status:              &apitype.Status{},
 			},
 		},
 		{
@@ -1265,9 +1265,9 @@ func TestService_Summary(t *testing.T) {
 				)
 			}),
 			want: &apitype.ServiceSummary{
-				WebURL:                   test.Ptr("https://example.com"),
-				HasDeployedVersionLookup: test.Ptr(false),
-				Status:                   &apitype.Status{},
+				WebURL:              test.Ptr("https://example.com"),
+				DeployedVersionType: test.Ptr(""),
+				Status:              &apitype.Status{},
 			},
 		},
 		{
@@ -1283,9 +1283,9 @@ func TestService_Summary(t *testing.T) {
 				)
 			}),
 			want: &apitype.ServiceSummary{
-				Tags:                     &[]string{"hello", "there"},
-				HasDeployedVersionLookup: test.Ptr(false),
-				Status:                   &apitype.Status{},
+				Tags:                &[]string{"hello", "there"},
+				DeployedVersionType: test.Ptr(""),
+				Status:              &apitype.Status{},
 			},
 		},
 		{
@@ -1300,8 +1300,8 @@ func TestService_Summary(t *testing.T) {
 				)
 			}),
 			want: &apitype.ServiceSummary{
-				HasDeployedVersionLookup: test.Ptr(true),
-				Status:                   &apitype.Status{},
+				DeployedVersionType: test.Ptr(dvweb.Type),
+				Status:              &apitype.Status{},
 			},
 		},
 		{
@@ -1316,8 +1316,8 @@ func TestService_Summary(t *testing.T) {
 				)
 			}),
 			want: &apitype.ServiceSummary{
-				HasDeployedVersionLookup: test.Ptr(false),
-				Status:                   &apitype.Status{},
+				DeployedVersionType: test.Ptr(""),
+				Status:              &apitype.Status{},
 			},
 		},
 		{
@@ -1335,9 +1335,9 @@ func TestService_Summary(t *testing.T) {
 				)
 			}),
 			want: &apitype.ServiceSummary{
-				HasDeployedVersionLookup: test.Ptr(false),
-				Command:                  test.Ptr(3),
-				Status:                   &apitype.Status{},
+				DeployedVersionType: test.Ptr(""),
+				Command:             test.Ptr(3),
+				Status:              &apitype.Status{},
 			},
 		},
 		{
@@ -1352,8 +1352,8 @@ func TestService_Summary(t *testing.T) {
 				)
 			}),
 			want: &apitype.ServiceSummary{
-				HasDeployedVersionLookup: test.Ptr(false),
-				Status:                   &apitype.Status{},
+				DeployedVersionType: test.Ptr(""),
+				Status:              &apitype.Status{},
 			},
 		},
 		{
@@ -1374,9 +1374,9 @@ func TestService_Summary(t *testing.T) {
 				)
 			}),
 			want: &apitype.ServiceSummary{
-				HasDeployedVersionLookup: test.Ptr(false),
-				WebHook:                  test.Ptr(3),
-				Status:                   &apitype.Status{},
+				DeployedVersionType: test.Ptr(""),
+				WebHook:             test.Ptr(3),
+				Status:              &apitype.Status{},
 			},
 		},
 		{
@@ -1392,7 +1392,7 @@ func TestService_Summary(t *testing.T) {
 				),
 			},
 			want: &apitype.ServiceSummary{
-				HasDeployedVersionLookup: test.Ptr(false),
+				DeployedVersionType: test.Ptr(""),
 				Status: &apitype.Status{
 					ApprovedVersion:          "1",
 					DeployedVersion:          "2",
@@ -1489,17 +1489,17 @@ func TestService_Summary(t *testing.T) {
 				return svc, err
 			}),
 			want: &apitype.ServiceSummary{
-				ID:                       "foo",
-				Name:                     test.Ptr("bar"),
-				Active:                   test.Ptr(false),
-				Comment:                  test.Ptr("svc for blah"),
-				Type:                     "github",
-				WebURL:                   test.Ptr("https://example.com"),
-				Icon:                     test.Ptr("https://example.com/icon.png"),
-				IconLinkTo:               test.Ptr("https://example.com"),
-				HasDeployedVersionLookup: test.Ptr(true),
-				Command:                  test.Ptr(2),
-				WebHook:                  test.Ptr(3),
+				ID:                  "foo",
+				Name:                test.Ptr("bar"),
+				Active:              test.Ptr(false),
+				Comment:             test.Ptr("svc for blah"),
+				Type:                "github",
+				WebURL:              test.Ptr("https://example.com"),
+				Icon:                test.Ptr("https://example.com/icon.png"),
+				IconLinkTo:          test.Ptr("https://example.com"),
+				DeployedVersionType: test.Ptr(dvweb.Type),
+				Command:             test.Ptr(2),
+				WebHook:             test.Ptr(3),
 				Status: &apitype.Status{
 					ApprovedVersion:          "1",
 					DeployedVersion:          "2",

--- a/web/api/types/argus.go
+++ b/web/api/types/argus.go
@@ -27,19 +27,19 @@ import (
 
 // ServiceSummary is the Summary of a Service.
 type ServiceSummary struct {
-	ID                       string    `json:"id,omitempty" yaml:"id,omitempty"`
-	Name                     *string   `json:"name,omitempty" yaml:"name,omitempty"`                                 // Name for this Service.
-	Active                   *bool     `json:"active,omitempty" yaml:"active,omitempty"`                             // Active Service?
-	Comment                  *string   `json:"comment,omitempty" yaml:"comment,omitempty"`                           // Comment on the Service.
-	Type                     string    `json:"type,omitempty" yaml:"type,omitempty"`                                 // "github"/"URL".
-	WebURL                   *string   `json:"url,omitempty" yaml:"url,omitempty"`                                   // URL to provide on the Web UI.
-	Icon                     *string   `json:"icon,omitempty" yaml:"icon,omitempty"`                                 // Service.Dashboard.Icon / Service.Notify.*.Params.Icon / Service.Notify.*.Defaults.Params.Icon.
-	IconLinkTo               *string   `json:"icon_link_to,omitempty" yaml:"icon_link_to,omitempty"`                 // URL to redirect Icon clicks to.
-	HasDeployedVersionLookup *bool     `json:"has_deployed_version,omitempty" yaml:"has_deployed_version,omitempty"` // Whether this service has a DeployedVersionLookup.
-	Command                  *int      `json:"command,omitempty" yaml:"command,omitempty"`                           // Amount of Commands to send on a new release.
-	WebHook                  *int      `json:"webhook,omitempty" yaml:"webhook,omitempty"`                           // Amount of WebHooks to send on a new release.
-	Status                   *Status   `json:"status,omitempty" yaml:"status,omitempty"`                             // Track the Status of this source (version and regex misses).
-	Tags                     *[]string `json:"tags,omitempty" yaml:"tags,omitempty"`                                 // Tags for the Service.
+	ID                  string    `json:"id,omitempty" yaml:"id,omitempty"`
+	Name                *string   `json:"name,omitempty" yaml:"name,omitempty"`                                   // Name for this Service.
+	Active              *bool     `json:"active,omitempty" yaml:"active,omitempty"`                               // Active Service?
+	Comment             *string   `json:"comment,omitempty" yaml:"comment,omitempty"`                             // Comment on the Service.
+	Type                string    `json:"type,omitempty" yaml:"type,omitempty"`                                   // "github"|"URL".
+	WebURL              *string   `json:"url,omitempty" yaml:"url,omitempty"`                                     // URL to provide on the Web UI.
+	Icon                *string   `json:"icon,omitempty" yaml:"icon,omitempty"`                                   // Service.Dashboard.Icon / Service.Notify.*.Params.Icon / Service.Notify.*.Defaults.Params.Icon.
+	IconLinkTo          *string   `json:"icon_link_to,omitempty" yaml:"icon_link_to,omitempty"`                   // URL to redirect Icon clicks to.
+	DeployedVersionType *string   `json:"deployed_version_type,omitempty" yaml:"deployed_version_type,omitempty"` // "manual"|"url", empty string if no DeployedVersionLookup.
+	Command             *int      `json:"command,omitempty" yaml:"command,omitempty"`                             // Amount of Commands to send on a new release.
+	WebHook             *int      `json:"webhook,omitempty" yaml:"webhook,omitempty"`                             // Amount of WebHooks to send on a new release.
+	Status              *Status   `json:"status,omitempty" yaml:"status,omitempty"`                               // Track the Status of this source (version and regex misses).
+	Tags                *[]string `json:"tags,omitempty" yaml:"tags,omitempty"`                                   // Tags for the Service.
 }
 
 // IsZero implements the yaml.IsZeroer interface.
@@ -52,7 +52,7 @@ func (s *ServiceSummary) IsZero() bool {
 		s.WebURL == nil &&
 		s.Icon == nil &&
 		s.IconLinkTo == nil &&
-		s.HasDeployedVersionLookup == nil &&
+		s.DeployedVersionType == nil &&
 		s.Command == nil &&
 		s.WebHook == nil &&
 		s.Status == nil &&
@@ -100,11 +100,8 @@ func (s *ServiceSummary) RemoveUnchanged(oldData *ServiceSummary) {
 	s.Icon = nilIfUnchanged(oldData.Icon, s.Icon)
 	// IconLinkTo.
 	s.IconLinkTo = nilIfUnchanged(oldData.IconLinkTo, s.IconLinkTo)
-	// Has DeployedVersionLookup?
-	if util.DerefOr(oldData.HasDeployedVersionLookup, false) ==
-		util.DerefOr(s.HasDeployedVersionLookup, false) {
-		s.HasDeployedVersionLookup = nil
-	}
+	// DeployedVersionType.
+	s.DeployedVersionType = nilIfUnchanged(oldData.DeployedVersionType, s.DeployedVersionType)
 
 	// Status.
 	statusSameCount := 0

--- a/web/api/types/argus_test.go
+++ b/web/api/types/argus_test.go
@@ -27,6 +27,12 @@ import (
 	"github.com/release-argus/Argus/util"
 )
 
+// Deployed-version lookup type strings.
+const (
+	dvManualType = "manual"
+	dvURLType    = "url"
+)
+
 func TestServiceSummary_IsZero(t *testing.T) {
 	// GIVEN: a ServiceSummary struct.
 	tests := []struct {
@@ -96,9 +102,9 @@ func TestServiceSummary_IsZero(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "non-empty/HasDeployedVersionLookup",
+			name: "non-empty/DeployedVersionType",
 			data: ServiceSummary{
-				HasDeployedVersionLookup: test.Ptr(false),
+				DeployedVersionType: test.Ptr(dvManualType),
 			},
 			want: false,
 		},
@@ -135,17 +141,17 @@ func TestServiceSummary_IsZero(t *testing.T) {
 		{
 			name: "non-empty/all",
 			data: ServiceSummary{
-				ID:                       "foo",
-				Name:                     test.Ptr("foo"),
-				Active:                   test.Ptr(true),
-				Comment:                  test.Ptr("foo"),
-				Type:                     "foo",
-				WebURL:                   test.Ptr("https://example.com"),
-				Icon:                     test.Ptr("https://example.com/icon.png"),
-				IconLinkTo:               test.Ptr("https://example.com/somewhere"),
-				HasDeployedVersionLookup: test.Ptr(false),
-				Command:                  test.Ptr(1),
-				WebHook:                  test.Ptr(2),
+				ID:                  "foo",
+				Name:                test.Ptr("foo"),
+				Active:              test.Ptr(true),
+				Comment:             test.Ptr("foo"),
+				Type:                "foo",
+				WebURL:              test.Ptr("https://example.com"),
+				Icon:                test.Ptr("https://example.com/icon.png"),
+				IconLinkTo:          test.Ptr("https://example.com/somewhere"),
+				DeployedVersionType: test.Ptr(dvManualType),
+				Command:             test.Ptr(1),
+				WebHook:             test.Ptr(2),
 				Status: &Status{
 					ApprovedVersion: "1.2.3",
 				},
@@ -211,17 +217,17 @@ func TestServiceSummary_String(t *testing.T) {
 		{
 			name: "full",
 			summary: &ServiceSummary{
-				ID:                       "bar",
-				Name:                     test.Ptr("foo"),
-				Active:                   test.Ptr(true),
-				Comment:                  test.Ptr("test"),
-				Type:                     "url",
-				WebURL:                   test.Ptr("https://example.com"),
-				Icon:                     test.Ptr("https://example.com/icon.png"),
-				IconLinkTo:               test.Ptr("https://release-argus.io"),
-				HasDeployedVersionLookup: test.Ptr(true),
-				Command:                  test.Ptr(2),
-				WebHook:                  test.Ptr(1),
+				ID:                  "bar",
+				Name:                test.Ptr("foo"),
+				Active:              test.Ptr(true),
+				Comment:             test.Ptr("test"),
+				Type:                "url",
+				WebURL:              test.Ptr("https://example.com"),
+				Icon:                test.Ptr("https://example.com/icon.png"),
+				IconLinkTo:          test.Ptr("https://release-argus.io"),
+				DeployedVersionType: test.Ptr(dvManualType),
+				Command:             test.Ptr(2),
+				WebHook:             test.Ptr(1),
 				Status: &Status{
 					ApprovedVersion: "1.2.3",
 				},
@@ -236,7 +242,7 @@ func TestServiceSummary_String(t *testing.T) {
 					"url": "https://example.com",
 					"icon": "https://example.com/icon.png",
 					"icon_link_to": "https://release-argus.io",
-					"has_deployed_version": true,
+					"deployed_version_type": "manual",
 					"command": 2,
 					"webhook": 1,
 					"status": {
@@ -467,25 +473,25 @@ func TestServiceSummary_RemoveUnchanged(t *testing.T) {
 			},
 		},
 		{
-			name: "same has_deployed_version_lookup",
+			name: "same deployed_version_type",
 			old: &ServiceSummary{
-				HasDeployedVersionLookup: test.Ptr(true),
+				DeployedVersionType: test.Ptr(dvManualType),
 			},
 			new: &ServiceSummary{
-				HasDeployedVersionLookup: test.Ptr(true),
+				DeployedVersionType: test.Ptr(dvManualType),
 			},
 			want: &ServiceSummary{},
 		},
 		{
-			name: "different has_deployed_version_lookup",
+			name: "different deployed_version_type",
 			old: &ServiceSummary{
-				HasDeployedVersionLookup: test.Ptr(true),
+				DeployedVersionType: test.Ptr(dvManualType),
 			},
 			new: &ServiceSummary{
-				HasDeployedVersionLookup: test.Ptr(false),
+				DeployedVersionType: test.Ptr(dvURLType),
 			},
 			want: &ServiceSummary{
-				HasDeployedVersionLookup: test.Ptr(false),
+				DeployedVersionType: test.Ptr(dvURLType),
 			},
 		},
 		{

--- a/web/ui/react-app/playwright.config.ts
+++ b/web/ui/react-app/playwright.config.ts
@@ -18,9 +18,10 @@ import { defineConfig, devices } from '@playwright/test';
  */
 const SERIAL_SPECS = [
 	'create-service.spec.ts',
-	'webhook.spec.ts',
-	'service-secret-inheritance.spec.ts',
+	'service-actions-dv-manual.spec.ts',
 	'service-ordering.spec.ts',
+	'service-secret-inheritance.spec.ts',
+	'webhook.spec.ts',
 ];
 
 const BROWSERS = {

--- a/web/ui/react-app/src/components/approvals/service-action-release.tsx
+++ b/web/ui/react-app/src/components/approvals/service-action-release.tsx
@@ -1,6 +1,7 @@
 import { type FC, useCallback, useMemo } from 'react';
 import { Button } from '@/components/ui/button';
 import useModal from '@/hooks/use-modal';
+import { DEPLOYED_VERSION_LOOKUP_TYPE } from '@/utils/api/types/config/service/deployed-version';
 import type {
 	ModalType,
 	ServiceSummary,
@@ -49,8 +50,15 @@ const ServiceActionRelease: FC<ServiceActionReleaseProps> = ({
 
 		const haveUpdateAction = service.webhook || service.command;
 
+		const canApproveManually: boolean =
+			!haveUpdateAction &&
+			(updateAvailable || updateSkipped) &&
+			service.deployed_version_type ===
+				DEPLOYED_VERSION_LOOKUP_TYPE.MANUAL.value;
+
 		return {
 			actionType,
+			canApproveManually,
 			haveUpdateAction,
 		};
 	}, [service]);
@@ -81,6 +89,17 @@ const ServiceActionRelease: FC<ServiceActionReleaseProps> = ({
 					variant={updateAvailable && !updateSkipped ? 'default' : 'secondary'}
 				>
 					{updateAvailable ? 'Approve' : 'Resend'}
+				</Button>
+			)}
+			{info.canApproveManually && (
+				<Button
+					aria-label="Approve release"
+					key="approve-manual"
+					onClick={() => showModal('APPROVE_MANUAL', service)}
+					size="xs"
+					variant={updateSkipped ? 'secondary' : 'default'}
+				>
+					Approve
 				</Button>
 			)}
 		</div>

--- a/web/ui/react-app/src/components/approvals/service-info.tsx
+++ b/web/ui/react-app/src/components/approvals/service-info.tsx
@@ -28,12 +28,12 @@ const ServiceInfo: FC<ServiceInfoProps> = ({
 		<div className="flex size-full min-h-22 flex-col gap-y-2">
 			<ul className="wrap-anywhere mb-auto flex w-full flex-col gap-1">
 				<ServiceInfoDeployedVersion
-					hasDeployedVersion={!!service?.has_deployed_version}
+					hasDeployedVersion={!!service?.deployed_version_type}
 					status={service?.status}
 					updateAvailable={updateAvailable}
 				/>
 				<ServiceInfoLatestVersion
-					hasDeployedVersion={!!service?.has_deployed_version}
+					hasDeployedVersion={!!service?.deployed_version_type}
 					status={service?.status}
 					updateAvailable={updateAvailable}
 				/>

--- a/web/ui/react-app/src/components/approvals/table/service-action-release.tsx
+++ b/web/ui/react-app/src/components/approvals/table/service-action-release.tsx
@@ -4,6 +4,7 @@ import { type FC, useCallback } from 'react';
 import { useToolbar } from '@/components/approvals/toolbar/toolbar-context';
 import { Button } from '@/components/ui/button';
 import useModal from '@/hooks/use-modal';
+import { DEPLOYED_VERSION_LOOKUP_TYPE } from '@/utils/api/types/config/service/deployed-version';
 import type {
 	ModalType,
 	ServiceSummary,
@@ -48,6 +49,10 @@ export const ServiceActionRelease: FC<ServiceActionReleaseProps> = ({
 		(service.command ?? 0) > 0 || (service.webhook ?? 0) > 0;
 	const updateAvailable = service.status?.state === 'AVAILABLE';
 	const updateSkipped = service.status?.state === 'SKIPPED';
+	const canApproveManually =
+		!haveUpdateAction &&
+		service.status?.state !== 'UP_TO_DATE' &&
+		service.deployed_version_type === DEPLOYED_VERSION_LOOKUP_TYPE.MANUAL.value;
 
 	return (
 		<div className="flex flex-row items-center gap-x-2">
@@ -84,6 +89,17 @@ export const ServiceActionRelease: FC<ServiceActionReleaseProps> = ({
 					variant={updateAvailable && !updateSkipped ? 'default' : 'secondary'}
 				>
 					{updateAvailable ? 'Approve' : 'Resend'}
+				</Button>
+			)}
+			{canApproveManually && (
+				<Button
+					aria-label="Approve release"
+					key="approve-manual"
+					onClick={() => showModal('APPROVE_MANUAL')}
+					size="xs"
+					variant={updateSkipped ? 'secondary' : 'default'}
+				>
+					Approve
 				</Button>
 			)}
 		</div>

--- a/web/ui/react-app/src/components/modals/service-edit/deployed-version-manual.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/deployed-version-manual.tsx
@@ -15,12 +15,11 @@ import {
 import { useSchemaContext } from '@/contexts/service-edit-zod-type';
 import { useServiceSummary } from '@/hooks/use-service-summary';
 import useValuesRefetch from '@/hooks/values-refetch';
-import { QUERY_KEYS } from '@/lib/query-keys';
 import { cn } from '@/lib/utils';
 import { beautifyGoErrors } from '@/utils';
 import { mapRequest } from '@/utils/api/types/api-request-handler';
 import { DEPLOYED_VERSION_LOOKUP_TYPE } from '@/utils/api/types/config/service/deployed-version';
-import type { ServiceSummary } from '@/utils/api/types/config/summary';
+import { applyDeployedVersionUpdate } from '@/utils/api/types/requests/service-edit';
 
 /* The throttle time for saving the version. */
 const SAVE_THROTTLE_MS = 1000;
@@ -63,26 +62,10 @@ const DeployedVersionManual = () => {
 		setLastFetched(currentTime);
 		try {
 			const data = await saveVersion();
-			queryClient.setQueryData<ServiceSummary>(
-				QUERY_KEYS.SERVICE.SUMMARY_ITEM(serviceID),
-				(_oldData) => {
-					const oldData = _oldData ?? {
-						id: serviceID,
-						status: {},
-					};
-
-					return {
-						...oldData,
-						status: {
-							...oldData.status,
-							deployed_version: data.version,
-						},
-					};
-				},
-			);
-		} catch (error) {
+			applyDeployedVersionUpdate(queryClient, serviceID, data.version || '');
+		} catch (error: unknown) {
 			toast.error('Failed to save version:', {
-				description: mutationError?.message,
+				description: `Error: ${error instanceof Error ? error.message : String(error)}`,
 			});
 		} finally {
 			document.getElementById('version')?.focus();

--- a/web/ui/react-app/src/components/modals/service-edit/deployed-version-manual.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/deployed-version-manual.tsx
@@ -63,10 +63,8 @@ const DeployedVersionManual = () => {
 		try {
 			const data = await saveVersion();
 			applyDeployedVersionUpdate(queryClient, serviceID, data.version || '');
-		} catch (error: unknown) {
-			toast.error('Failed to save version:', {
-				description: `Error: ${error instanceof Error ? error.message : String(error)}`,
-			});
+		} catch (_) {
+			// Ignore.
 		} finally {
 			document.getElementById('version')?.focus();
 		}

--- a/web/ui/react-app/src/hooks/use-approve-deployed-version-manual.ts
+++ b/web/ui/react-app/src/hooks/use-approve-deployed-version-manual.ts
@@ -1,0 +1,50 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { beautifyGoErrors } from '@/utils';
+import { mapRequest } from '@/utils/api/types/api-request-handler';
+import { DEPLOYED_VERSION_LOOKUP_TYPE } from '@/utils/api/types/config/service/deployed-version';
+import { applyDeployedVersionUpdate } from '@/utils/api/types/requests/service-edit';
+
+export type ApproveManualDeployedVersionVariables = {
+	/* The ID of the service to approve the release for. */
+	serviceID: string;
+	/* The version to approve (the latest known version). */
+	targetVersion: string;
+};
+
+/**
+ * Approves the latest version for a service with a manual `deployed_version` and no
+ * WebHooks/Commands, setting the deployed version to match the latest version.
+ */
+export const useApproveManualDeployedVersion = () => {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: (variables: ApproveManualDeployedVersionVariables) =>
+			mapRequest('VERSION_REFRESH', {
+				data: {
+					type: DEPLOYED_VERSION_LOOKUP_TYPE.MANUAL.value,
+					version: variables.targetVersion,
+				},
+				dataSemanticVersioning: null,
+				dataTarget: 'deployed_version',
+				original: {
+					type: DEPLOYED_VERSION_LOOKUP_TYPE.MANUAL.value,
+				},
+				originalSemanticVersioning: null,
+				serviceID: variables.serviceID,
+			}),
+		onError: (error) => {
+			toast.error('Failed to approve release', {
+				description: beautifyGoErrors(error.message),
+			});
+		},
+		onSuccess: (data, variables) => {
+			applyDeployedVersionUpdate(
+				queryClient,
+				variables.serviceID,
+				data.version || '',
+			);
+		},
+	});
+};

--- a/web/ui/react-app/src/modals/action-release.tsx
+++ b/web/ui/react-app/src/modals/action-release.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/components/ui/dialog';
 import Tip from '@/components/ui/tip';
 import { addMessageHandler, removeMessageHandler } from '@/contexts/websocket';
+import { useApproveManualDeployedVersion } from '@/hooks/use-approve-deployed-version-manual';
 import useModal from '@/hooks/use-modal';
 import { QUERY_KEYS } from '@/lib/query-keys';
 import reducerActionModal from '@/reducers/action-release';
@@ -88,11 +89,13 @@ const isActionRunnable = (
  */
 const ActionReleaseModal = () => {
 	// modal.actionType:
-	//   RESEND - 0 WebHooks failed. 'Resend' Modal.
-	//   SEND   - Send WebHooks for this new version. 'New release' Modal.
-	//   SKIP   - Release not wanted. 'Skip' Modal.
-	//   RETRY  - 1+ WebHooks failed sending. 'Retry' Modal.
+	//   RESEND             - 0 WebHooks failed. 'Resend' Modal.
+	//   SEND               - Send WebHooks for this new version. 'New release' Modal.
+	//   SKIP | SKIP_NO_WH  - Release not wanted. 'Skip' Modal.
+	//   RETRY              - 1+ WebHooks failed sending. 'Retry' Modal.
+	//   APPROVE_MANUAL - Approve a release for a service with no WebHooks/Commands and a manual deployed_version. 'Approve' Modal.
 	const { modal, hideModal: hideModalDialog } = useModal();
+	const { mutate: approveManualVersion } = useApproveManualDeployedVersion();
 	const [modalData, setModalData] = useReducer(reducerActionModal, {
 		commands: {},
 		sentC: [],
@@ -164,6 +167,11 @@ const ActionReleaseModal = () => {
 			string,
 			{ title: string; ariaLabel: string; buttonText: string }
 		> = {
+			APPROVE_MANUAL: {
+				ariaLabel: 'Approve this release',
+				buttonText: 'Approve',
+				title: 'Approve this release?',
+			},
 			DEFAULT: {
 				ariaLabel: 'Skip this release',
 				buttonText: 'Skip release',
@@ -461,11 +469,18 @@ const ActionReleaseModal = () => {
 								return;
 							}
 							switch (modal.actionType) {
+								case 'APPROVE_MANUAL':
+									approveManualVersion({
+										serviceID: modal.service.id,
+										targetVersion: modal.service.status?.latest_version ?? '',
+									});
+									hideModal();
+									break;
 								case 'RESEND':
 									onClickAcknowledge('ARGUS_ALL');
 									break;
-								case 'SEND':
 								case 'RETRY':
+								case 'SEND':
 									onClickAcknowledge('ARGUS_FAILED');
 									break;
 								case 'SKIP':

--- a/web/ui/react-app/src/modals/service-edit.tsx
+++ b/web/ui/react-app/src/modals/service-edit.tsx
@@ -193,12 +193,14 @@ const ServiceEditModalWithData: FC<ServiceEditModalWithDataProps> = ({
 						() => ({
 							active: dataPayload.options.active,
 							command: dataPayload.command?.length,
-							has_deployed_version:
+							deployed_version_type:
 								dataPayload.deployed_version &&
 								(dataPayload.deployed_version.type ===
 								DEPLOYED_VERSION_LOOKUP_TYPE.URL.value
 									? !!dataPayload.deployed_version.url
-									: !!dataPayload.deployed_version.version),
+									: !!dataPayload.deployed_version.version)
+									? dataPayload.deployed_version.type
+									: undefined,
 							icon: dataPayload.dashboard?.icon,
 							icon_link_to: dataPayload.dashboard?.icon_link_to,
 							id: dataPayload.id,

--- a/web/ui/react-app/src/pages/approvals/layouts/table/columns.tsx
+++ b/web/ui/react-app/src/pages/approvals/layouts/table/columns.tsx
@@ -40,9 +40,9 @@ export const columns: ColumnDefWithMeta<ServiceSummary>[] = [
 	},
 	{
 		accessorFn: (row) =>
-			row.has_deployed_version ? row.status?.deployed_version : null,
+			row.deployed_version_type ? row.status?.deployed_version : null,
 		cell: ({ row }) =>
-			row.original.has_deployed_version
+			row.original.deployed_version_type
 				? row.original.status?.deployed_version
 				: null,
 		enableSorting: true,
@@ -58,10 +58,10 @@ export const columns: ColumnDefWithMeta<ServiceSummary>[] = [
 	},
 	{
 		accessorFn: (row) =>
-			row.has_deployed_version ? row.status?.deployed_version_timestamp : null,
+			row.deployed_version_type ? row.status?.deployed_version_timestamp : null,
 		cell: ({ row }) => (
 			<div>
-				{row.original.has_deployed_version &&
+				{row.original.deployed_version_type &&
 				row.original.status?.deployed_version_timestamp
 					? formatISO9075(
 							new Date(row.original.status.deployed_version_timestamp),

--- a/web/ui/react-app/src/utils/api/types/config/summary.ts
+++ b/web/ui/react-app/src/utils/api/types/config/summary.ts
@@ -1,3 +1,4 @@
+import type { DeployedVersionLookupType } from '@/utils/api/types/config/service/deployed-version';
 import type { LatestVersionLookupType } from '@/utils/api/types/config/service/latest-version';
 
 export type OrderAPIResponse = {
@@ -21,7 +22,8 @@ export type ServiceSummary = {
 	url?: string;
 	icon?: string;
 	icon_link_to?: string;
-	has_deployed_version?: boolean;
+	// '' if no DeployedVersionLookup, undefined if not yet loaded.
+	deployed_version_type?: DeployedVersionLookupType | '';
 	notify?: boolean;
 	webhook?: number;
 	command?: number;
@@ -41,6 +43,7 @@ export type ModalType =
 	| 'SEND'
 	| 'SKIP'
 	| 'SKIP_NO_WH'
+	| 'APPROVE_MANUAL'
 	| '';
 
 export type ActionModalData = {

--- a/web/ui/react-app/src/utils/api/types/requests/service-edit.ts
+++ b/web/ui/react-app/src/utils/api/types/requests/service-edit.ts
@@ -71,6 +71,11 @@ export const applyDeployedVersionUpdate = (
 				{
 					id: serviceID,
 					status: {
+						// Clear approved_version only when the current latest version is being deployed.
+						approved_version:
+							version === oldData?.status?.latest_version
+								? ''
+								: oldData?.status?.approved_version,
 						deployed_version: version,
 						deployed_version_timestamp: formatRFC3339(new Date()),
 					},

--- a/web/ui/react-app/src/utils/api/types/requests/service-edit.ts
+++ b/web/ui/react-app/src/utils/api/types/requests/service-edit.ts
@@ -1,3 +1,6 @@
+import type { QueryClient } from '@tanstack/react-query';
+import { formatRFC3339 } from 'date-fns';
+import { QUERY_KEYS } from '@/lib/query-keys';
 import type {
 	ServiceSummary,
 	ServiceUpdateState,
@@ -27,7 +30,7 @@ export const serviceSummaryReducer = (
 	status.deployed_version ??= status?.latest_version;
 	status.deployed_version_timestamp ??= status?.latest_version_timestamp;
 	// Treat all version updates as both latest/deployed if no deployed version for this service.
-	if (oldData?.has_deployed_version === false && service?.status) {
+	if (oldData?.deployed_version_type === '' && service?.status) {
 		service.status.deployed_version ??= service.status.latest_version;
 		service.status.deployed_version_timestamp ??=
 			service.status.latest_version_timestamp;
@@ -45,6 +48,36 @@ export const serviceSummaryReducer = (
 			state: getServiceUpdateState(status),
 		},
 	} as ServiceSummary;
+};
+
+/**
+ * Applies a new `deployed_version` to a service's cached summary, re-deriving
+ * `status.state` (and stamping `deployed_version_timestamp`) via `serviceSummaryReducer`
+ * so 'update available'/'approve'/'skip' UI stays in sync with the new version.
+ *
+ * @param queryClient - The React Query client.
+ * @param serviceID - The ID of the service to update.
+ * @param version - The new `deployed_version`.
+ */
+export const applyDeployedVersionUpdate = (
+	queryClient: QueryClient,
+	serviceID: string,
+	version: string,
+) => {
+	queryClient.setQueryData<ServiceSummary>(
+		QUERY_KEYS.SERVICE.SUMMARY_ITEM(serviceID),
+		(oldData) =>
+			serviceSummaryReducer(
+				{
+					id: serviceID,
+					status: {
+						deployed_version: version,
+						deployed_version_timestamp: formatRFC3339(new Date()),
+					},
+				},
+				oldData,
+			),
+	);
 };
 
 export const getServiceUpdateState = (

--- a/web/ui/react-app/tests/fixtures/service.ts
+++ b/web/ui/react-app/tests/fixtures/service.ts
@@ -1,5 +1,6 @@
 import { expect, type Locator, type Page, test } from '@playwright/test';
 import { bareEndpoint } from './test-endpoints';
+import { openSection } from './validation';
 
 export type KeyVal = { key: string; value: string };
 
@@ -481,6 +482,50 @@ export const createService = async (
 	// The server verifies the lookup via a real network call before
 	// responding, so the modal can take longer than the default 5s to close.
 	await expect(dialog).not.toBeVisible({ timeout: 30_000 });
+};
+
+/**
+ * Opens a service's edit modal and uses the inline 'Save version' action next
+ * to the `deployed_version.version` field to persist a new manual deployed
+ * version, then closes the modal without submitting the rest of the form.
+ *
+ * @param page - The dashboard page (edit mode must already be on).
+ * @param serviceID - The ID of the service to edit (must have a manual
+ *   `deployed_version`).
+ * @param version - The new deployed version to save.
+ */
+export const saveDeployedVersionManual = async (
+	page: Page,
+	serviceID: string,
+	version: string,
+) => {
+	const serviceCard = page.locator(`[data-service-id="${serviceID}"]`);
+	await serviceCard.getByRole('button', { name: /edit/i }).click();
+
+	const dialog = page.getByRole('dialog');
+	await expect(dialog).toBeVisible();
+	const section = await openSection(dialog, 'Deployed Version');
+	await section.locator('input[name="deployed_version.version"]').fill(version);
+
+	const saveButton = section.getByRole('button', { name: 'Save version' });
+	await expect(saveButton).toBeEnabled();
+	// Manual deployed_version updates are server-side rate-limited
+	// - retry the click until it lands outside that window.
+	await expect(async () => {
+		const [response] = await Promise.all([
+			page.waitForResponse(
+				(res) =>
+					res.url().includes('/api/v1/deployed_version/refresh') &&
+					res.request().method() === 'GET',
+			),
+			saveButton.click(),
+		]);
+		expect(response.ok()).toBeTruthy();
+	}).toPass();
+
+	// Close the modal without submitting the rest of the form.
+	await page.keyboard.press('Escape');
+	await expect(dialog).not.toBeVisible();
 };
 
 /**

--- a/web/ui/react-app/tests/service-actions-dv-manual.spec.ts
+++ b/web/ui/react-app/tests/service-actions-dv-manual.spec.ts
@@ -1,0 +1,352 @@
+import { expect, test } from '@playwright/test';
+import {
+	cleanupServices,
+	createService,
+	LOOKUP_LATEST_VERSION_JSON,
+	saveDeployedVersionManual,
+	screenshotsUnder,
+	withProject,
+} from './fixtures/service';
+import { openSection } from './fixtures/validation';
+
+// createService makes a real network call to verify the lookups before the
+// modal closes, so allow extra time.
+test.beforeEach(() => {
+	test.slow();
+});
+
+test.describe('deployed_version=manual approve/skip actions', () => {
+	let createdID: string | undefined;
+	test.afterEach(async ({ page }) => {
+		if (createdID) await cleanupServices(page, [createdID]);
+		createdID = undefined;
+	});
+
+	test('Approve sets the deployed version and hides the actions', async ({
+		page,
+	}, testInfo) => {
+		const shot = screenshotsUnder(
+			page,
+			testInfo.project.name,
+			'service-actions-dv-manual/dashboard/approve',
+		);
+		const baseID = 'DV=MANUAL, APPROVE';
+		const id = withProject(baseID, testInfo.project.name);
+		createdID = id;
+
+		await page.goto('/');
+		await page.getByRole('button', { name: /toggle edit mode/i }).click();
+
+		// GIVEN: a service with a manual deployed_version, an update available,
+		// and no WebHooks/Commands.
+		await createService(page, id, {
+			deployedVersion: { type: 'manual', version: '0.0.1' },
+			latestVersion: LOOKUP_LATEST_VERSION_JSON,
+		});
+		await expect(page.getByRole('heading', { name: id })).toBeVisible();
+
+		const serviceCard = page.locator(`[data-service-id="${id}"]`);
+
+		// THEN: both the "Skip" and "Approve" actions are shown, and both the
+		// deployed and latest versions are visible.
+		await expect(
+			serviceCard.getByRole('button', { name: 'Reject release' }),
+		).toBeVisible();
+		await expect(
+			serviceCard.getByRole('button', { name: 'Approve release' }),
+		).toBeVisible();
+		await expect(serviceCard.getByText('0.0.1', { exact: true })).toBeVisible();
+		await expect(serviceCard.getByText('1.2.3', { exact: true })).toBeVisible();
+		await shot('01-update-available', serviceCard);
+
+		// WHEN: the user clicks "Approve" and confirms in the resulting modal.
+		const approveButton = serviceCard.getByRole('button', {
+			name: 'Approve release',
+		});
+		await expect(approveButton).toBeEnabled();
+
+		const dialog = page.getByRole('dialog');
+		const confirmButton = dialog.locator('#modal-action');
+		// Manual deployed_version updates are server-side rate-limited
+		// - the modal closes immediately on confirm regardless of the
+		// request's outcome, so retry the whole approve+confirm flow
+		// if it lands inside that window.
+		await expect(async () => {
+			await approveButton.click();
+			await expect(dialog).toBeVisible();
+			await expect(confirmButton).toHaveText(/^Approve$/i);
+			await shot('02-approve-modal', serviceCard);
+			const [response] = await Promise.all([
+				page.waitForResponse(
+					(res) =>
+						res.url().includes('/api/v1/deployed_version/refresh') &&
+						res.request().method() === 'GET',
+				),
+				confirmButton.click(),
+			]);
+			expect(response.ok()).toBeTruthy();
+		}).toPass();
+		await expect(dialog).not.toBeVisible();
+
+		// THEN: the deployed version updates to the latest version, and the
+		// "Skip"/"Approve" actions disappear (nothing left to action).
+		await expect(serviceCard.getByText('1.2.3', { exact: true })).toBeVisible();
+		await expect(
+			serviceCard.getByRole('button', { name: 'Reject release' }),
+		).toBeHidden();
+		await expect(
+			serviceCard.getByRole('button', { name: 'Approve release' }),
+		).toBeHidden();
+		// AND: the old deployed version is no longer shown - only the "@" line
+		// for the now-matching deployed/latest version remains.
+		await expect(serviceCard.getByText('0.0.1', { exact: true })).toHaveCount(
+			0,
+		);
+		await shot('03-approved', serviceCard);
+	});
+
+	test('Skip hides Skip but keeps Approve (as secondary) and both versions displayed', async ({
+		page,
+	}, testInfo) => {
+		const shot = screenshotsUnder(
+			page,
+			testInfo.project.name,
+			'service-actions-dv-manual/dashboard/skip',
+		);
+		const baseID = 'dv=MANUAL, SKIP';
+		const id = withProject(baseID, testInfo.project.name);
+		createdID = id;
+
+		await page.goto('/');
+		await page.getByRole('button', { name: /toggle edit mode/i }).click();
+
+		// GIVEN: a service with a manual deployed_version, an update available,
+		// and no WebHooks/Commands.
+		await createService(page, id, {
+			deployedVersion: { type: 'manual', version: '0.0.1' },
+			latestVersion: LOOKUP_LATEST_VERSION_JSON,
+		});
+		await expect(page.getByRole('heading', { name: id })).toBeVisible();
+
+		const serviceCard = page.locator(`[data-service-id="${id}"]`);
+		const approveButton = serviceCard.getByRole('button', {
+			name: 'Approve release',
+		});
+		await expect(
+			serviceCard.getByRole('button', { name: 'Reject release' }),
+		).toBeVisible();
+		// AND: the "Approve" action is shown in its primary (not-yet-skipped) colour.
+		await expect(approveButton).toHaveClass(/bg-primary/);
+		await shot('01-update-available', serviceCard);
+
+		// WHEN: the user clicks "Skip" and confirms in the resulting modal.
+		await serviceCard.getByRole('button', { name: 'Reject release' }).click();
+		const dialog = page.getByRole('dialog');
+		await expect(dialog).toBeVisible();
+		await shot('02-skip-modal', serviceCard);
+
+		const confirmButton = dialog.locator('#modal-action');
+		await expect(confirmButton).toHaveText(/^Skip release$/i);
+		await confirmButton.click();
+		await expect(dialog).not.toBeVisible();
+
+		// THEN: the "Skip" action disappears but "Approve" remains - now in
+		// its secondary colour, letting the user override the skip - and the
+		// deployed version AND the (skipped) latest version both remain visible.
+		await expect(
+			serviceCard.getByRole('button', { name: 'Reject release' }),
+		).toBeHidden();
+		await expect(approveButton).toBeVisible();
+		await expect(approveButton).toHaveClass(/bg-secondary/);
+		await expect(serviceCard.getByText('0.0.1', { exact: true })).toBeVisible();
+		await expect(serviceCard.getByText('1.2.3', { exact: true })).toBeVisible();
+		await shot('03-skipped', serviceCard);
+	});
+
+	test('Saving a new deployed version from the edit modal shows the actions', async ({
+		page,
+	}, testInfo) => {
+		const shot = screenshotsUnder(
+			page,
+			testInfo.project.name,
+			'service-actions-dv-manual/edit/save-new-version',
+		);
+		const baseID = 'DV=MANUAL, EDIT-SAVE NEW';
+		const id = withProject(baseID, testInfo.project.name);
+		createdID = id;
+
+		await page.goto('/');
+		await page.getByRole('button', { name: /toggle edit mode/i }).click();
+
+		// GIVEN: a service with a manual deployed_version already matching the
+		// latest version (up to date - no actions shown).
+		await createService(page, id, {
+			deployedVersion: { type: 'manual', version: '1.2.3' },
+			latestVersion: LOOKUP_LATEST_VERSION_JSON,
+		});
+		await expect(page.getByRole('heading', { name: id })).toBeVisible();
+
+		const serviceCard = page.locator(`[data-service-id="${id}"]`);
+		await expect(
+			serviceCard.getByRole('button', { name: 'Reject release' }),
+		).toBeHidden();
+		await expect(
+			serviceCard.getByRole('button', { name: 'Approve release' }),
+		).toBeHidden();
+		await shot('01-up-to-date', serviceCard);
+
+		// WHEN: the deployed version is saved to a new version (that isn't the
+		// latest version) via the edit modal's inline 'Save version' action.
+		await saveDeployedVersionManual(page, id, '9.9.9');
+
+		// THEN: the "Skip"/"Approve" actions immediately appear, reflecting the
+		// no-longer-up-to-date state.
+		await expect(
+			serviceCard.getByRole('button', { name: 'Reject release' }),
+		).toBeVisible();
+		await expect(
+			serviceCard.getByRole('button', { name: 'Approve release' }),
+		).toBeVisible();
+		await expect(serviceCard.getByText('9.9.9', { exact: true })).toBeVisible();
+		await expect(serviceCard.getByText('1.2.3', { exact: true })).toBeVisible();
+		await shot('02-actions-shown', serviceCard);
+	});
+
+	test('Saving another deployed version that is not the latest version from the edit modal keeps the actions shown', async ({
+		page,
+	}, testInfo) => {
+		const shot = screenshotsUnder(
+			page,
+			testInfo.project.name,
+			'service-actions-dv-manual/edit/save-other-version',
+		);
+		const baseID = 'DV=MANUAL, EDIT-SAVE OTHER';
+		const id = withProject(baseID, testInfo.project.name);
+		createdID = id;
+
+		await page.goto('/');
+		await page.getByRole('button', { name: /toggle edit mode/i }).click();
+
+		// GIVEN: a service with a manual deployed_version, an update already
+		// available (deployed != latest), and no WebHooks/Commands.
+		await createService(page, id, {
+			deployedVersion: { type: 'manual', version: '0.0.1' },
+			latestVersion: LOOKUP_LATEST_VERSION_JSON,
+		});
+		await expect(page.getByRole('heading', { name: id })).toBeVisible();
+
+		const serviceCard = page.locator(`[data-service-id="${id}"]`);
+		await expect(
+			serviceCard.getByRole('button', { name: 'Reject release' }),
+		).toBeVisible();
+		await expect(
+			serviceCard.getByRole('button', { name: 'Approve release' }),
+		).toBeVisible();
+		await shot('01-update-available', serviceCard);
+
+		// WHEN: the deployed version is saved to an older version (a downgrade,
+		// still not the latest version) via the edit modal's inline
+		// 'Save version' action, without reloading the page.
+		await saveDeployedVersionManual(page, id, '0.0.0');
+
+		// THEN: the "Skip"/"Approve" actions remain visible, and the displayed
+		// deployed version updates to the new (older) value.
+		await expect(
+			serviceCard.getByRole('button', { name: 'Reject release' }),
+		).toBeVisible();
+		await expect(
+			serviceCard.getByRole('button', { name: 'Approve release' }),
+		).toBeVisible();
+		await expect(serviceCard.getByText('0.0.0', { exact: true })).toBeVisible();
+		await expect(serviceCard.getByText('1.2.3', { exact: true })).toBeVisible();
+		await expect(serviceCard.getByText('0.0.1', { exact: true })).toHaveCount(
+			0,
+		);
+		await shot('02-actions-still-shown', serviceCard);
+	});
+
+	test('Saving to the latest version then to another version in the same edit session updates the actions each time', async ({
+		page,
+	}, testInfo) => {
+		const shot = screenshotsUnder(
+			page,
+			testInfo.project.name,
+			'service-actions-dv-manual/edit/save-latest-then-other-version',
+		);
+		const baseID = 'DV=MANUAL, EDIT-SAVE LATEST-THEN-OTHER';
+		const id = withProject(baseID, testInfo.project.name);
+		createdID = id;
+
+		await page.goto('/');
+		await page.getByRole('button', { name: /toggle edit mode/i }).click();
+
+		// GIVEN: a service with a manual deployed_version, an update already
+		// available (deployed != latest), and no WebHooks/Commands.
+		await createService(page, id, {
+			deployedVersion: { type: 'manual', version: '0.0.1' },
+			latestVersion: LOOKUP_LATEST_VERSION_JSON,
+		});
+		await expect(page.getByRole('heading', { name: id })).toBeVisible();
+
+		const serviceCard = page.locator(`[data-service-id="${id}"]`);
+		await expect(
+			serviceCard.getByRole('button', { name: 'Reject release' }),
+		).toBeVisible();
+		await expect(
+			serviceCard.getByRole('button', { name: 'Approve release' }),
+		).toBeVisible();
+		await shot('01-update-available', serviceCard);
+
+		// WHEN: within a single edit-modal session, the deployed version is
+		// first saved to the current latest version.
+		await serviceCard.getByRole('button', { name: /edit/i }).click();
+		const dialog = page.getByRole('dialog');
+		await expect(dialog).toBeVisible();
+		const section = await openSection(dialog, 'Deployed Version');
+		const versionInput = section.locator(
+			'input[name="deployed_version.version"]',
+		);
+		const saveButton = section.getByRole('button', { name: 'Save version' });
+		const saveVersion = (version: string) =>
+			expect(async () => {
+				await versionInput.fill(version);
+				const [response] = await Promise.all([
+					page.waitForResponse(
+						(res) =>
+							res.url().includes('/api/v1/deployed_version/refresh') &&
+							res.request().method() === 'GET',
+					),
+					saveButton.click(),
+				]);
+				expect(response.ok()).toBeTruthy();
+			}).toPass();
+		await saveVersion('1.2.3');
+
+		// THEN: the actions are hidden (up to date).
+		await expect(
+			serviceCard.locator('button[aria-label="Reject release"]'),
+		).toBeHidden();
+		await expect(
+			serviceCard.locator('button[aria-label="Approve release"]'),
+		).toBeHidden();
+
+		// WHEN: without closing the modal, a different version is saved.
+		await saveVersion('4.5.6');
+		await page.keyboard.press('Escape');
+		await expect(dialog).not.toBeVisible();
+
+		// THEN: the actions reappear.
+		await expect(
+			serviceCard.getByRole('button', { name: 'Reject release' }),
+		).toBeVisible();
+		await expect(
+			serviceCard.getByRole('button', { name: 'Approve release' }),
+		).toBeVisible();
+		await expect(serviceCard.getByText('4.5.6', { exact: true })).toBeVisible();
+		await expect(serviceCard.getByText('1.2.3', { exact: true })).toBeVisible();
+		await expect(serviceCard.getByText('0.0.1', { exact: true })).toHaveCount(
+			0,
+		);
+		await shot('02-actions-shown-again', serviceCard);
+	});
+});


### PR DESCRIPTION
Add an "Approve" button to services using a manual deployed_version with no webhook/command configured, setting the deployed version to the latest known version via the existing 'refresh' endpoint.

Rename `ServiceSummary.HasDeployedVersionLookup` (bool) to `DeployedVersionType` (string) so the frontend can determine the deployed_version type ("manual"/"url") without an extra lookup.


<table>
  <tr>
    <td width="50%" align="center">
      <strong>dv=manual, no commands/webhooks</strong><br/>
      <img
        src="https://github.com/user-attachments/assets/905c31d7-4002-4109-a4eb-f3ea29981390"
        style="width:100%; height:auto;"
      />
    </td>
    <td width="50%" align="center">
      <strong>dv=manual, with commands/webhooks</strong><br/>
      <img
        src="https://github.com/user-attachments/assets/6d1e9600-ed8d-45ce-80aa-c3fd260d45c5"
        style="width:100%; height:auto;"
      />
    </td>
  </tr>
</table>

<table>
  <tr>
    <td width="50%" align="center">
      <strong>Skip</strong><br/>
      <img
        src="https://github.com/user-attachments/assets/2d2a95a4-7361-409a-b566-37c413c0c0e2"
        style="width:100%; height:auto;"
      />
    </td>
    <td width="50%" align="center">
      <strong>Skipped</strong><br/>
      <img
        src="https://github.com/user-attachments/assets/79712fb3-d6bb-47d4-85fd-410a6a58a634"
        style="width:100%; height:auto;"
      />
    </td>
  </tr>
</table>

---

<table>
  <tr>
    <td width="50%" align="center">
      <strong>Approve</strong><br/>
      <img
        src="https://github.com/user-attachments/assets/f4ffcd4e-09c6-43bd-a085-5f635ee12c50"
        style="width:100%; height:auto;"
      />
    </td>
    <td width="50%" align="center">
      <strong>Approved</strong><br/>
      <img
        src="https://github.com/user-attachments/assets/4e0c2a4b-c8dc-4556-918c-10849a34d88a""
        style="width:100%; height:auto;"
      />
    </td>
  </tr>
</table>
