### PR TITLE
refactor(latest_version): split Defaults/HardDefaults per lookup type

### DIFF
--- a/cmd/argus/main_test.go
+++ b/cmd/argus/main_test.go
@@ -107,8 +107,8 @@ func TestRun(t *testing.T) {
 			resetFlags()
 			configFile = &file
 			env := map[string]string{
-				"ARGUS_SERVICE_LATEST_VERSION_ACCESS_TOKEN": test.GitHubToken(t),
-				"ARGUS_DATA_DATABASE_FILE":                  filepath.Join(tempDir, "argus.db"),
+				"ARGUS_SERVICE_LATEST_VERSION_GITHUB_ACCESS_TOKEN": test.GitHubToken(t),
+				"ARGUS_DATA_DATABASE_FILE":                         filepath.Join(tempDir, "argus.db"),
 			}
 			test.SetEnv(t, env)
 			if tc.preStartFunc != nil {

--- a/config/defaults_test.go
+++ b/config/defaults_test.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -28,9 +29,12 @@ import (
 	"github.com/release-argus/Argus/service"
 	"github.com/release-argus/Argus/service/dashboard"
 	dvbase "github.com/release-argus/Argus/service/deployed_version/types/base"
+	latestver "github.com/release-argus/Argus/service/latest_version"
 	"github.com/release-argus/Argus/service/latest_version/filter"
 	"github.com/release-argus/Argus/service/latest_version/filter/docker"
 	lvbase "github.com/release-argus/Argus/service/latest_version/types/base"
+	"github.com/release-argus/Argus/service/latest_version/types/github"
+	"github.com/release-argus/Argus/service/latest_version/types/web"
 	opt "github.com/release-argus/Argus/service/option"
 	"github.com/release-argus/Argus/util"
 	"github.com/release-argus/Argus/webhook"
@@ -436,55 +440,61 @@ func TestDefaults_String(t *testing.T) {
 							`)),
 						)
 					}),
-					LatestVersion: lvbase.Defaults{
-						AccessToken:       "foo",
-						AllowInvalidCerts: test.Ptr(true),
-						UsePreRelease:     test.Ptr(false),
-						Options: test.Must(t, func() (*opt.Defaults, error) {
-							return opt.DecodeDefaults("yaml", []byte("interval: 1m"))
-						}),
-						Require: filter.RequireDefaults{
-							Docker: *test.Must(t, func() (*docker.Defaults, error) {
-								return docker.DecodeDefaults(
-									"yaml", []byte(test.TrimYAML(`
-										type: ghcr
-										tag: tagFallback
-										registry:
-											ghcr:
-												auth:
-													username: usernameGHCR
-													token: tokenGHCR
-											hub:
-												auth:
-													username: usernameHub
-													token: tokenHub
-											quay:
-												auth:
-													username: usernameQuay
-													token: tokenQuay
-									`)),
-									test.Must(t, func() (*docker.Defaults, error) {
-										return docker.DecodeDefaults(
-											"yaml", []byte(test.TrimYAML(`
-												type: ghcr
+					LatestVersion: latestver.Defaults{
+						GitHub: github.Defaults{
+							AccessToken:   "foo",
+							UsePreRelease: test.Ptr(false),
+						},
+						URL: web.Defaults{
+							AllowInvalidCerts: test.Ptr(true),
+						},
+						Common: lvbase.Defaults{
+							Options: test.Must(t, func() (*opt.Defaults, error) {
+								return opt.DecodeDefaults("yaml", []byte("interval: 1m"))
+							}),
+							Require: filter.RequireDefaults{
+								Docker: *test.Must(t, func() (*docker.Defaults, error) {
+									return docker.DecodeDefaults(
+										"yaml", []byte(test.TrimYAML(`
+											type: ghcr
+											tag: tagFallback
+											registry:
 												ghcr:
 													auth:
-														username: usernameGHCRother
-														token: tokenGHCRother
+														username: usernameGHCR
+														token: tokenGHCR
 												hub:
 													auth:
-														username: usernameHubOther
-														token: tokenHubOther
+														username: usernameHub
+														token: tokenHub
 												quay:
 													auth:
-														username: usernameQuayOther
-														token: tokenQuayOther
-											`)),
-											nil,
-										)
-									}),
-								)
-							}),
+														username: usernameQuay
+														token: tokenQuay
+										`)),
+										test.Must(t, func() (*docker.Defaults, error) {
+											return docker.DecodeDefaults(
+												"yaml", []byte(test.TrimYAML(`
+													type: ghcr
+													ghcr:
+														auth:
+															username: usernameGHCRother
+															token: tokenGHCRother
+													hub:
+														auth:
+															username: usernameHubOther
+															token: tokenHubOther
+													quay:
+														auth:
+															username: usernameQuayOther
+															token: tokenQuayOther
+												`)),
+												nil,
+											)
+										}),
+									)
+								}),
+							},
 						},
 					},
 					DeployedVersionLookup: dvbase.Defaults{
@@ -532,24 +542,27 @@ func TestDefaults_String(t *testing.T) {
 						interval: 1m
 						semantic_versioning: false
 					latest_version:
-						access_token: foo
-						allow_invalid_certs: true
-						use_prerelease: false
-						require:
-							docker:
-								type: ghcr
-								tag: tagFallback
-								registry:
-									ghcr:
-										auth:
-											token: tokenGHCR
-									hub:
-										auth:
-											username: usernameHub
-											token: tokenHub
-									quay:
-										auth:
-											token: tokenQuay
+						common:
+							require:
+								docker:
+									type: ghcr
+									tag: tagFallback
+									registry:
+										ghcr:
+											auth:
+												token: tokenGHCR
+										hub:
+											auth:
+												username: usernameHub
+												token: tokenHub
+										quay:
+											auth:
+												token: tokenQuay
+						github:
+							access_token: foo
+							use_prerelease: false
+						url:
+							allow_invalid_certs: true
 					deployed_version:
 						allow_invalid_certs: false
 					dashboard:
@@ -676,10 +689,11 @@ func TestDefaults_MapEnvToStruct(t *testing.T) {
 	unmodifiedDefaults.Default()
 	// GIVEN: Defaults and a bunch of env vars.
 	tests := []struct {
-		name     string
-		env      map[string]string
-		want     *Defaults
-		errRegex string
+		name       string
+		env        map[string]string
+		envCleanup []string
+		want       *Defaults
+		errRegex   string
 	}{
 		{
 			name: "empty vars ignored",
@@ -733,16 +747,82 @@ func TestDefaults_MapEnvToStruct(t *testing.T) {
 		{
 			name: "service.latest_version/valid",
 			env: map[string]string{
-				"ARGUS_SERVICE_LATEST_VERSION_ACCESS_TOKEN":        "ghp_something",
-				"ARGUS_SERVICE_LATEST_VERSION_ALLOW_INVALID_CERTS": "true",
-				"ARGUS_SERVICE_LATEST_VERSION_USE_PRERELEASE":      "true",
+				"ARGUS_SERVICE_LATEST_VERSION_GITHUB_ACCESS_TOKEN":     "ghp_something",
+				"ARGUS_SERVICE_LATEST_VERSION_URL_ALLOW_INVALID_CERTS": "true",
+				"ARGUS_SERVICE_LATEST_VERSION_GITHUB_USE_PRERELEASE":   "true",
 			},
 			want: &Defaults{
 				Service: service.Defaults{
-					LatestVersion: lvbase.Defaults{
-						AccessToken:       "ghp_something",
-						AllowInvalidCerts: test.Ptr(true),
-						UsePreRelease:     test.Ptr(true),
+					LatestVersion: latestver.Defaults{
+						GitHub: github.Defaults{
+							AccessToken:   "ghp_something",
+							UsePreRelease: test.Ptr(true),
+						},
+						URL: web.Defaults{
+							AllowInvalidCerts: test.Ptr(true),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "service.latest_version/deprecated env vars, old only",
+			env: map[string]string{
+				"ARGUS_SERVICE_LATEST_VERSION_ACCESS_TOKEN":        "ghp_deprecated",
+				"ARGUS_SERVICE_LATEST_VERSION_ALLOW_INVALID_CERTS": "true",
+				"ARGUS_SERVICE_LATEST_VERSION_USE_PRERELEASE":      "true",
+			},
+			envCleanup: []string{
+				"ARGUS_SERVICE_LATEST_VERSION_GITHUB_ACCESS_TOKEN",
+				"ARGUS_SERVICE_LATEST_VERSION_GITHUB_USE_PRERELEASE",
+				"ARGUS_SERVICE_LATEST_VERSION_URL_ALLOW_INVALID_CERTS",
+			},
+			want: &Defaults{
+				Service: service.Defaults{
+					LatestVersion: latestver.Defaults{
+						GitHub: github.Defaults{
+							AccessToken:   "ghp_deprecated",
+							UsePreRelease: test.Ptr(true),
+						},
+						URL: web.Defaults{
+							AllowInvalidCerts: test.Ptr(true),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "service.latest_version/deprecated env vars, old and new set, new wins",
+			env: map[string]string{
+				"ARGUS_SERVICE_LATEST_VERSION_ACCESS_TOKEN":            "ghp_deprecated",
+				"ARGUS_SERVICE_LATEST_VERSION_GITHUB_ACCESS_TOKEN":     "ghp_canonical",
+				"ARGUS_SERVICE_LATEST_VERSION_ALLOW_INVALID_CERTS":     "true",
+				"ARGUS_SERVICE_LATEST_VERSION_URL_ALLOW_INVALID_CERTS": "false",
+			},
+			want: &Defaults{
+				Service: service.Defaults{
+					LatestVersion: latestver.Defaults{
+						GitHub: github.Defaults{
+							AccessToken: "ghp_canonical",
+						},
+						URL: web.Defaults{
+							AllowInvalidCerts: test.Ptr(false),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "service.latest_version/canonical env vars only, no deprecation",
+			env: map[string]string{
+				"ARGUS_SERVICE_LATEST_VERSION_GITHUB_ACCESS_TOKEN": "ghp_canonical",
+			},
+			want: &Defaults{
+				Service: service.Defaults{
+					LatestVersion: latestver.Defaults{
+						GitHub: github.Defaults{
+							AccessToken: "ghp_canonical",
+						},
 					},
 				},
 			},
@@ -750,46 +830,48 @@ func TestDefaults_MapEnvToStruct(t *testing.T) {
 		{
 			name: "service.latest_version.require/valid",
 			env: map[string]string{
-				"ARGUS_SERVICE_LATEST_VERSION_REQUIRE_DOCKER_TYPE":                        "ghcr",
-				"ARGUS_SERVICE_LATEST_VERSION_REQUIRE_DOCKER_IMAGE":                       "imageFallback",
-				"ARGUS_SERVICE_LATEST_VERSION_REQUIRE_DOCKER_TAG":                         "tagFallback",
-				"ARGUS_SERVICE_LATEST_VERSION_REQUIRE_DOCKER_REGISTRY_GHCR_IMAGE":         "imageForGHCR",
-				"ARGUS_SERVICE_LATEST_VERSION_REQUIRE_DOCKER_REGISTRY_GHCR_TAG":           "tagForGHCR",
-				"ARGUS_SERVICE_LATEST_VERSION_REQUIRE_DOCKER_REGISTRY_GHCR_AUTH_TOKEN":    "tokenForGHCR",
-				"ARGUS_SERVICE_LATEST_VERSION_REQUIRE_DOCKER_REGISTRY_GHCR_AUTH_USERNAME": "usernameForGHCR",
-				"ARGUS_SERVICE_LATEST_VERSION_REQUIRE_DOCKER_REGISTRY_HUB_IMAGE":          "imageForHub",
-				"ARGUS_SERVICE_LATEST_VERSION_REQUIRE_DOCKER_REGISTRY_HUB_TAG":            "tagForHub",
-				"ARGUS_SERVICE_LATEST_VERSION_REQUIRE_DOCKER_REGISTRY_HUB_AUTH_TOKEN":     "tokenForHub",
-				"ARGUS_SERVICE_LATEST_VERSION_REQUIRE_DOCKER_REGISTRY_HUB_AUTH_USERNAME":  "usernameForHub",
-				"ARGUS_SERVICE_LATEST_VERSION_REQUIRE_DOCKER_REGISTRY_QUAY_IMAGE":         "imageForQuay",
-				"ARGUS_SERVICE_LATEST_VERSION_REQUIRE_DOCKER_REGISTRY_QUAY_TAG":           "tagForQuay",
-				"ARGUS_SERVICE_LATEST_VERSION_REQUIRE_DOCKER_REGISTRY_QUAY_AUTH_TOKEN":    "tokenForQuay",
-				"ARGUS_SERVICE_LATEST_VERSION_REQUIRE_DOCKER_REGISTRY_QUAY_AUTH_USERNAME": "usernameForQuay",
+				"ARGUS_SERVICE_LATEST_VERSION_COMMON_REQUIRE_DOCKER_TYPE":                        "ghcr",
+				"ARGUS_SERVICE_LATEST_VERSION_COMMON_REQUIRE_DOCKER_IMAGE":                       "imageFallback",
+				"ARGUS_SERVICE_LATEST_VERSION_COMMON_REQUIRE_DOCKER_TAG":                         "tagFallback",
+				"ARGUS_SERVICE_LATEST_VERSION_COMMON_REQUIRE_DOCKER_REGISTRY_GHCR_IMAGE":         "imageForGHCR",
+				"ARGUS_SERVICE_LATEST_VERSION_COMMON_REQUIRE_DOCKER_REGISTRY_GHCR_TAG":           "tagForGHCR",
+				"ARGUS_SERVICE_LATEST_VERSION_COMMON_REQUIRE_DOCKER_REGISTRY_GHCR_AUTH_TOKEN":    "tokenForGHCR",
+				"ARGUS_SERVICE_LATEST_VERSION_COMMON_REQUIRE_DOCKER_REGISTRY_GHCR_AUTH_USERNAME": "usernameForGHCR",
+				"ARGUS_SERVICE_LATEST_VERSION_COMMON_REQUIRE_DOCKER_REGISTRY_HUB_IMAGE":          "imageForHub",
+				"ARGUS_SERVICE_LATEST_VERSION_COMMON_REQUIRE_DOCKER_REGISTRY_HUB_TAG":            "tagForHub",
+				"ARGUS_SERVICE_LATEST_VERSION_COMMON_REQUIRE_DOCKER_REGISTRY_HUB_AUTH_TOKEN":     "tokenForHub",
+				"ARGUS_SERVICE_LATEST_VERSION_COMMON_REQUIRE_DOCKER_REGISTRY_HUB_AUTH_USERNAME":  "usernameForHub",
+				"ARGUS_SERVICE_LATEST_VERSION_COMMON_REQUIRE_DOCKER_REGISTRY_QUAY_IMAGE":         "imageForQuay",
+				"ARGUS_SERVICE_LATEST_VERSION_COMMON_REQUIRE_DOCKER_REGISTRY_QUAY_TAG":           "tagForQuay",
+				"ARGUS_SERVICE_LATEST_VERSION_COMMON_REQUIRE_DOCKER_REGISTRY_QUAY_AUTH_TOKEN":    "tokenForQuay",
+				"ARGUS_SERVICE_LATEST_VERSION_COMMON_REQUIRE_DOCKER_REGISTRY_QUAY_AUTH_USERNAME": "usernameForQuay",
 			},
 			want: &Defaults{
 				Service: service.Defaults{
-					LatestVersion: lvbase.Defaults{
-						Require: filter.RequireDefaults{
-							Docker: *test.Must(t, func() (*docker.Defaults, error) {
-								return docker.DecodeDefaults(
-									"yaml", []byte(test.TrimYAML(`
-										type: ghcr
-										tag: tagFallback
-										registry:
-											ghcr:
-												auth:
-													token: tokenForGHCR
-											hub:
-												auth:
-													username: usernameForHub
-													token: tokenForHub
-											quay:
-												auth:
-													token: tokenForQuay
-									`)),
-									nil,
-								)
-							}),
+					LatestVersion: latestver.Defaults{
+						Common: lvbase.Defaults{
+							Require: filter.RequireDefaults{
+								Docker: *test.Must(t, func() (*docker.Defaults, error) {
+									return docker.DecodeDefaults(
+										"yaml", []byte(test.TrimYAML(`
+											type: ghcr
+											tag: tagFallback
+											registry:
+												ghcr:
+													auth:
+														token: tokenForGHCR
+												hub:
+													auth:
+														username: usernameForHub
+														token: tokenForHub
+												quay:
+													auth:
+														token: tokenForQuay
+										`)),
+										nil,
+									)
+								}),
+							},
 						},
 					},
 				},
@@ -798,31 +880,31 @@ func TestDefaults_MapEnvToStruct(t *testing.T) {
 		{
 			name: "service.latest_version.require/invalid type",
 			env: map[string]string{
-				"ARGUS_SERVICE_LATEST_VERSION_REQUIRE_DOCKER_TYPE":                       "foo",
-				"ARGUS_SERVICE_LATEST_VERSION_REQUIRE_DOCKER_REGISTRY_GHCR_AUTH_TOKEN":   "tokenForGHCR",
-				"ARGUS_SERVICE_LATEST_VERSION_REQUIRE_DOCKER_REGISTRY_HUB_AUTH_TOKEN":    "tokenForDockerHub",
-				"ARGUS_SERVICE_LATEST_VERSION_REQUIRE_DOCKER_REGISTRY_HUB_AUTH_USERNAME": "usernameForDockerHub",
-				"ARGUS_SERVICE_LATEST_VERSION_REQUIRE_DOCKER_REGISTRY_QUAY_AUTH_TOKEN":   "tokenForQuay",
+				"ARGUS_SERVICE_LATEST_VERSION_COMMON_REQUIRE_DOCKER_TYPE":                       "foo",
+				"ARGUS_SERVICE_LATEST_VERSION_COMMON_REQUIRE_DOCKER_REGISTRY_GHCR_AUTH_TOKEN":   "tokenForGHCR",
+				"ARGUS_SERVICE_LATEST_VERSION_COMMON_REQUIRE_DOCKER_REGISTRY_HUB_AUTH_TOKEN":    "tokenForDockerHub",
+				"ARGUS_SERVICE_LATEST_VERSION_COMMON_REQUIRE_DOCKER_REGISTRY_HUB_AUTH_USERNAME": "usernameForDockerHub",
+				"ARGUS_SERVICE_LATEST_VERSION_COMMON_REQUIRE_DOCKER_REGISTRY_QUAY_AUTH_TOKEN":   "tokenForQuay",
 			},
-			errRegex: test.TrimYAML(`ARGUS_SERVICE_LATEST_VERSION_REQUIRE_DOCKER_TYPE: "foo" <invalid> .+`),
+			errRegex: test.TrimYAML(`ARGUS_SERVICE_LATEST_VERSION_COMMON_REQUIRE_DOCKER_TYPE: "foo" <invalid> .+`),
 		},
 		{
 			name: "service.latest_version/invalid bool/allow_invalid_certs",
 			env: map[string]string{
-				"ARGUS_SERVICE_LATEST_VERSION_ACCESS_TOKEN":        "ghp_something",
-				"ARGUS_SERVICE_LATEST_VERSION_ALLOW_INVALID_CERTS": "bar",
-				"ARGUS_SERVICE_LATEST_VERSION_USE_PRERELEASE":      "true",
+				"ARGUS_SERVICE_LATEST_VERSION_GITHUB_ACCESS_TOKEN":     "ghp_something",
+				"ARGUS_SERVICE_LATEST_VERSION_URL_ALLOW_INVALID_CERTS": "bar",
+				"ARGUS_SERVICE_LATEST_VERSION_GITHUB_USE_PRERELEASE":   "true",
 			},
-			errRegex: `ARGUS_SERVICE_LATEST_VERSION_ALLOW_INVALID_CERTS: "bar" <invalid>`,
+			errRegex: `ARGUS_SERVICE_LATEST_VERSION_URL_ALLOW_INVALID_CERTS: "bar" <invalid>`,
 		},
 		{
 			name: "service.latest_version/invalid bool/use_prerelease",
 			env: map[string]string{
-				"ARGUS_SERVICE_LATEST_VERSION_ACCESS_TOKEN":        "ghp_something",
-				"ARGUS_SERVICE_LATEST_VERSION_ALLOW_INVALID_CERTS": "true",
-				"ARGUS_SERVICE_LATEST_VERSION_USE_PRERELEASE":      "bop",
+				"ARGUS_SERVICE_LATEST_VERSION_GITHUB_ACCESS_TOKEN":     "ghp_something",
+				"ARGUS_SERVICE_LATEST_VERSION_URL_ALLOW_INVALID_CERTS": "true",
+				"ARGUS_SERVICE_LATEST_VERSION_GITHUB_USE_PRERELEASE":   "bop",
 			},
-			errRegex: `ARGUS_SERVICE_LATEST_VERSION_USE_PRERELEASE: "bop" <invalid>`,
+			errRegex: `ARGUS_SERVICE_LATEST_VERSION_GITHUB_USE_PRERELEASE: "bop" <invalid>`,
 		},
 		{
 			name: "service.deployed_version/valid",
@@ -1567,15 +1649,15 @@ func TestDefaults_MapEnvToStruct(t *testing.T) {
 		{
 			name: "multiple fails",
 			env: map[string]string{
-				"ARGUS_NOTIFY_DISCORD_OPTIONS_DELAY":               "foo",
-				"ARGUS_NOTIFY_SLACK_OPTIONS_DELAY":                 "bar",
-				"ARGUS_NOTIFY_TEAMS_OPTIONS_DELAY":                 "baz",
-				"ARGUS_WEBHOOK_DELAY":                              "pasta",
-				"ARGUS_WEBHOOK_TYPE":                               "pizza",
-				"ARGUS_SERVICE_LATEST_VERSION_REQUIRE_DOCKER_TYPE": "pizza",
+				"ARGUS_NOTIFY_DISCORD_OPTIONS_DELAY":                      "foo",
+				"ARGUS_NOTIFY_SLACK_OPTIONS_DELAY":                        "bar",
+				"ARGUS_NOTIFY_TEAMS_OPTIONS_DELAY":                        "baz",
+				"ARGUS_WEBHOOK_DELAY":                                     "pasta",
+				"ARGUS_WEBHOOK_TYPE":                                      "pizza",
+				"ARGUS_SERVICE_LATEST_VERSION_COMMON_REQUIRE_DOCKER_TYPE": "pizza",
 			},
 			errRegex: test.TrimYAML(`
-				ARGUS_SERVICE_LATEST_VERSION_REQUIRE_DOCKER_TYPE: "pizza" <invalid> .+
+				ARGUS_SERVICE_LATEST_VERSION_COMMON_REQUIRE_DOCKER_TYPE: "pizza" <invalid> .+
 				ARGUS_NOTIFY_DISCORD_OPTIONS_DELAY: "foo" <invalid> .+
 				ARGUS_NOTIFY_SLACK_OPTIONS_DELAY: "bar" <invalid> .+
 				ARGUS_NOTIFY_TEAMS_OPTIONS_DELAY: "baz" <invalid> .+
@@ -1603,11 +1685,13 @@ func TestDefaults_MapEnvToStruct(t *testing.T) {
 
 			defaults := Defaults{
 				Service: service.Defaults{
-					LatestVersion: lvbase.Defaults{
-						Require: filter.RequireDefaults{
-							Docker: *test.Must(t, func() (*docker.Defaults, error) {
-								return docker.DecodeDefaults("json", []byte("{}"), nil)
-							}),
+					LatestVersion: latestver.Defaults{
+						Common: lvbase.Defaults{
+							Require: filter.RequireDefaults{
+								Docker: *test.Must(t, func() (*docker.Defaults, error) {
+									return docker.DecodeDefaults("json", []byte("{}"), nil)
+								}),
+							},
 						},
 					},
 					DeployedVersionLookup: dvbase.Defaults{},
@@ -1636,6 +1720,13 @@ func TestDefaults_MapEnvToStruct(t *testing.T) {
 						}
 					}
 				}
+			}
+			for _, k := range tc.envCleanup {
+				if v, ok := os.LookupEnv(k); ok {
+					os.Unsetenv(k)
+					t.Cleanup(func() { _ = os.Setenv(k, v) })
+				}
+				t.Cleanup(func() { _ = os.Unsetenv(k) })
 			}
 			test.SetEnv(t, tc.env)
 			wantOk := tc.errRegex == ""
@@ -1711,14 +1802,16 @@ func TestDefaults_CheckValues(t *testing.T) {
 			name: "Service.LatestVersion.Require.Docker.Type",
 			input: &Defaults{
 				Service: service.Defaults{
-					LatestVersion: lvbase.Defaults{
-						Require: filter.RequireDefaults{
-							Docker: *test.Must(t, func() (*docker.Defaults, error) {
-								return docker.DecodeDefaults(
-									"yaml", []byte("type: pizza"),
-									nil,
-								)
-							}),
+					LatestVersion: latestver.Defaults{
+						Common: lvbase.Defaults{
+							Require: filter.RequireDefaults{
+								Docker: *test.Must(t, func() (*docker.Defaults, error) {
+									return docker.DecodeDefaults(
+										"yaml", []byte("type: pizza"),
+										nil,
+									)
+								}),
+							},
 						},
 					},
 				},
@@ -1739,14 +1832,16 @@ func TestDefaults_CheckValues(t *testing.T) {
 					Options: *test.Must(t, func() (*opt.Defaults, error) {
 						return opt.DecodeDefaults("yaml", []byte("interval: 10x"))
 					}),
-					LatestVersion: lvbase.Defaults{
-						Require: filter.RequireDefaults{
-							Docker: *test.Must(t, func() (*docker.Defaults, error) {
-								return docker.DecodeDefaults(
-									"yaml", []byte("type: pizza"),
-									nil,
-								)
-							}),
+					LatestVersion: latestver.Defaults{
+						Common: lvbase.Defaults{
+							Require: filter.RequireDefaults{
+								Docker: *test.Must(t, func() (*docker.Defaults, error) {
+									return docker.DecodeDefaults(
+										"yaml", []byte("type: pizza"),
+										nil,
+									)
+								}),
+							},
 						},
 					},
 				},
@@ -1897,12 +1992,15 @@ var hardDefaultsStr = test.TrimYAML(`
 				semantic_versioning: true
 			latest_version:
 				type: github
-				allow_invalid_certs: false
-				use_prerelease: false
-				require:
-					docker:
-						type: hub
-						tag: '{{ version }}'
+				common:
+					require:
+						docker:
+							type: hub
+							tag: '{{ version }}'
+				github:
+					use_prerelease: false
+				url:
+					allow_invalid_certs: false
 			deployed_version:
 				type: url
 				allow_invalid_certs: false

--- a/config/env.go
+++ b/config/env.go
@@ -27,9 +27,114 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/release-argus/Argus/internal/logx"
 	"github.com/release-argus/Argus/util"
 	"github.com/release-argus/Argus/util/errfmt"
 )
+
+// deprecatedConfigEnvVars maps deprecated 'ARGUS_*' env vars to their new name.
+var deprecatedConfigEnvVars = map[string]string{
+	"ARGUS_SERVICE_LATEST_VERSION_ACCESS_TOKEN":        "ARGUS_SERVICE_LATEST_VERSION_GITHUB_ACCESS_TOKEN",
+	"ARGUS_SERVICE_LATEST_VERSION_USE_PRERELEASE":      "ARGUS_SERVICE_LATEST_VERSION_GITHUB_USE_PRERELEASE",
+	"ARGUS_SERVICE_LATEST_VERSION_ALLOW_INVALID_CERTS": "ARGUS_SERVICE_LATEST_VERSION_URL_ALLOW_INVALID_CERTS",
+}
+
+// deprecatedConfigEnvVarPrefixes maps deprecated 'ARGUS_*' env var prefixes to their new prefix.
+var deprecatedConfigEnvVarPrefixes = map[string]string{
+	"ARGUS_SERVICE_LATEST_VERSION_REQUIRE_": "ARGUS_SERVICE_LATEST_VERSION_COMMON_REQUIRE_",
+}
+
+// migrateDeprecatedEnvVars renames deprecated env var keys [deprecatedConfigEnvVars]
+// in envVars to their new name, logging a deprecation notice for each rename.
+func migrateDeprecatedEnvVars(envVars []string) []string {
+	for oldName, newName := range deprecatedConfigEnvVars {
+		oldPrefix := oldName + "="
+		newPrefix := newName + "="
+
+		oldIdx := -1
+		hasNew := false
+		for i, envVar := range envVars {
+			switch {
+			case strings.HasPrefix(envVar, oldPrefix):
+				oldIdx = i
+			case strings.HasPrefix(envVar, newPrefix):
+				hasNew = true
+			}
+		}
+		if oldIdx == -1 {
+			continue
+		}
+
+		if hasNew {
+			// The new name is already set explicitly - drop the deprecated one, new wins.
+			logx.Deprecated(fmt.Sprintf(
+				"Dropping deprecated env var '%s' ('%s' already set)",
+				oldName, newName,
+			))
+			os.Unsetenv(oldName) //nolint:errcheck // best-effort; avoid leaving a stale duplicate.
+			envVars = append(envVars[:oldIdx], envVars[oldIdx+1:]...)
+			continue
+		}
+		logx.Deprecated(fmt.Sprintf(
+			"Renaming env var '%s' to '%s'",
+			oldName, newName,
+		))
+		value := strings.TrimPrefix(envVars[oldIdx], oldPrefix)
+		os.Setenv(newName, value) //nolint:errcheck // best-effort; value/key are known-valid.
+		os.Unsetenv(oldName)      //nolint:errcheck // best-effort; avoid leaving a stale duplicate.
+		envVars[oldIdx] = newName + "=" + value
+	}
+
+	return migrateDeprecatedEnvVarPrefixes(envVars)
+}
+
+// migrateDeprecatedEnvVarPrefixes renames every envVars entry whose key starts with
+// a deprecated prefix [deprecatedConfigEnvVarPrefixes] to use the new prefix,
+// logging one deprecation notice per old/new prefix pair observed.
+func migrateDeprecatedEnvVarPrefixes(envVars []string) []string {
+	existingKeys := make(map[string]bool, len(envVars))
+	for _, envVar := range envVars {
+		key, _, _ := strings.Cut(envVar, "=")
+		existingKeys[key] = true
+	}
+
+	logged := make(map[string]bool, len(deprecatedConfigEnvVarPrefixes))
+	result := make([]string, 0, len(envVars))
+	for _, envVar := range envVars {
+		key, value, _ := strings.Cut(envVar, "=")
+
+		var oldPrefix, newPrefix string
+		for old, new := range deprecatedConfigEnvVarPrefixes {
+			if strings.HasPrefix(key, old) {
+				oldPrefix, newPrefix = old, new
+				break
+			}
+		}
+		if oldPrefix == "" {
+			result = append(result, envVar)
+			continue
+		}
+
+		if !logged[oldPrefix] {
+			logx.Deprecated(fmt.Sprintf(
+				"Migrating env vars '%s*' to '%s*'",
+				oldPrefix, newPrefix,
+			))
+			logged[oldPrefix] = true
+		}
+		newKey := newPrefix + strings.TrimPrefix(key, oldPrefix)
+		if existingKeys[newKey] {
+			// The new name is already set explicitly - drop the deprecated one, new wins.
+			os.Unsetenv(key) //nolint:errcheck // best-effort; avoid leaving a stale duplicate.
+			continue
+		}
+		os.Setenv(newKey, value) //nolint:errcheck // best-effort; value/key are known-valid.
+		os.Unsetenv(key)         //nolint:errcheck // best-effort; avoid leaving a stale duplicate.
+		result = append(result, newKey+"="+value)
+	}
+
+	return result
+}
 
 // mapEnvToStruct maps environment variables to a struct.
 func mapEnvToStruct(src any, prefix string, envVars []string) error {
@@ -49,6 +154,7 @@ func mapEnvToStruct(src any, prefix string, envVars []string) error {
 				envVars = append(envVars, envVar)
 			}
 		}
+		envVars = migrateDeprecatedEnvVars(envVars)
 		// Have no env vars to map.
 		if len(envVars) == 0 {
 			return nil

--- a/config/env_test.go
+++ b/config/env_test.go
@@ -22,6 +22,8 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
+	"sort"
 	"strings"
 	"testing"
 
@@ -44,6 +46,201 @@ type testStructChild struct {
 	Float  float64 `yaml:"float,omitempty"`
 }
 
+func TestMigrateDeprecatedEnvVars(t *testing.T) {
+	// GIVEN: a slice of env vars, possibly containing deprecated names.
+	tests := []struct {
+		name    string
+		envVars []string
+		want    map[string]string
+	}{
+		{
+			name: "no deprecated vars present",
+			envVars: []string{
+				"ARGUS_FOO=bar",
+			},
+			want: map[string]string{
+				"ARGUS_FOO": "bar",
+			},
+		},
+		{
+			name: "deprecated var present, canonical absent - renamed",
+			envVars: []string{
+				"ARGUS_SERVICE_LATEST_VERSION_ACCESS_TOKEN=ghp_deprecated",
+			},
+			want: map[string]string{
+				"ARGUS_SERVICE_LATEST_VERSION_GITHUB_ACCESS_TOKEN": "ghp_deprecated",
+			},
+		},
+		{
+			name: "deprecated and canonical both present - canonical wins, deprecated dropped",
+			envVars: []string{
+				"ARGUS_SERVICE_LATEST_VERSION_ACCESS_TOKEN=ghp_deprecated",
+				"ARGUS_SERVICE_LATEST_VERSION_GITHUB_ACCESS_TOKEN=ghp_canonical",
+			},
+			want: map[string]string{
+				"ARGUS_SERVICE_LATEST_VERSION_GITHUB_ACCESS_TOKEN": "ghp_canonical",
+			},
+		},
+		{
+			name: "all exact-name deprecated vars are renamed",
+			envVars: []string{
+				"ARGUS_SERVICE_LATEST_VERSION_ACCESS_TOKEN=ghp_deprecated",
+				"ARGUS_SERVICE_LATEST_VERSION_USE_PRERELEASE=true",
+				"ARGUS_SERVICE_LATEST_VERSION_ALLOW_INVALID_CERTS=true",
+				"ARGUS_UNRELATED=untouched",
+				"other=also_untouched",
+			},
+			want: map[string]string{
+				"ARGUS_SERVICE_LATEST_VERSION_GITHUB_ACCESS_TOKEN":     "ghp_deprecated",
+				"ARGUS_SERVICE_LATEST_VERSION_GITHUB_USE_PRERELEASE":   "true",
+				"ARGUS_SERVICE_LATEST_VERSION_URL_ALLOW_INVALID_CERTS": "true",
+				"ARGUS_UNRELATED": "untouched",
+				"other":           "also_untouched",
+			},
+		},
+		{
+			name: "deprecated 'require' prefix var is delegated to the prefix migration",
+			envVars: []string{
+				"ARGUS_SERVICE_LATEST_VERSION_REQUIRE_DOCKER_TYPE=hub",
+			},
+			want: map[string]string{
+				"ARGUS_SERVICE_LATEST_VERSION_COMMON_REQUIRE_DOCKER_TYPE": "hub",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// t.Parallel() - Cannot run in parallel since we're sharing some env vars.
+
+			for k := range tc.want {
+				if v, ok := os.LookupEnv(k); ok {
+					os.Unsetenv(k)
+					t.Cleanup(func() { _ = os.Setenv(k, v) })
+				}
+				t.Cleanup(func() { _ = os.Unsetenv(k) })
+			}
+			envVars := test.SplitEnvVars(tc.envVars)
+			test.SetEnv(t, envVars)
+
+			// WHEN: migrateDeprecatedEnvVars is called.
+			got := migrateDeprecatedEnvVars(tc.envVars)
+
+			prefix := fmt.Sprintf(
+				"%s\nmigrateDeprecatedEnvVars(%v)",
+				packageName, tc.envVars,
+			)
+
+			// THEN: the returned slice has the deprecated vars renamed/dropped as expected.
+			gotSorted, wantSorted := append([]string{}, got...), test.MapJoin(tc.want, "=")
+			sort.Strings(gotSorted)
+			if !slices.Equal(gotSorted, wantSorted) {
+				t.Errorf(
+					"%s mismatch\ngot:  %v\nwant: %v",
+					prefix, gotSorted, wantSorted,
+				)
+			}
+
+			// AND: any renamed var was also set for real.
+			for k, v := range tc.want {
+				if got := os.Getenv(k); got != v {
+					t.Errorf(
+						"%s real env var %q mismatch\ngot:  %q\nwant: %q",
+						prefix, k, got, v,
+					)
+				}
+			}
+		})
+	}
+}
+
+func TestMigrateDeprecatedEnvVarPrefixes(t *testing.T) {
+	// GIVEN: a slice of env vars, possibly prefixed with a deprecated prefix.
+	tests := []struct {
+		name    string
+		envVars []string
+		want    map[string]string
+	}{
+		{
+			name: "no deprecated prefix present",
+			envVars: []string{
+				"ARGUS_FOO=bar",
+			},
+			want: map[string]string{
+				"ARGUS_FOO": "bar",
+			},
+		},
+		{
+			name: "multiple sub-keys under the deprecated prefix are all renamed",
+			envVars: []string{
+				"ARGUS_SERVICE_LATEST_VERSION_REQUIRE_DOCKER_TYPE=hub",
+				"ARGUS_SERVICE_LATEST_VERSION_REQUIRE_DOCKER_IMAGE=foo/bar",
+				"UNRELATED=untouched",
+			},
+			want: map[string]string{
+				"ARGUS_SERVICE_LATEST_VERSION_COMMON_REQUIRE_DOCKER_TYPE":  "hub",
+				"ARGUS_SERVICE_LATEST_VERSION_COMMON_REQUIRE_DOCKER_IMAGE": "foo/bar",
+				"UNRELATED": "untouched",
+			},
+		},
+		{
+			name: "deprecated and canonical sub-key both present - canonical wins, deprecated dropped",
+			envVars: []string{
+				"ARGUS_SERVICE_LATEST_VERSION_REQUIRE_DOCKER_TYPE=deprecated_value",
+				"ARGUS_SERVICE_LATEST_VERSION_COMMON_REQUIRE_DOCKER_TYPE=canonical_value",
+			},
+			want: map[string]string{
+				"ARGUS_SERVICE_LATEST_VERSION_COMMON_REQUIRE_DOCKER_TYPE": "canonical_value",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// t.Parallel() - Cannot run in parallel since we're sharing some env vars.
+
+			for k := range tc.want {
+				if v, ok := os.LookupEnv(k); ok {
+					os.Unsetenv(k)
+					t.Cleanup(func() { _ = os.Setenv(k, v) })
+				}
+				t.Cleanup(func() { _ = os.Unsetenv(k) })
+			}
+			envVars := test.SplitEnvVars(tc.envVars)
+			test.SetEnv(t, envVars)
+
+			// WHEN: migrateDeprecatedEnvVarPrefixes is called.
+			got := migrateDeprecatedEnvVarPrefixes(tc.envVars)
+
+			prefix := fmt.Sprintf(
+				"%s\nmigrateDeprecatedEnvVarPrefixes(%v)",
+				packageName, tc.envVars,
+			)
+
+			// THEN: the returned slice has the deprecated-prefixed vars renamed/dropped
+			// as expected.
+			gotSorted, wantSorted := append([]string{}, got...), test.MapJoin(tc.want, "=")
+			sort.Strings(gotSorted)
+			if !slices.Equal(gotSorted, wantSorted) {
+				t.Errorf(
+					"%s mismatch\ngot:  %v\nwant: %v",
+					prefix, gotSorted, wantSorted,
+				)
+			}
+
+			// AND: any renamed var was also set for real.
+			for k, v := range tc.want {
+				if got := os.Getenv(k); got != v {
+					t.Errorf(
+						"%s real env var %q mismatch\ngot:  %q\nwant: %q",
+						prefix, k, got, v,
+					)
+				}
+			}
+		})
+	}
+}
+
 func TestMapEnvToStruct(t *testing.T) {
 	// GIVEN: a struct and a bunch of env vars.
 	tests := []struct {
@@ -52,6 +249,7 @@ func TestMapEnvToStruct(t *testing.T) {
 		customStructBuilder *func() any
 		prefix              string
 		env                 map[string]string
+		envCleanup          []string
 		marshalWant         bool
 		want                string
 		errRegex            string
@@ -520,12 +718,91 @@ func TestMapEnvToStruct(t *testing.T) {
 			}(),
 			errRegex: `^$`,
 		},
+		{
+			name: "deprecated service.latest_version env vars are migrated before mapping",
+			env: map[string]string{
+				"ARGUS_SERVICE_LATEST_VERSION_ACCESS_TOKEN":        "ghp_deprecated",
+				"ARGUS_SERVICE_LATEST_VERSION_USE_PRERELEASE":      "true",
+				"ARGUS_SERVICE_LATEST_VERSION_ALLOW_INVALID_CERTS": "true",
+			},
+			envCleanup: []string{
+				"ARGUS_SERVICE_LATEST_VERSION_GITHUB_ACCESS_TOKEN",
+				"ARGUS_SERVICE_LATEST_VERSION_GITHUB_USE_PRERELEASE",
+				"ARGUS_SERVICE_LATEST_VERSION_URL_ALLOW_INVALID_CERTS",
+			},
+			customStruct: &Defaults{},
+			want: test.TrimYAML(`
+				service:
+					latest_version:
+						github:
+							access_token: ghp_deprecated
+							use_prerelease: true
+						url:
+							allow_invalid_certs: true
+			`),
+			errRegex: `^$`,
+		},
+		{
+			name: "canonical service.latest_version env vars need no migration",
+			env: map[string]string{
+				"ARGUS_SERVICE_LATEST_VERSION_GITHUB_ACCESS_TOKEN": "ghp_canonical",
+			},
+			customStruct: &Defaults{},
+			want: test.TrimYAML(`
+				service:
+					latest_version:
+						github:
+							access_token: ghp_canonical
+			`),
+			errRegex: `^$`,
+		},
+		{
+			name: "deprecated and canonical service.latest_version env vars both set, canonical wins",
+			env: map[string]string{
+				"ARGUS_SERVICE_LATEST_VERSION_ACCESS_TOKEN":        "ghp_deprecated",
+				"ARGUS_SERVICE_LATEST_VERSION_GITHUB_ACCESS_TOKEN": "ghp_canonical",
+			},
+			customStruct: &Defaults{},
+			want: test.TrimYAML(`
+				service:
+					latest_version:
+						github:
+							access_token: ghp_canonical
+			`),
+			errRegex: `^$`,
+		},
+		{
+			name: "deprecated service.latest_version.require env vars (prefix-mapped) are migrated before mapping",
+			env: map[string]string{
+				"ARGUS_SERVICE_LATEST_VERSION_REQUIRE_DOCKER_TYPE": "hub",
+			},
+			envCleanup: []string{
+				"ARGUS_SERVICE_LATEST_VERSION_COMMON_REQUIRE_DOCKER_TYPE",
+			},
+			customStruct: &Defaults{},
+			want: test.TrimYAML(`
+				service:
+					latest_version:
+						common:
+							require:
+								docker:
+									type: hub
+			`),
+			errRegex: `^$`,
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			// t.Parallel() - Cannot run in parallel since we're sharing some env vars.
 
+			for _, k := range tc.envCleanup {
+				if v, ok := os.LookupEnv(k); ok {
+					os.Unsetenv(k)
+					t.Cleanup(func() { _ = os.Setenv(k, v) })
+				}
+				t.Cleanup(func() { _ = os.Unsetenv(k) })
+			}
 			test.SetEnv(t, tc.env)
 
 			// WHEN: mapEnvToStruct is called on it.

--- a/config/init.go
+++ b/config/init.go
@@ -74,8 +74,8 @@ func (c *Config) Load(
 
 	// Default Empty List ETag as it depends on default access_token.
 	accessTokenDefault := util.FirstNonDefaultWithEnv(
-		c.Defaults.Service.LatestVersion.AccessToken,
-		c.HardDefaults.Service.LatestVersion.AccessToken,
+		c.Defaults.Service.LatestVersion.GitHub.AccessToken,
+		c.HardDefaults.Service.LatestVersion.GitHub.AccessToken,
 	)
 	github.SetEmptyListETag(accessTokenDefault)
 

--- a/config/init_test.go
+++ b/config/init_test.go
@@ -212,13 +212,13 @@ func TestConfig_InitDefaults(t *testing.T) {
 	prefix := fmt.Sprintf("%s\nConfig InitDefaults()", packageName)
 
 	// THEN: HardDefaults...Docker.Type has a value.
-	if cfg.HardDefaults.Service.LatestVersion.Require.Docker.Type == "" {
+	if cfg.HardDefaults.Service.LatestVersion.Common.Require.Docker.Type == "" {
 		t.Fatalf("%s got HardDefaults.Docker.Require=''. want value", packageName)
 	}
 
 	// AND: Defaults inherit from HardDefaults.
-	if cfg.Defaults.Service.LatestVersion.Require.Docker.Defaults !=
-		&cfg.HardDefaults.Service.LatestVersion.Require.Docker {
+	if cfg.Defaults.Service.LatestVersion.Common.Require.Docker.Defaults !=
+		&cfg.HardDefaults.Service.LatestVersion.Common.Require.Docker {
 		t.Fatalf("%s got Defaults....Docker.Defaults != HardDefaults...Docker.Defaults", packageName)
 	}
 
@@ -226,7 +226,7 @@ func TestConfig_InitDefaults(t *testing.T) {
 	fieldTests := []test.FieldAssertion{
 		{
 			Name: "Defaults: Service.LatestVersion.Options -> Service.Options",
-			Got:  cfg.Defaults.Service.LatestVersion.Options,
+			Got:  cfg.Defaults.Service.LatestVersion.Common.Options,
 			Want: &cfg.Defaults.Service.Options,
 			Mode: test.CompareSamePointer,
 		},
@@ -238,7 +238,7 @@ func TestConfig_InitDefaults(t *testing.T) {
 		},
 		{
 			Name: "HardDefaults: Service.LatestVersion.Options -> Service.Options",
-			Got:  cfg.HardDefaults.Service.LatestVersion.Options,
+			Got:  cfg.HardDefaults.Service.LatestVersion.Common.Options,
 			Want: &cfg.HardDefaults.Service.Options,
 			Mode: test.CompareSamePointer,
 		},

--- a/config/verify_test.go
+++ b/config/verify_test.go
@@ -27,7 +27,6 @@ import (
 	shoutrrrtest "github.com/release-argus/Argus/notify/shoutrrr/test"
 	"github.com/release-argus/Argus/service"
 	latestver "github.com/release-argus/Argus/service/latest_version"
-	lvbase "github.com/release-argus/Argus/service/latest_version/types/base"
 	opt "github.com/release-argus/Argus/service/option"
 	svctest "github.com/release-argus/Argus/service/test"
 	"github.com/release-argus/Argus/util"
@@ -73,7 +72,7 @@ func testVerify(t *testing.T) *Config {
 					`)),
 					nil,
 					nil,
-					lvbase.DefaultsConfig{
+					latestver.DefaultsConfig{
 						Soft: &cfg.Defaults.Service.LatestVersion,
 						Hard: &cfg.HardDefaults.Service.LatestVersion,
 					},
@@ -461,12 +460,15 @@ var configStr = test.TrimYAML(`
 				semantic_versioning: true
 			latest_version:
 				type: github
-				allow_invalid_certs: false
-				use_prerelease: false
-				require:
-					docker:
-						type: hub
-						tag: '{{ version }}'
+				common:
+					require:
+						docker:
+							type: hub
+							tag: '{{ version }}'
+				github:
+					use_prerelease: false
+				url:
+					allow_invalid_certs: false
 			deployed_version:
 				type: url
 				allow_invalid_certs: false

--- a/config/yaml_help_test.go
+++ b/config/yaml_help_test.go
@@ -59,7 +59,8 @@ func testYAML_config_test(path string) {
 					interval: 123
 					semantic_versioning: false
 				latest_version:
-					access_token: ghp_default
+					github:
+						access_token: ghp_default
 				notify:
 					default: {}
 				command:

--- a/db/init.go
+++ b/db/init.go
@@ -68,7 +68,7 @@ func (api *api) initialise() (ok bool) {
 	if ok := checkFile(databaseFile); !ok {
 		return ok
 	}
-	db, err := openDatabase("sqlite", databaseFile)
+	db, err := openDatabase("sqlite", databaseFile+"?_pragma=busy_timeout(5000)")
 	if err != nil {
 		logx.Fatal(err, logFrom)
 		return

--- a/internal/test/env.go
+++ b/internal/test/env.go
@@ -18,6 +18,7 @@ package test
 
 import (
 	"os"
+	"strings"
 	"sync"
 	"testing"
 )
@@ -57,4 +58,18 @@ func SetEnv(t *testing.T, vars map[string]string) {
 		}
 		envMu.Unlock()
 	})
+}
+
+func SplitEnvVars(envVars []string) map[string]string {
+	result := make(map[string]string, len(envVars))
+
+	for _, kv := range envVars {
+		key, value, ok := strings.Cut(kv, "=")
+		if !ok {
+			continue // Skip invalid env var format.
+		}
+		result[key] = value
+	}
+
+	return result
 }

--- a/internal/test/env_test.go
+++ b/internal/test/env_test.go
@@ -17,6 +17,7 @@
 package test
 
 import (
+	"fmt"
 	"os"
 	"testing"
 )
@@ -96,6 +97,59 @@ func TestSetEnv(t *testing.T) {
 						packageName, got, ok, k, expected,
 					)
 				}
+			}
+		})
+	}
+}
+
+func TestSplitEnvVars(t *testing.T) {
+	// GIVEN: a slice of env vars in the form "KEY=VALUE".
+	tests := []struct {
+		name string
+		env  []string
+		want map[string]string
+	}{
+		{
+			name: "simple",
+			env: []string{
+				"FOO=bar",
+				"BAZ=qux",
+			},
+			want: map[string]string{
+				"FOO": "bar",
+				"BAZ": "qux",
+			},
+		},
+		{
+			name: "empty value",
+			env:  []string{"FOO="},
+			want: map[string]string{"FOO": ""},
+		},
+		{
+			name: "no equals sign",
+			env:  []string{"FOO"},
+			want: map[string]string{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// WHEN: SplitEnvVars is called.
+			got := SplitEnvVars(tc.env)
+
+			prefix := fmt.Sprintf("%s\nSplitEnvVars()", packageName)
+
+			// THEN: the result is as expected.
+			if testErr := AssertMapEqual(
+				t,
+				got,
+				tc.want,
+				prefix,
+				"",
+			); testErr != nil {
+				t.Fatal(testErr)
 			}
 		})
 	}

--- a/internal/test/help_test.go
+++ b/internal/test/help_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build unit
+//go:build unit || integration
 
 package test
 

--- a/internal/test/maps.go
+++ b/internal/test/maps.go
@@ -12,23 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package web provides a web-based lookup type.
-package web
+//go:build unit || integration
 
-import (
-	"github.com/release-argus/Argus/util"
-)
+package test
 
-// GetType returns the type of the receiver.
-func (l *Lookup) GetType() string {
-	return Type
-}
+import "slices"
 
-// allowInvalidCerts resolves whether invalid TLS certificates are permitted.
-func (l *Lookup) allowInvalidCerts() bool {
-	return *util.FirstNonNilPtr(
-		l.AllowInvalidCerts,
-		l.typeDefaults.AllowInvalidCerts,
-		l.typeHardDefaults.AllowInvalidCerts,
-	)
+// MapJoin returns a slice containing each key-value pair in m joined by sep.
+// The returned elements are sorted by key.
+func MapJoin[K, V ~string](m map[K]V, sep string) []string {
+	out := make([]string, 0, len(m))
+
+	for k, v := range m {
+		out = append(out, string(k)+sep+string(v))
+	}
+	slices.Sort(out)
+
+	return out
 }

--- a/internal/test/maps_test.go
+++ b/internal/test/maps_test.go
@@ -1,0 +1,91 @@
+// Copyright [2026] [Argus]
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build unit
+
+package test
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestMapJoin(t *testing.T) {
+	// GIVEN: a map to join with a separator.
+	tests := []struct {
+		name string
+		m    map[string]string
+		sep  string
+		want []string
+	}{
+		{
+			name: "empty map",
+			m:    map[string]string{},
+			sep:  "_",
+			want: []string{},
+		},
+		{
+			name: "empty separator",
+			m: map[string]string{
+				"a": "1",
+			},
+			sep:  "",
+			want: []string{"a1"},
+		},
+		{
+			name: "single entry",
+			m: map[string]string{
+				"key": "value",
+			},
+			sep:  ":",
+			want: []string{"key:value"},
+		},
+		{
+			name: "multiple entires",
+			m: map[string]string{
+				"a": "5",
+				"b": "6",
+				"c": "0",
+			},
+			sep:  "_",
+			want: []string{"a_5", "b_6", "c_0"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// WHEN: MapJoin is called on them.
+			got := MapJoin(tc.m, tc.sep)
+
+			prefix := fmt.Sprintf(
+				"%s\nMapJoin(m=%v, sep=%q)",
+				packageName, tc.m, tc.sep,
+			)
+
+			// THEN: they are joined as expected.
+			if testErr := AssertSlicesEqualFunc(
+				t,
+				got,
+				tc.want,
+				func(a, b string) bool { return a == b },
+				prefix,
+				"",
+			); testErr != nil {
+				t.Fatal(testErr)
+			}
+		})
+	}
+}

--- a/internal/test/string_test.go
+++ b/internal/test/string_test.go
@@ -71,7 +71,7 @@ func TestIndent(t *testing.T) {
 			// THEN: the result should be the string with each line indented by the given number of spaces.
 			if result != tc.want {
 				t.Errorf(
-					"%s\nIndent(str=%q, indents=%q) mismatch\ngot:  %q\nwant: %q",
+					"%s\nIndent(str=%q, indents=%d) mismatch\ngot:  %q\nwant: %q",
 					packageName, tc.str, tc.indent,
 					result, tc.want,
 				)

--- a/service/api_test.go
+++ b/service/api_test.go
@@ -430,11 +430,13 @@ func TestFromPayload(t *testing.T) {
 			}`,
 			svcCfg: DefaultsConfig{
 				Hard: &Defaults{
-					LatestVersion: lvbase.Defaults{
+					LatestVersion: latestver.Defaults{
 						Type: lvgithub.Type,
-						Require: filter.RequireDefaults{
-							Docker: docker.Defaults{
-								Type: "ghcr",
+						Common: lvbase.Defaults{
+							Require: filter.RequireDefaults{
+								Docker: docker.Defaults{
+									Type: "ghcr",
+								},
 							},
 						},
 					},

--- a/service/defaults.go
+++ b/service/defaults.go
@@ -20,7 +20,7 @@ import (
 	"github.com/release-argus/Argus/config/decode"
 	"github.com/release-argus/Argus/service/dashboard"
 	deployedver_base "github.com/release-argus/Argus/service/deployed_version/types/base"
-	latestver_base "github.com/release-argus/Argus/service/latest_version/types/base"
+	latestver "github.com/release-argus/Argus/service/latest_version"
 	opt "github.com/release-argus/Argus/service/option"
 	"github.com/release-argus/Argus/service/status"
 	"github.com/release-argus/Argus/util/polymorphic"
@@ -29,7 +29,7 @@ import (
 // Defaults are the default values for a Service.
 type Defaults struct {
 	Options               opt.Defaults              `json:"options,omitzero" yaml:"options,omitzero"`                   // Options to give the Service.
-	LatestVersion         latestver_base.Defaults   `json:"latest_version,omitzero" yaml:"latest_version,omitzero"`     // Vars to scrape the latest version of the Service.
+	LatestVersion         latestver.Defaults        `json:"latest_version,omitzero" yaml:"latest_version,omitzero"`     // Vars to scrape the latest version of the Service.
 	DeployedVersionLookup deployedver_base.Defaults `json:"deployed_version,omitzero" yaml:"deployed_version,omitzero"` // Vars to scrape the Service's current deployed version.
 	Notify                map[string]struct{}       `json:"notify,omitempty" yaml:"notify,omitempty"`                   // Default Notifiers to give a Service.
 	Command               command.Commands          `json:"command,omitempty" yaml:"command,omitempty"`                 // Default Commands to give a Service.
@@ -144,14 +144,14 @@ func (d *Defaults) SetDefaults(dflts *Defaults) {
 	d.LatestVersion.SetDefaults(&dflts.LatestVersion)
 
 	// Options.
-	d.LatestVersion.Options = &d.Options
+	d.LatestVersion.Common.Options = &d.Options
 	d.DeployedVersionLookup.Options = &d.Options
-	dflts.LatestVersion.Options = &dflts.Options
+	dflts.LatestVersion.Common.Options = &dflts.Options
 	dflts.DeployedVersionLookup.Options = &dflts.Options
 }
 
 // Init wires the appropriate Defaults pointers between structs.
 func (d *Defaults) Init() {
-	d.LatestVersion.Options = &d.Options
+	d.LatestVersion.Common.Options = &d.Options
 	d.DeployedVersionLookup.Options = &d.Options
 }

--- a/service/defaults_test.go
+++ b/service/defaults_test.go
@@ -25,9 +25,12 @@ import (
 	"github.com/release-argus/Argus/internal/test"
 	"github.com/release-argus/Argus/service/dashboard"
 	dvbase "github.com/release-argus/Argus/service/deployed_version/types/base"
+	latestver "github.com/release-argus/Argus/service/latest_version"
 	"github.com/release-argus/Argus/service/latest_version/filter"
 	"github.com/release-argus/Argus/service/latest_version/filter/docker"
 	lvbase "github.com/release-argus/Argus/service/latest_version/types/base"
+	"github.com/release-argus/Argus/service/latest_version/types/github"
+	"github.com/release-argus/Argus/service/latest_version/types/web"
 	opt "github.com/release-argus/Argus/service/option"
 )
 
@@ -57,7 +60,7 @@ func TestDefaults_IsZero(t *testing.T) {
 		{
 			name: "non-empty/LatestVersion",
 			opt: &Defaults{
-				LatestVersion: lvbase.Defaults{
+				LatestVersion: latestver.Defaults{
 					Type: "url",
 				},
 			},
@@ -116,7 +119,7 @@ func TestDefaults_IsZero(t *testing.T) {
 						Interval: "1m",
 					},
 				},
-				LatestVersion: lvbase.Defaults{
+				LatestVersion: latestver.Defaults{
 					Type: "url",
 				},
 				DeployedVersionLookup: dvbase.Defaults{
@@ -529,57 +532,63 @@ func TestDefaults_String(t *testing.T) {
 						`)),
 					)
 				}),
-				LatestVersion: lvbase.Defaults{
-					AccessToken:       "foo",
-					AllowInvalidCerts: test.Ptr(true),
-					UsePreRelease:     test.Ptr(false),
-					Options: &opt.Defaults{
-						Base: opt.Base{
-							Interval: "1m",
-						},
+				LatestVersion: latestver.Defaults{
+					GitHub: github.Defaults{
+						AccessToken:   "foo",
+						UsePreRelease: test.Ptr(false),
 					},
-					Require: filter.RequireDefaults{
-						Docker: *test.Must(t, func() (*docker.Defaults, error) {
-							return docker.DecodeDefaults(
-								"yaml", []byte(test.TrimYAML(`
-									type: ghcr
-									registry:
-										ghcr:
-											auth:
-												username: usernameGHCR
-												token: tokenGHCR
-										hub:
-											auth:
-												username: usernameHub
-												token: tokenHub
-										quay:
-											auth:
-												username: usernameQuay
-												token: tokenQuay
-								`)),
-								test.Must(t, func() (*docker.Defaults, error) {
-									return docker.DecodeDefaults(
-										"yaml", []byte(test.TrimYAML(`
-											type: ghcr
-											registry:
-												ghcr:
-													auth:
-														username: usernameGHCR_Other
-														token: tokenGHCR_Other
-												hub:
-													auth:
-														username: usernameHub_Other
-														token: tokenHub_Other
-												quay:
-													auth:
-														username: usernameQuay_Other
-														token: tokenQuay_Other
-										`)),
-										nil,
-									)
-								}),
-							)
-						}),
+					URL: web.Defaults{
+						AllowInvalidCerts: test.Ptr(true),
+					},
+					Common: lvbase.Defaults{
+						Options: &opt.Defaults{
+							Base: opt.Base{
+								Interval: "1m",
+							},
+						},
+						Require: filter.RequireDefaults{
+							Docker: *test.Must(t, func() (*docker.Defaults, error) {
+								return docker.DecodeDefaults(
+									"yaml", []byte(test.TrimYAML(`
+										type: ghcr
+										registry:
+											ghcr:
+												auth:
+													username: usernameGHCR
+													token: tokenGHCR
+											hub:
+												auth:
+													username: usernameHub
+													token: tokenHub
+											quay:
+												auth:
+													username: usernameQuay
+													token: tokenQuay
+									`)),
+									test.Must(t, func() (*docker.Defaults, error) {
+										return docker.DecodeDefaults(
+											"yaml", []byte(test.TrimYAML(`
+												type: ghcr
+												registry:
+													ghcr:
+														auth:
+															username: usernameGHCR_Other
+															token: tokenGHCR_Other
+													hub:
+														auth:
+															username: usernameHub_Other
+															token: tokenHub_Other
+													quay:
+														auth:
+															username: usernameQuay_Other
+															token: tokenQuay_Other
+											`)),
+											nil,
+										)
+									}),
+								)
+							}),
+						},
 					},
 				},
 				DeployedVersionLookup: dvbase.Defaults{
@@ -594,23 +603,26 @@ func TestDefaults_String(t *testing.T) {
 					interval: 1m
 					semantic_versioning: false
 				latest_version:
-					access_token: foo
-					allow_invalid_certs: true
-					use_prerelease: false
-					require:
-						docker:
-							type: ghcr
-							registry:
-								ghcr:
-									auth:
-										token: tokenGHCR
-								hub:
-									auth:
-										username: usernameHub
-										token: tokenHub
-								quay:
-									auth:
-										token: tokenQuay
+					common:
+						require:
+							docker:
+								type: ghcr
+								registry:
+									ghcr:
+										auth:
+											token: tokenGHCR
+									hub:
+										auth:
+											username: usernameHub
+											token: tokenHub
+									quay:
+										auth:
+											token: tokenQuay
+					github:
+						access_token: foo
+						use_prerelease: false
+					url:
+						allow_invalid_certs: true
 				deployed_version:
 					allow_invalid_certs: false
 				dashboard:
@@ -655,10 +667,10 @@ func TestDefaults_Default(t *testing.T) {
 	}
 
 	// AND: the X.Options vars are pointing to the Options struct.
-	if d.LatestVersion.Options != &d.Options {
+	if d.LatestVersion.Common.Options != &d.Options {
 		t.Errorf(
 			"%s invalid .LatestVersion.Options pointer:\ngot:  %p\nwant: %p",
-			packageName, d.LatestVersion.Options, &d.Options,
+			packageName, d.LatestVersion.Common.Options, &d.Options,
 		)
 	}
 	if d.DeployedVersionLookup.Options != &d.Options {
@@ -686,31 +698,31 @@ func TestDefaults_SetDefaults(t *testing.T) {
 	fieldTests := []test.FieldAssertion{
 		{
 			Name: "LatestVersion.Require.Docker.ContainerDetailDefaults.Defaults -> HardDefaults",
-			Got:  d.LatestVersion.Require.Docker.ContainerDetailDefaults.Defaults,
-			Want: &hd.LatestVersion.Require.Docker.ContainerDetailDefaults,
+			Got:  d.LatestVersion.Common.Require.Docker.ContainerDetailDefaults.Defaults,
+			Want: &hd.LatestVersion.Common.Require.Docker.ContainerDetailDefaults,
 			Mode: test.CompareSamePointer,
 		},
 		{
 			Name: "LatestVersion.Require.Docker.Registry.GHCR.Auth.Defaults -> HardDefaults...Registry.GHCR.Auth",
-			Got:  d.LatestVersion.Require.Docker.Registry.GHCR.GetAuth().Defaults(),
-			Want: hd.LatestVersion.Require.Docker.Registry.GHCR.GetAuth(),
+			Got:  d.LatestVersion.Common.Require.Docker.Registry.GHCR.GetAuth().Defaults(),
+			Want: hd.LatestVersion.Common.Require.Docker.Registry.GHCR.GetAuth(),
 			Mode: test.CompareSamePointer,
 		},
 		{
 			Name: "LatestVersion.Require.Docker.Registry.Hub.Auth.Defaults -> HardDefaults...Registry.Hub.Auth",
-			Got:  d.LatestVersion.Require.Docker.Registry.Hub.GetAuth().Defaults(),
-			Want: hd.LatestVersion.Require.Docker.Registry.Hub.GetAuth(),
+			Got:  d.LatestVersion.Common.Require.Docker.Registry.Hub.GetAuth().Defaults(),
+			Want: hd.LatestVersion.Common.Require.Docker.Registry.Hub.GetAuth(),
 			Mode: test.CompareSamePointer,
 		},
 		{
 			Name: "LatestVersion.Require.Docker.Registry.Quay.Auth.Defaults -> HardDefaults...Registry.Quay.Auth",
-			Got:  d.LatestVersion.Require.Docker.Registry.Quay.GetAuth().Defaults(),
-			Want: hd.LatestVersion.Require.Docker.Registry.Quay.GetAuth(),
+			Got:  d.LatestVersion.Common.Require.Docker.Registry.Quay.GetAuth().Defaults(),
+			Want: hd.LatestVersion.Common.Require.Docker.Registry.Quay.GetAuth(),
 			Mode: test.CompareSamePointer,
 		},
 		{
 			Name: "LatestVersion.Options -> Options",
-			Got:  d.LatestVersion.Options,
+			Got:  d.LatestVersion.Common.Options,
 			Want: &d.Options,
 			Mode: test.CompareSamePointer,
 		},
@@ -722,7 +734,7 @@ func TestDefaults_SetDefaults(t *testing.T) {
 		},
 		{
 			Name: "LatestVersion.Options.Defaults -> HardDefaults.Options",
-			Got:  hd.LatestVersion.Options,
+			Got:  hd.LatestVersion.Common.Options,
 			Want: &hd.Options,
 			Mode: test.CompareSamePointer,
 		},

--- a/service/help_test.go
+++ b/service/help_test.go
@@ -98,7 +98,7 @@ func plainDefaultsConfig(t *testing.T) DefaultsConfig {
 	defaults := Defaults{}
 	hardDefaults := Defaults{}
 	hardDefaults.Default()
-	hardDefaults.LatestVersion.AccessToken = test.GitHubToken(nil)
+	hardDefaults.LatestVersion.GitHub.AccessToken = test.GitHubToken(nil)
 
 	defaults.SetDefaults(&hardDefaults)
 	return DefaultsConfig{

--- a/service/latest_version/decode.go
+++ b/service/latest_version/decode.go
@@ -32,7 +32,7 @@ func Decode(
 	data []byte,
 	options *opt.Options,
 	status *status.Status,
-	cfg base.DefaultsConfig,
+	cfg DefaultsConfig,
 ) (Lookup, error) {
 	if len(data) == 0 {
 		return nil, nil
@@ -68,7 +68,15 @@ func Decode(
 		}
 	}
 
-	field.Init(options, status, cfg)
+	field.Init(
+		options,
+		status,
+		base.DefaultsConfig{
+			Soft: &cfg.Soft.Common,
+			Hard: &cfg.Hard.Common,
+		},
+	)
+	applyTypeDefaults(field, cfg)
 	if err := field.DecodeSelf(format, data); err != nil {
 		return nil, &decode.KeyFieldError{
 			Key: "latest_version",
@@ -87,7 +95,7 @@ func ApplyOverrides(
 	target Lookup,
 	options *opt.Options,
 	status *status.Status,
-	cfg base.DefaultsConfig,
+	cfg DefaultsConfig,
 ) (Lookup, error) {
 	// No overrides.
 	if len(data) == 0 {

--- a/service/latest_version/decode_test.go
+++ b/service/latest_version/decode_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/release-argus/Argus/internal/test"
 	"github.com/release-argus/Argus/service/latest_version/filter"
 	"github.com/release-argus/Argus/service/latest_version/types/base"
+	"github.com/release-argus/Argus/service/latest_version/types/github"
+	"github.com/release-argus/Argus/service/latest_version/types/web"
 	opt "github.com/release-argus/Argus/service/option"
 	opttest "github.com/release-argus/Argus/service/option/test"
 	statustest "github.com/release-argus/Argus/service/status/test"
@@ -293,10 +295,30 @@ func TestDecode(t *testing.T) {
 			fieldTests := []test.FieldAssertion{
 				{Name: "Options", Got: lookup.GetOptions(), Want: options, Mode: test.CompareSamePointer},
 				{Name: "Status", Got: lookup.GetStatus(), Want: svcStatus, Mode: test.CompareSamePointer},
-				{Name: "Defaults", Got: lookup.GetDefaults(), Want: lvCfg.Soft, Mode: test.CompareSamePointer},
-				{Name: "HardDefaults", Got: lookup.GetHardDefaults(), Want: lvCfg.Hard, Mode: test.CompareSamePointer},
+				{Name: "Defaults", Got: lookup.GetDefaults(), Want: &lvCfg.Soft.Common, Mode: test.CompareSamePointer},
+				{Name: "HardDefaults", Got: lookup.GetHardDefaults(), Want: &lvCfg.Hard.Common, Mode: test.CompareSamePointer},
 			}
 			if err := test.AssertFields(t, fieldTests, prefix, "Lookup"); err != nil {
+				t.Fatal(err)
+			}
+
+			// AND: the type-specific Defaults/HardDefaults are wired correctly.
+			var typeFieldTests []test.FieldAssertion
+			switch v := lookup.(type) {
+			case *github.Lookup:
+				gotSoft, gotHard := v.GetTypeDefaults()
+				typeFieldTests = []test.FieldAssertion{
+					{Name: "GitHub typeDefaults", Got: gotSoft, Want: &lvCfg.Soft.GitHub, Mode: test.CompareSamePointer},
+					{Name: "GitHub typeHardDefaults", Got: gotHard, Want: &lvCfg.Hard.GitHub, Mode: test.CompareSamePointer},
+				}
+			case *web.Lookup:
+				gotSoft, gotHard := v.GetTypeDefaults()
+				typeFieldTests = []test.FieldAssertion{
+					{Name: "URL typeDefaults", Got: gotSoft, Want: &lvCfg.Soft.URL, Mode: test.CompareSamePointer},
+					{Name: "URL typeHardDefaults", Got: gotHard, Want: &lvCfg.Hard.URL, Mode: test.CompareSamePointer},
+				}
+			}
+			if err := test.AssertFields(t, typeFieldTests, prefix, "Lookup"); err != nil {
 				t.Fatal(err)
 			}
 		})

--- a/service/latest_version/defaults.go
+++ b/service/latest_version/defaults.go
@@ -1,0 +1,134 @@
+// Copyright [2026] [Argus]
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package latestver provides the latest_version lookup service to for a service.
+package latestver
+
+import (
+	"github.com/release-argus/Argus/config/decode"
+	"github.com/release-argus/Argus/internal/logx"
+	"github.com/release-argus/Argus/service/latest_version/filter"
+	"github.com/release-argus/Argus/service/latest_version/types/base"
+	"github.com/release-argus/Argus/service/latest_version/types/github"
+	"github.com/release-argus/Argus/service/latest_version/types/web"
+)
+
+// DefaultsConfig pairs soft and hard latest version defaults.
+type DefaultsConfig struct {
+	Soft *Defaults
+	Hard *Defaults
+}
+
+// Defaults are the default values for a Lookup - fields common to every registered
+// type live under 'common', and fields specific to a single type live under that
+// type's own key.
+type Defaults struct {
+	Type string `json:"type,omitempty" yaml:"type,omitempty"` // "github" | "url".
+
+	Common base.Defaults   `json:"common,omitzero" yaml:"common,omitzero"`
+	GitHub github.Defaults `json:"github,omitzero" yaml:"github,omitzero"`
+	URL    web.Defaults    `json:"url,omitzero" yaml:"url,omitzero"`
+
+	// Deprecated: moved to 'github.access_token'.
+	AccessTokenDeprecated string `json:"access_token,omitempty" yaml:"access_token,omitempty"`
+	// Deprecated: moved to 'github.use_prerelease'.
+	UsePreReleaseDeprecated *bool `json:"use_prerelease,omitempty" yaml:"use_prerelease,omitempty"`
+	// Deprecated: moved to 'url.allow_invalid_certs'.
+	AllowInvalidCertsDeprecated *bool `json:"allow_invalid_certs,omitempty" yaml:"allow_invalid_certs,omitempty"`
+	// Deprecated: moved to 'common.require'.
+	RequireDeprecated *filter.RequireDefaults `json:"require,omitzero" yaml:"require,omitzero"`
+}
+
+// DecodeDefaults creates and returns new [Defaults] from format-encoded data.
+func DecodeDefaults(format string, data []byte) (*Defaults, error) {
+	var field Defaults
+
+	if err := decode.Unmarshal(format, data, &field); err != nil {
+		return nil, &decode.KeyFieldError{
+			Key: "latest_version",
+			Err: err,
+		}
+	}
+
+	return &field, nil
+}
+
+// IsZero implements the yaml.IsZeroer interface.
+func (d Defaults) IsZero() bool {
+	return d.Type == "" &&
+		d.Common.IsZero() &&
+		d.GitHub.IsZero() &&
+		d.URL.IsZero() &&
+		d.AccessTokenDeprecated == "" &&
+		d.UsePreReleaseDeprecated == nil &&
+		d.AllowInvalidCertsDeprecated == nil &&
+		(d.RequireDeprecated == nil || d.RequireDeprecated.IsZero())
+}
+
+// Default sets the values of the receiver to their default values.
+func (d *Defaults) Default() {
+	d.Type = "github"
+	d.Common.Default()
+	d.GitHub.Default()
+	d.URL.Default()
+}
+
+// SetDefaults assigns defaults to the receiver.
+func (d *Defaults) SetDefaults(dflts *Defaults) {
+	d.Common.SetDefaults(&dflts.Common)
+}
+
+// CheckValues migrates deprecated fields, then validates the fields of the receiver.
+func (d *Defaults) CheckValues() error {
+	// Deprecated: access_token -> github.access_token.
+	if d.AccessTokenDeprecated != "" && d.GitHub.AccessToken == "" {
+		d.GitHub.AccessToken = d.AccessTokenDeprecated
+		logx.Deprecated("Renaming 'defaults.service.latest_version.access_token' to 'defaults.service.latest_version.github.access_token'")
+	}
+	d.AccessTokenDeprecated = ""
+
+	// Deprecated: use_prerelease -> github.use_prerelease.
+	if d.UsePreReleaseDeprecated != nil && d.GitHub.UsePreRelease == nil {
+		d.GitHub.UsePreRelease = d.UsePreReleaseDeprecated
+		logx.Deprecated("Renaming 'defaults.service.latest_version.use_prerelease' to 'defaults.service.latest_version.github.use_prerelease'")
+	}
+	d.UsePreReleaseDeprecated = nil
+
+	// Deprecated: allow_invalid_certs -> url.allow_invalid_certs.
+	if d.AllowInvalidCertsDeprecated != nil && d.URL.AllowInvalidCerts == nil {
+		d.URL.AllowInvalidCerts = d.AllowInvalidCertsDeprecated
+		logx.Deprecated("Renaming 'defaults.service.latest_version.allow_invalid_certs' to 'defaults.service.latest_version.url.allow_invalid_certs'")
+	}
+	d.AllowInvalidCertsDeprecated = nil
+
+	// Deprecated: require -> common.require.
+	if d.RequireDeprecated != nil && !d.RequireDeprecated.IsZero() && d.Common.Require.IsZero() {
+		d.Common.Require = *d.RequireDeprecated
+		logx.Deprecated("Renaming 'defaults.service.latest_version.require' to 'defaults.service.latest_version.common.require'")
+	}
+	d.RequireDeprecated = nil
+
+	return d.Common.CheckValues() //nolint:wrapcheck
+}
+
+// applyTypeDefaults assigns the cfg's per-type Soft/Hard defaults onto
+// lookup, based on its concrete type. It is a no-op for unregistered types.
+func applyTypeDefaults(lookup Lookup, cfg DefaultsConfig) {
+	switch v := lookup.(type) {
+	case *github.Lookup:
+		v.SetTypeDefaults(&cfg.Soft.GitHub, &cfg.Hard.GitHub)
+	case *web.Lookup:
+		v.SetTypeDefaults(&cfg.Soft.URL, &cfg.Hard.URL)
+	}
+}

--- a/service/latest_version/defaults_test.go
+++ b/service/latest_version/defaults_test.go
@@ -1,0 +1,562 @@
+// Copyright [2026] [Argus]
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build unit
+
+package latestver
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/release-argus/Argus/config/decode"
+	"github.com/release-argus/Argus/internal/test"
+	"github.com/release-argus/Argus/service/latest_version/filter"
+	"github.com/release-argus/Argus/service/latest_version/filter/docker"
+	"github.com/release-argus/Argus/service/latest_version/types/base"
+	"github.com/release-argus/Argus/service/latest_version/types/github"
+	"github.com/release-argus/Argus/service/latest_version/types/web"
+)
+
+func TestDecodeDefaults(t *testing.T) {
+	// GIVEN: data in a given format to Decode into Defaults.
+	tests := []struct {
+		name         string
+		format, data string
+		want         string
+		errRegex     string
+	}{
+		{
+			name:   "JSON/empty",
+			format: "json",
+			data:   "",
+			want:   "",
+			errRegex: test.TrimYAML(`
+				latest_version:
+					jsontext:
+						unexpected EOF$`,
+			),
+		},
+		{
+			name:     "JSON/empty object",
+			format:   "json",
+			data:     "{}",
+			want:     "{}\n",
+			errRegex: `^$`,
+		},
+		{
+			name:     "YAML/empty",
+			format:   "yaml",
+			data:     "",
+			want:     "{}\n",
+			errRegex: `^$`,
+		},
+		{
+			name:   "YAML/invalid data types",
+			format: "yaml",
+			data:   `type: ['github']`,
+			errRegex: test.TrimYAML(`
+					^latest_version:
+						[^\s]+ cannot unmarshal .* into Go struct field Defaults.Type of type string
+						[^\s]+.*
+						\s+\^$`,
+			),
+		},
+		{
+			name:   "JSON/full",
+			format: "json",
+			data: test.TrimJSON(`{
+				"type": "github",
+				"common": {
+					"require": {
+						"docker": {
+							"type": "hub",
+							"tag": "t"
+						}
+					}
+				},
+				"github": {
+					"access_token": "foo",
+					"use_prerelease": true
+				},
+				"url": {
+					"allow_invalid_certs": true
+				}
+			}`),
+			want: test.TrimYAML(`
+				type: github
+				common:
+					require:
+						docker:
+							type: hub
+							tag: t
+				github:
+					access_token: foo
+					use_prerelease: true
+				url:
+					allow_invalid_certs: true
+			`),
+			errRegex: `^$`,
+		},
+		{
+			name:   "YAML/full",
+			format: "yaml",
+			data: test.TrimYAML(`
+				type: github
+				common:
+					require:
+						docker:
+							type: hub
+							tag: t
+				github:
+					access_token: foo
+					use_prerelease: true
+				url:
+					allow_invalid_certs: true
+			`),
+			want: test.TrimYAML(`
+				type: github
+				common:
+					require:
+						docker:
+							type: hub
+							tag: t
+				github:
+					access_token: foo
+					use_prerelease: true
+				url:
+					allow_invalid_certs: true
+			`),
+			errRegex: `^$`,
+		},
+		{
+			name:   "YAML/deprecated fields decode",
+			format: "yaml",
+			data: test.TrimYAML(`
+				access_token: foo
+				use_prerelease: true
+				allow_invalid_certs: true
+				require:
+					docker:
+						type: hub
+						tag: t
+			`),
+			want: test.TrimYAML(`
+				access_token: foo
+				use_prerelease: true
+				allow_invalid_certs: true
+				require:
+					docker:
+						type: hub
+						tag: t
+			`),
+			errRegex: `^$`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if _, _, testErr := test.AssertDecode(
+				t,
+				DecodeDefaults,
+				tc.format, tc.data,
+				func(v *Defaults) string { return decode.ToYAMLString(v, "") },
+				tc.want,
+				tc.errRegex,
+				packageName,
+				"DecodeDefaults",
+			); testErr != nil {
+				t.Fatal(testErr)
+			}
+		})
+	}
+}
+
+func TestDefaults_IsZero(t *testing.T) {
+	// GIVEN: Defaults.
+	tests := []struct {
+		name string
+		data *Defaults
+		want bool
+	}{
+		{
+			name: "empty",
+			data: &Defaults{},
+			want: true,
+		},
+		{
+			name: "non-empty/Type",
+			data: &Defaults{Type: "github"},
+			want: false,
+		},
+		{
+			name: "non-empty/GitHub",
+			data: &Defaults{GitHub: github.Defaults{AccessToken: "foo"}},
+			want: false,
+		},
+		{
+			name: "non-empty/URL",
+			data: &Defaults{URL: web.Defaults{AllowInvalidCerts: test.Ptr(true)}},
+			want: false,
+		},
+		{
+			name: "non-empty/AccessTokenDeprecated",
+			data: &Defaults{AccessTokenDeprecated: "foo"},
+			want: false,
+		},
+		{
+			name: "non-empty/UsePreReleaseDeprecated",
+			data: &Defaults{UsePreReleaseDeprecated: test.Ptr(true)},
+			want: false,
+		},
+		{
+			name: "non-empty/AllowInvalidCertsDeprecated",
+			data: &Defaults{AllowInvalidCertsDeprecated: test.Ptr(true)},
+			want: false,
+		},
+		{
+			name: "non-empty/RequireDeprecated",
+			data: &Defaults{RequireDeprecated: &filter.RequireDefaults{
+				Docker: docker.Defaults{Type: "hub"},
+			}},
+			want: false,
+		},
+		{
+			name: "non-empty/all",
+			data: &Defaults{
+				Type:                        "github",
+				GitHub:                      github.Defaults{AccessToken: "foo"},
+				URL:                         web.Defaults{AllowInvalidCerts: test.Ptr(true)},
+				AccessTokenDeprecated:       "foo",
+				UsePreReleaseDeprecated:     test.Ptr(true),
+				AllowInvalidCertsDeprecated: test.Ptr(true),
+				RequireDeprecated: &filter.RequireDefaults{
+					Docker: docker.Defaults{Type: "hub"},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// WHEN: IsZero is called.
+			got := tc.data.IsZero()
+
+			// THEN: the result is expected.
+			if got != tc.want {
+				t.Errorf(
+					"%s\nDefaults.IsZero() value mismatch\ngot:  %t\nwant: %t",
+					packageName, got, tc.want,
+				)
+			}
+		})
+	}
+}
+
+func TestDefaults_Default(t *testing.T) {
+	// GIVEN: a Defaults.
+	defaults := Defaults{}
+	want := Defaults{
+		Type: "github",
+		Common: base.Defaults{
+			Require: filter.RequireDefaults{
+				Docker: docker.Defaults{
+					Type: "hub",
+					ContainerDetailDefaults: docker.ContainerDetailDefaults{
+						Tag: "{{ version }}",
+					},
+				},
+			},
+		},
+		GitHub: github.Defaults{
+			UsePreRelease: test.Ptr(false),
+		},
+		URL: web.Defaults{
+			AllowInvalidCerts: test.Ptr(false),
+		},
+	}
+
+	// WHEN: Default is called.
+	defaults.Default()
+
+	wantStr := decode.ToYAMLString(want, "")
+	gotStr := decode.ToYAMLString(defaults, "")
+	// THEN: it should set the defaults as expected - common (Require), and every
+	// registered type's own defaults.
+	if gotStr != wantStr {
+		t.Errorf(
+			"%s\nDefaults.Default() value mismatch\ngot:  %q\nwant: %q",
+			packageName, gotStr, wantStr,
+		)
+	}
+}
+
+func TestDefaults_SetDefaults(t *testing.T) {
+	// GIVEN: Two sets of Defaults.
+	d := &Defaults{}
+	hd := &Defaults{}
+	hd.Default()
+
+	// WHEN: SetDefaults is called on defaults with these other defaults.
+	d.SetDefaults(hd)
+
+	// THEN: the common Require defaults chain to the hard defaults' Require.
+	if d.Common.Require.Docker.Defaults != &hd.Common.Require.Docker {
+		t.Errorf(
+			"%s\nDefaults.SetDefaults() pointer mismatch\ngot:  %p\nwant: %p",
+			packageName, d.Common.Require.Docker.Defaults, &hd.Common.Require.Docker,
+		)
+	}
+}
+
+func TestDefaults_CheckValues(t *testing.T) {
+	// GIVEN: a Defaults, possibly with deprecated fields set.
+	tests := []struct {
+		name                 string
+		input                *Defaults
+		wantAccessToken      string
+		wantUsePreRelease    *bool
+		wantAllowInvalidCert *bool
+		wantRequire          *filter.RequireDefaults
+	}{
+		{
+			name: "access_token migrated to github.access_token",
+			input: &Defaults{
+				AccessTokenDeprecated: "foo",
+			},
+			wantAccessToken: "foo",
+		},
+		{
+			name: "access_token does not override an explicit github.access_token",
+			input: &Defaults{
+				AccessTokenDeprecated: "old",
+				GitHub:                github.Defaults{AccessToken: "new"},
+			},
+			wantAccessToken: "new",
+		},
+		{
+			name: "use_prerelease migrated to github.use_prerelease",
+			input: &Defaults{
+				UsePreReleaseDeprecated: test.Ptr(true),
+			},
+			wantUsePreRelease: test.Ptr(true),
+		},
+		{
+			name: "use_prerelease does not override an explicit github.use_prerelease",
+			input: &Defaults{
+				UsePreReleaseDeprecated: test.Ptr(true),
+				GitHub: github.Defaults{
+					UsePreRelease: test.Ptr(false),
+				},
+			},
+			wantUsePreRelease: test.Ptr(false),
+		},
+		{
+			name: "allow_invalid_certs migrated to url.allow_invalid_certs",
+			input: &Defaults{
+				AllowInvalidCertsDeprecated: test.Ptr(true),
+			},
+			wantAllowInvalidCert: test.Ptr(true),
+		},
+		{
+			name: "allow_invalid_certs does not override an explicit url.allow_invalid_certs",
+			input: &Defaults{
+				AllowInvalidCertsDeprecated: test.Ptr(true),
+				URL:                         web.Defaults{AllowInvalidCerts: test.Ptr(false)},
+			},
+			wantAllowInvalidCert: test.Ptr(false),
+		},
+		{
+			name: "require migrated to common.require",
+			input: &Defaults{
+				RequireDeprecated: &filter.RequireDefaults{
+					Docker: docker.Defaults{
+						Type: "hub",
+					},
+				},
+			},
+			wantRequire: &filter.RequireDefaults{
+				Docker: docker.Defaults{
+					Type: "hub",
+				},
+			},
+		},
+		{
+			name: "require does not override an explicit common.require",
+			input: &Defaults{
+				RequireDeprecated: &filter.RequireDefaults{
+					Docker: docker.Defaults{
+						Type: "hub",
+					},
+				},
+				Common: base.Defaults{
+					Require: filter.RequireDefaults{
+						Docker: docker.Defaults{
+							Type: "ghcr",
+						},
+					},
+				},
+			},
+			wantRequire: &filter.RequireDefaults{
+				Docker: docker.Defaults{
+					Type: "ghcr",
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			prefix := fmt.Sprintf("%s\nDefaults.CheckValues()", packageName)
+
+			// WHEN: CheckValues is called.
+			if err := tc.input.CheckValues(); err != nil {
+				t.Fatalf(
+					"%s unexpected error: %v",
+					prefix, err,
+				)
+			}
+
+			// THEN: the deprecated fields were migrated to their new home.
+			if tc.wantAccessToken != "" && tc.input.GitHub.AccessToken != tc.wantAccessToken {
+				t.Errorf(
+					"%s GitHub.AccessToken mismatch\ngot:  %q\nwant: %q",
+					prefix, tc.input.GitHub.AccessToken, tc.wantAccessToken,
+				)
+			}
+			if tc.wantUsePreRelease != nil {
+				if got, want := test.StringifyPtr(tc.input.GitHub.UsePreRelease), test.StringifyPtr(tc.wantUsePreRelease); got != want {
+					t.Errorf(
+						"%s GitHub.UsePreRelease mismatch\ngot:  %v\nwant: %v",
+						prefix, got, want,
+					)
+				}
+			}
+			if tc.wantAllowInvalidCert != nil {
+				if got, want := test.StringifyPtr(tc.input.URL.AllowInvalidCerts), test.StringifyPtr(tc.wantAllowInvalidCert); got != want {
+					t.Errorf(
+						"%s URL.AllowInvalidCerts mismatch\ngot:  %v\nwant: %v",
+						prefix, got, want,
+					)
+				}
+			}
+			if tc.wantRequire != nil {
+				if got, want := test.StringifyPtr(&tc.input.Common.Require), test.StringifyPtr(tc.wantRequire); got != want {
+					t.Errorf(
+						"%s Require mismatch\ngot:  %v\nwant: %v",
+						prefix, got, want,
+					)
+				}
+			}
+
+			// AND: the deprecated fields were cleared.
+			if tc.input.AccessTokenDeprecated != "" {
+				t.Errorf(
+					"%s AccessTokenDeprecated not cleared: %q",
+					prefix, tc.input.AccessTokenDeprecated)
+			}
+			if tc.input.UsePreReleaseDeprecated != nil {
+				t.Errorf(
+					"%s UsePreReleaseDeprecated not cleared: %v",
+					prefix, tc.input.UsePreReleaseDeprecated)
+			}
+			if tc.input.AllowInvalidCertsDeprecated != nil {
+				t.Errorf(
+					"%s AllowInvalidCertsDeprecated not cleared: %v",
+					prefix, tc.input.AllowInvalidCertsDeprecated)
+			}
+			if tc.input.RequireDeprecated != nil {
+				t.Errorf(
+					"%s RequireDeprecated not cleared: %v",
+					prefix, tc.input.RequireDeprecated)
+			}
+		})
+	}
+}
+
+func TestApplyTypeDefaults(t *testing.T) {
+	// GIVEN: a DefaultsConfig.
+	cfg := DefaultsConfig{
+		Soft: &Defaults{
+			GitHub: github.Defaults{AccessToken: "soft-token"},
+			URL:    web.Defaults{AllowInvalidCerts: test.Ptr(true)},
+		},
+		Hard: &Defaults{
+			GitHub: github.Defaults{AccessToken: "hard-token"},
+			URL:    web.Defaults{AllowInvalidCerts: test.Ptr(false)},
+		},
+	}
+
+	t.Run("github.Lookup gets the GitHub-specific defaults", func(t *testing.T) {
+		// AND: a Lookup of type github.Lookup.
+		lookup := &github.Lookup{}
+
+		// WHEN: applyTypeDefaults is called.
+		applyTypeDefaults(lookup, cfg)
+
+		// THEN: the receiver's type defaults point at the given GitHub defaults.
+		gotSoft, gotHard := lookup.GetTypeDefaults()
+		if gotSoft != &cfg.Soft.GitHub {
+			t.Errorf(
+				"%s\napplyTypeDefaults() Soft pointer mismatch\ngot:  %p\nwant: %p",
+				packageName, gotSoft, &cfg.Soft.GitHub,
+			)
+		}
+		if gotHard != &cfg.Hard.GitHub {
+			t.Errorf(
+				"%s\napplyTypeDefaults() Hard pointer mismatch\ngot:  %p\nwant: %p",
+				packageName, gotHard, &cfg.Hard.GitHub,
+			)
+		}
+	})
+
+	t.Run("web.Lookup gets the URL-specific defaults", func(t *testing.T) {
+		// AND: a Lookup of type web.Lookup.
+		lookup := &web.Lookup{}
+
+		// WHEN: applyTypeDefaults is called.
+		applyTypeDefaults(lookup, cfg)
+
+		// THEN: the receiver's type defaults point at the given URL defaults.
+		gotSoft, gotHard := lookup.GetTypeDefaults()
+		if gotSoft != &cfg.Soft.URL {
+			t.Errorf(
+				"%s\napplyTypeDefaults() Soft pointer mismatch\ngot:  %p\nwant: %p",
+				packageName, gotSoft, &cfg.Soft.URL,
+			)
+		}
+		if gotHard != &cfg.Hard.URL {
+			t.Errorf(
+				"%s\napplyTypeDefaults() Hard pointer mismatch\ngot:  %p\nwant: %p",
+				packageName, gotHard, &cfg.Hard.URL,
+			)
+		}
+	})
+
+	t.Run("unregistered type is a no-op", func(t *testing.T) {
+		// AND: an unregistered Lookup type.
+		lookup := &mockLookup{}
+
+		// WHEN: applyTypeDefaults is called.
+		// THEN: it must not panic for a type with no SetTypeDefaults dispatch.
+		applyTypeDefaults(lookup, cfg)
+	})
+}

--- a/service/latest_version/filter/regex_test.go
+++ b/service/latest_version/filter/regex_test.go
@@ -241,7 +241,7 @@ func TestRequire_RegexCheckContentGitHub(t *testing.T) {
 			releaseDate, err := tc.require.RegexCheckContentGitHub(v, tc.body, logx.LogFrom{})
 
 			prefix := fmt.Sprintf(
-				"%s\nRequire.RegexCheckContentGitHub(version=%q, body=%q)",
+				"%s\nRequire.RegexCheckContentGitHub(version=%q, body=%v)",
 				packageName, v, tc.body,
 			)
 

--- a/service/latest_version/help_test.go
+++ b/service/latest_version/help_test.go
@@ -86,8 +86,12 @@ func testLookup(t *testing.T, typ string, fail bool) (lv Lookup) {
 	lv.Init(
 		lv.GetOptions(),
 		lv.GetStatus(),
-		lvCfg,
+		base.DefaultsConfig{
+			Soft: &lvCfg.Soft.Common,
+			Hard: &lvCfg.Hard.Common,
+		},
 	)
+	applyTypeDefaults(lv, lvCfg)
 	lv.GetStatus().ServiceInfo.ID = "TEST_LV"
 
 	// Check the values.
@@ -142,23 +146,23 @@ func testWeb(t *testing.T, fail bool) Lookup {
 }
 
 // plainDefaultsConfig returns plain defaults and hardDefaults for testing.
-func plainDefaultsConfig(t *testing.T) base.DefaultsConfig {
+func plainDefaultsConfig(t *testing.T) DefaultsConfig {
 	t.Helper()
 
 	optDefaults, _ := opt.DecodeDefaults("yaml", nil)
 	optHardDefaults, _ := opt.DecodeDefaults("yaml", nil)
 	optHardDefaults.Default()
 
-	defaults, _ := base.DecodeDefaults("yaml", nil)
-	defaults.Options = optDefaults
-	hardDefaults, _ := base.DecodeDefaults("yaml", nil)
+	defaults, _ := DecodeDefaults("yaml", nil)
+	defaults.Common.Options = optDefaults
+	hardDefaults, _ := DecodeDefaults("yaml", nil)
 	hardDefaults.Default()
-	hardDefaults.AccessToken = test.GitHubToken(nil)
-	hardDefaults.Options = optHardDefaults
+	hardDefaults.GitHub.AccessToken = test.GitHubToken(nil)
+	hardDefaults.Common.Options = optHardDefaults
 
-	defaults.Require.SetDefaults(&hardDefaults.Require)
+	defaults.Common.Require.SetDefaults(&hardDefaults.Common.Require)
 
-	return base.DefaultsConfig{
+	return DefaultsConfig{
 		Soft: defaults,
 		Hard: hardDefaults,
 	}

--- a/service/latest_version/init_test.go
+++ b/service/latest_version/init_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/release-argus/Argus/internal/test"
+	"github.com/release-argus/Argus/service/latest_version/types/base"
 	opt "github.com/release-argus/Argus/service/option"
 	"github.com/release-argus/Argus/service/status"
 )
@@ -39,7 +40,10 @@ func TestLookup_Init(t *testing.T) {
 	lookup.Init(
 		&options,
 		&svcStatus,
-		lvCfg,
+		base.DefaultsConfig{
+			Soft: &lvCfg.Soft.Common,
+			Hard: &lvCfg.Hard.Common,
+		},
 	)
 
 	prefix := fmt.Sprintf("%s\nLookup.Init()", packageName)
@@ -48,8 +52,8 @@ func TestLookup_Init(t *testing.T) {
 	fieldTests := []test.FieldAssertion{
 		{Name: "Options", Got: lookup.GetOptions(), Want: &options, Mode: test.CompareSamePointer},
 		{Name: "Status", Got: lookup.GetStatus(), Want: &svcStatus, Mode: test.CompareSamePointer},
-		{Name: "Defaults", Got: lookup.GetDefaults(), Want: lvCfg.Soft, Mode: test.CompareSamePointer},
-		{Name: "HardDefaults", Got: lookup.GetHardDefaults(), Want: lvCfg.Hard, Mode: test.CompareSamePointer},
+		{Name: "Defaults", Got: lookup.GetDefaults(), Want: &lvCfg.Soft.Common, Mode: test.CompareSamePointer},
+		{Name: "HardDefaults", Got: lookup.GetHardDefaults(), Want: &lvCfg.Hard.Common, Mode: test.CompareSamePointer},
 	}
 	if err := test.AssertFields(t, fieldTests, prefix, "Lookup"); err != nil {
 		t.Fatal(err)

--- a/service/latest_version/refresh.go
+++ b/service/latest_version/refresh.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/release-argus/Argus/config/decode"
 	"github.com/release-argus/Argus/internal/logx"
-	"github.com/release-argus/Argus/service/latest_version/types/base"
 	"github.com/release-argus/Argus/service/shared"
 	"github.com/release-argus/Argus/util"
 )
@@ -32,6 +31,7 @@ func Refresh(
 	overrides []byte,
 	semanticVersioning *string, // nil, "true", "false", "null" (unchanged, true, false, default).
 	secretRefs *shared.VSecretRef,
+	cfg DefaultsConfig,
 ) (string, bool, error) {
 	if lookup == nil {
 		return "", false, errors.New("lookup is nil")
@@ -56,6 +56,7 @@ func Refresh(
 		overrides,
 		semanticVerDiff,
 		semanticVersioning,
+		cfg,
 	)
 	if err != nil {
 		return "", false, err
@@ -101,16 +102,14 @@ func applyOverridesJSON(
 	overrides []byte,
 	semanticVerDiff bool,
 	semanticVersioning *string, // nil, "true", "false", "null" (unchanged, true, false, default).
+	cfg DefaultsConfig,
 ) (Lookup, error) {
 	newLookup, err := ApplyOverrides(
 		"yaml", overrides,
 		lookup,
 		lookup.GetOptions(),
 		lookup.GetStatus(),
-		base.DefaultsConfig{
-			Soft: lookup.GetDefaults(),
-			Hard: lookup.GetHardDefaults(),
-		},
+		cfg,
 	)
 	if err != nil {
 		return nil, err

--- a/service/latest_version/refresh_integration_test.go
+++ b/service/latest_version/refresh_integration_test.go
@@ -287,6 +287,7 @@ func TestLookup_Refresh(t *testing.T) {
 				tc.args.overrides,
 				tc.args.semanticVersioning,
 				&secretRefs,
+				plainDefaultsConfig(t),
 			)
 
 			prefix := fmt.Sprintf("%s\nRefresh()", packageName)

--- a/service/latest_version/refresh_test.go
+++ b/service/latest_version/refresh_test.go
@@ -181,7 +181,7 @@ func TestApplyOverridesJSON(t *testing.T) {
 								token: pass
 					`)),
 					svcStatus,
-					&lvCfg.Soft.Require,
+					&lvCfg.Soft.Common.Require,
 				)
 			}),
 			wantRequireInherit: true,
@@ -228,7 +228,7 @@ func TestApplyOverridesJSON(t *testing.T) {
 								token: 'pass'
 					`)),
 					svcStatus,
-					&lvCfg.Soft.Require,
+					&lvCfg.Soft.Common.Require,
 				)
 			}),
 			wantRequireInherit: false,
@@ -278,7 +278,7 @@ func TestApplyOverridesJSON(t *testing.T) {
 								token: 'pass'
 					`)),
 					svcStatus,
-					&lvCfg.Soft.Require,
+					&lvCfg.Soft.Common.Require,
 				)
 			}),
 			wantRequireInherit: true,
@@ -316,6 +316,7 @@ func TestApplyOverridesJSON(t *testing.T) {
 				tc.args.overrides,
 				tc.args.semanticVerDiff,
 				tc.args.semanticVersioning,
+				lvCfg,
 			)
 
 			prefix := fmt.Sprintf(

--- a/service/latest_version/test/defaults.go
+++ b/service/latest_version/test/defaults.go
@@ -21,28 +21,28 @@ import (
 	"testing"
 
 	"github.com/release-argus/Argus/internal/test"
-	"github.com/release-argus/Argus/service/latest_version/types/base"
+	latestver "github.com/release-argus/Argus/service/latest_version"
 	opt "github.com/release-argus/Argus/service/option"
 )
 
 // PlainDefaultsConfig returns plain defaults and hardDefaults for testing.
-func PlainDefaultsConfig(t *testing.T) base.DefaultsConfig {
+func PlainDefaultsConfig(t *testing.T) latestver.DefaultsConfig {
 	t.Helper()
 
 	optDefaults, _ := opt.DecodeDefaults("yaml", nil)
 	optHardDefaults, _ := opt.DecodeDefaults("yaml", nil)
 	optHardDefaults.Default()
 
-	defaults, _ := base.DecodeDefaults("yaml", nil)
-	defaults.Options = optDefaults
-	hardDefaults, _ := base.DecodeDefaults("yaml", nil)
+	defaults, _ := latestver.DecodeDefaults("yaml", nil)
+	defaults.Common.Options = optDefaults
+	hardDefaults, _ := latestver.DecodeDefaults("yaml", nil)
 	hardDefaults.Default()
-	hardDefaults.AccessToken = test.GitHubToken(t)
-	hardDefaults.Options = optHardDefaults
+	hardDefaults.GitHub.AccessToken = test.GitHubToken(t)
+	hardDefaults.Common.Options = optHardDefaults
 
-	defaults.Require.SetDefaults(&hardDefaults.Require)
+	defaults.Common.Require.SetDefaults(&hardDefaults.Common.Require)
 
-	return base.DefaultsConfig{
+	return latestver.DefaultsConfig{
 		Soft: defaults,
 		Hard: hardDefaults,
 	}

--- a/service/latest_version/test/defaults_test.go
+++ b/service/latest_version/test/defaults_test.go
@@ -31,8 +31,8 @@ func TestPlainDefaultsConfig(t *testing.T) {
 	}
 
 	// AND: the defaults of the defaults.Require are the hardDefaults.Require.
-	want := &lvCfg.Hard.Require.Docker
-	if got := lvCfg.Soft.Require.Docker.Defaults; got != want {
+	want := &lvCfg.Hard.Common.Require.Docker
+	if got := lvCfg.Soft.Common.Require.Docker.Defaults; got != want {
 		t.Errorf(
 			"%s\nPlainDefaultsConfig() defaults.Require.Default() not set to expected HardDefaults mismatch\ngot:  %p\nwant %p",
 			packageName, got, want,

--- a/service/latest_version/types/base/defaults.go
+++ b/service/latest_version/types/base/defaults.go
@@ -27,32 +27,15 @@ type DefaultsConfig struct {
 	Hard *Defaults
 }
 
-// Defaults are the default values for a Lookup.
+// Defaults are the default values common to Lookup types.
 type Defaults struct {
-	Type              string `json:"type,omitempty" yaml:"type,omitempty"`                               // "github" | "url".
-	AccessToken       string `json:"access_token,omitempty" yaml:"access_token,omitempty"`               // GitHub access token to use.
-	AllowInvalidCerts *bool  `json:"allow_invalid_certs,omitempty" yaml:"allow_invalid_certs,omitempty"` // Default - false = Disallows invalid HTTPS certificates.
-	UsePreRelease     *bool  `json:"use_prerelease,omitempty" yaml:"use_prerelease,omitempty"`           // Whether releases with prerelease tag are considered.
-
 	Options *opt.Defaults          `json:"-" yaml:"-"`                               // Options for the Lookup.
 	Require filter.RequireDefaults `json:"require,omitzero" yaml:"require,omitzero"` // Requirements before release considered valid.
 }
 
 // IsZero implements the yaml.IsZeroer interface.
 func (d Defaults) IsZero() bool {
-	return d.Type == "" &&
-		d.AccessToken == "" &&
-		d.AllowInvalidCerts == nil &&
-		d.UsePreRelease == nil &&
-		d.Require.IsZero()
-}
-
-// DefaultsDecode is an unmarshal-only helper for [Defaults].
-type DefaultsDecode struct {
-	Type              string `json:"type,omitempty" yaml:"type,omitempty"`
-	AccessToken       string `json:"access_token,omitempty" yaml:"access_token,omitempty"`
-	AllowInvalidCerts *bool  `json:"allow_invalid_certs,omitempty" yaml:"allow_invalid_certs,omitempty"`
-	UsePreRelease     *bool  `json:"use_prerelease,omitempty" yaml:"use_prerelease,omitempty"`
+	return d.Require.IsZero()
 }
 
 // DecodeDefaults creates and returns new [Defaults] from format-encoded data.
@@ -71,16 +54,6 @@ func DecodeDefaults(format string, data []byte) (*Defaults, error) {
 
 // Default sets the values of the receiver to their default values.
 func (d *Defaults) Default() {
-	// allow_invalid_certs.
-	allowInvalidCerts := false
-	d.AllowInvalidCerts = &allowInvalidCerts
-	// use_prerelease.
-	usePreRelease := false
-	d.UsePreRelease = &usePreRelease
-
-	// type.
-	d.Type = "github"
-
 	d.Require.Default()
 }
 

--- a/service/latest_version/types/base/defaults_test.go
+++ b/service/latest_version/types/base/defaults_test.go
@@ -39,54 +39,8 @@ func TestDefaults_IsZero(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "non-empty/Type",
-			data: &Defaults{
-				Type: "a",
-			},
-			want: false,
-		},
-		{
-			name: "non-empty/AccessToken",
-			data: &Defaults{
-				AccessToken: "foo",
-			},
-			want: false,
-		},
-		{
-			name: "non-empty/AllowInvalidCerts",
-			data: &Defaults{
-				AllowInvalidCerts: test.Ptr(true),
-			},
-			want: false,
-		},
-		{
-			name: "non-empty/UsePreRelease",
-			data: &Defaults{
-				UsePreRelease: test.Ptr(true),
-			},
-			want: false,
-		},
-		{
 			name: "non-empty/Require",
 			data: &Defaults{
-				Require: filter.RequireDefaults{
-					Docker: *test.Must(t, func() (*docker.Defaults, error) {
-						return docker.DecodeDefaults(
-							"yaml", []byte(`type: ghcr`),
-							nil,
-						)
-					}),
-				},
-			},
-			want: false,
-		},
-		{
-			name: "non-empty/all",
-			data: &Defaults{
-				Type:              "a",
-				AccessToken:       "foo",
-				AllowInvalidCerts: test.Ptr(true),
-				UsePreRelease:     test.Ptr(true),
 				Require: filter.RequireDefaults{
 					Docker: *test.Must(t, func() (*docker.Defaults, error) {
 						return docker.DecodeDefaults(
@@ -154,10 +108,10 @@ func TestDecodeDefaults(t *testing.T) {
 		{
 			name:   "YAML/invalid data types",
 			format: "yaml",
-			data:   `type: ['github']`,
+			data:   `require: ['docker']`,
 			errRegex: test.TrimYAML(`
 					^latest_version:
-						[^\s]+ .*unmarshal.*
+						[^\s]+ sequence was used where mapping is expected
 						[^\s]+.*
 						\s+\^$`,
 			),
@@ -166,20 +120,12 @@ func TestDecodeDefaults(t *testing.T) {
 			name:   "YAML/full",
 			format: "yaml",
 			data: test.TrimYAML(`
-				type: github
-				access_token: foo
-				allow_invalid_certs: false
-				use_prerelease: true
 				foo: bar
 				require:
 					docker:
 						tag: t
 			`),
 			want: test.TrimYAML(`
-				type: github
-				access_token: foo
-				allow_invalid_certs: false
-				use_prerelease: true
 				require:
 					docker:
 						tag: t
@@ -212,9 +158,6 @@ func TestDefaults_Default(t *testing.T) {
 	// GIVEN: a LookupDefault.
 	defaults := Defaults{}
 	want := Defaults{
-		Type:              "github",
-		AllowInvalidCerts: test.Ptr(false),
-		UsePreRelease:     test.Ptr(false),
 		Require: filter.RequireDefaults{
 			Docker: docker.Defaults{
 				Type: "hub",

--- a/service/latest_version/types/base/help_test.go
+++ b/service/latest_version/types/base/help_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/release-argus/Argus/config/decode"
 	"github.com/release-argus/Argus/internal/logx"
-	"github.com/release-argus/Argus/internal/test"
 	logtest "github.com/release-argus/Argus/internal/test/log"
 	opt "github.com/release-argus/Argus/service/option"
 	"github.com/release-argus/Argus/service/status"
@@ -106,7 +105,6 @@ func plainDefaultsConfig(t *testing.T) DefaultsConfig {
 	defaults.Options = optDefaults
 	hardDefaults, _ := DecodeDefaults("yaml", nil)
 	hardDefaults.Default()
-	hardDefaults.AccessToken = test.GitHubToken(t)
 	hardDefaults.Options = optHardDefaults
 
 	defaults.Require.SetDefaults(&hardDefaults.Require)

--- a/service/latest_version/types/github/defaults.go
+++ b/service/latest_version/types/github/defaults.go
@@ -1,0 +1,33 @@
+// Copyright [2026] [Argus]
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package github
+
+// Defaults are the GitHub-specific default values for a Lookup.
+type Defaults struct {
+	AccessToken   string `json:"access_token,omitempty" yaml:"access_token,omitempty"`     // Access token to use.
+	UsePreRelease *bool  `json:"use_prerelease,omitempty" yaml:"use_prerelease,omitempty"` // Whether releases with prerelease tag are considered.
+}
+
+// IsZero implements the yaml.IsZeroer interface.
+func (d Defaults) IsZero() bool {
+	return d.AccessToken == "" &&
+		d.UsePreRelease == nil
+}
+
+// Default sets the values of the receiver to their default values.
+func (d *Defaults) Default() {
+	usePreRelease := false
+	d.UsePreRelease = &usePreRelease
+}

--- a/service/latest_version/types/github/defaults_test.go
+++ b/service/latest_version/types/github/defaults_test.go
@@ -1,0 +1,105 @@
+// Copyright [2026] [Argus]
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build unit
+
+package github
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/release-argus/Argus/internal/test"
+)
+
+func TestDefaults_IsZero(t *testing.T) {
+	// GIVEN: Defaults.
+	tests := []struct {
+		name string
+		data *Defaults
+		want bool
+	}{
+		{
+			name: "empty",
+			data: &Defaults{},
+			want: true,
+		},
+		{
+			name: "non-empty/AccessToken",
+			data: &Defaults{
+				AccessToken: "foo",
+			},
+			want: false,
+		},
+		{
+			name: "non-empty/UsePreRelease",
+			data: &Defaults{
+				UsePreRelease: test.Ptr(true),
+			},
+			want: false,
+		},
+		{
+			name: "non-empty/all",
+			data: &Defaults{
+				AccessToken:   "foo",
+				UsePreRelease: test.Ptr(true),
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// WHEN: IsZero is called.
+			got := tc.data.IsZero()
+
+			// THEN: the result is expected.
+			if got != tc.want {
+				t.Errorf(
+					"%s\nDefaults.IsZero() value mismatch\ngot:  %t\nwant: %t",
+					packageName, got, tc.want,
+				)
+			}
+		})
+	}
+}
+
+func TestDefaults_Default(t *testing.T) {
+	// GIVEN: a Defaults.
+	defaults := Defaults{}
+	want := Defaults{
+		UsePreRelease: test.Ptr(false),
+	}
+
+	// WHEN: Default is called.
+	defaults.Default()
+
+	prefix := fmt.Sprintf("%s\nDefaults.Default()", packageName)
+
+	// THEN: it should set the defaults as expected.
+	if defaults.AccessToken != want.AccessToken {
+		t.Errorf(
+			"%s AccessToken mismatch\ngot:  %q\nwant: %q",
+			prefix, defaults.AccessToken, want.AccessToken,
+		)
+	}
+	if defaults.UsePreRelease == nil || *defaults.UsePreRelease != *want.UsePreRelease {
+		t.Errorf(
+			"%s UsePreRelease mismatch\ngot:  %v\nwant: %v",
+			prefix, defaults.UsePreRelease, want.UsePreRelease,
+		)
+	}
+}

--- a/service/latest_version/types/github/gets.go
+++ b/service/latest_version/types/github/gets.go
@@ -31,8 +31,8 @@ func (l *Lookup) GetType() string {
 func (l *Lookup) accessToken() string {
 	return util.FirstNonDefaultWithEnv(
 		l.AccessToken,
-		l.Defaults.AccessToken,
-		l.HardDefaults.AccessToken,
+		l.typeDefaults.AccessToken,
+		l.typeHardDefaults.AccessToken,
 	)
 }
 
@@ -69,8 +69,8 @@ func (l *Lookup) url(page int) string {
 func (l *Lookup) usePreRelease() bool {
 	return *util.FirstNonDefault(
 		l.UsePreRelease,
-		l.Defaults.UsePreRelease,
-		l.HardDefaults.UsePreRelease,
+		l.typeDefaults.UsePreRelease,
+		l.typeHardDefaults.UsePreRelease,
 	)
 }
 

--- a/service/latest_version/types/github/gets_test.go
+++ b/service/latest_version/types/github/gets_test.go
@@ -92,8 +92,8 @@ func TestLookup_AccessToken(t *testing.T) {
 
 			lookup := testLookup(t, false)
 			lookup.AccessToken = tc.rootValue
-			lookup.Defaults.AccessToken = tc.defaultValue
-			lookup.HardDefaults.AccessToken = tc.hardDefaultValue
+			lookup.typeDefaults.AccessToken = tc.defaultValue
+			lookup.typeHardDefaults.AccessToken = tc.hardDefaultValue
 
 			// WHEN: accessToken is called.
 			got := lookup.accessToken()
@@ -245,8 +245,8 @@ func TestLookup_UsePreRelease(t *testing.T) {
 
 			lookup := testLookup(t, false)
 			lookup.UsePreRelease = tc.rootValue
-			lookup.Defaults.UsePreRelease = tc.defaultValue
-			lookup.HardDefaults.UsePreRelease = tc.hardDefaultValue
+			lookup.typeDefaults.UsePreRelease = tc.defaultValue
+			lookup.typeHardDefaults.UsePreRelease = tc.hardDefaultValue
 
 			// WHEN: usePreRelease is called.
 			result := lookup.usePreRelease()

--- a/service/latest_version/types/github/githubdata.go
+++ b/service/latest_version/types/github/githubdata.go
@@ -45,6 +45,9 @@ func SetEmptyListETag(accessToken string) {
 			Hard: &hardDefaults,
 		},
 	)
+	var typeHardDefaults Defaults
+	typeHardDefaults.Default()
+	lookup.SetTypeDefaults(&Defaults{}, &typeHardDefaults)
 	lookup.AccessToken = accessToken
 
 	// Fallback to /tags to stop the /tags fallback query if on /releases.

--- a/service/latest_version/types/github/help_test.go
+++ b/service/latest_version/types/github/help_test.go
@@ -140,6 +140,13 @@ func testLookup(t *testing.T, failing bool) *Lookup {
 		svcStatus,
 		lvCfg,
 	)
+
+	typeHardDefaults := &Defaults{
+		AccessToken: test.GitHubToken(t),
+	}
+	typeHardDefaults.Default()
+	lookup.SetTypeDefaults(&Defaults{}, typeHardDefaults)
+
 	if failing {
 		lookup.AccessToken = "invalid"
 	}
@@ -159,7 +166,6 @@ func plainDefaultsConfig(t *testing.T) base.DefaultsConfig {
 	defaults.Options = optDefaults
 	hardDefaults, _ := base.DecodeDefaults("yaml", nil)
 	hardDefaults.Default()
-	hardDefaults.AccessToken = test.GitHubToken(t)
 	hardDefaults.Options = optHardDefaults
 
 	defaults.Require.SetDefaults(&hardDefaults.Require)

--- a/service/latest_version/types/github/query.go
+++ b/service/latest_version/types/github/query.go
@@ -215,7 +215,7 @@ func (l *Lookup) handleStatusOK(resp *http.Response, body []byte, logFrom logx.L
 
 	// []byte{91, 93} == []byte("[]") == empty JSON array.
 	if len(body) == 2 && bytes.Equal(body, []byte{91, 93}) {
-		defaultAccessToken := util.FirstNonDefaultWithEnv(l.Defaults.AccessToken, l.HardDefaults.AccessToken)
+		defaultAccessToken := util.FirstNonDefaultWithEnv(l.typeDefaults.AccessToken, l.typeHardDefaults.AccessToken)
 		firstPage := !strings.HasPrefix(resp.Request.URL.RawQuery, "page=")
 		// Update the default empty list ETag if we used the default access_token.
 		if firstPage && (l.AccessToken == "" || l.accessToken() == defaultAccessToken) {

--- a/service/latest_version/types/github/query_integration_test.go
+++ b/service/latest_version/types/github/query_integration_test.go
@@ -327,7 +327,7 @@ func TestLookup_Query(t *testing.T) {
 			overrides: `access_token: null`,
 			semVer:    true,
 			want: want{
-				errRegex: `^$`,
+				errRegex: `^$|rate limit reached for GitHub`,
 			},
 		},
 	}
@@ -344,7 +344,7 @@ func TestLookup_Query(t *testing.T) {
 				temporaryFailureInNameResolution = false
 				lookup := testLookup(t, false)
 				if strings.Contains(tc.overrides, "access_token: null") {
-					lookup.HardDefaults.AccessToken = ""
+					lookup.typeHardDefaults.AccessToken = ""
 				}
 				lookup.Status.ServiceInfo.ID = tc.name
 				if err := lookup.ApplyOverrides("yaml", []byte(tc.overrides)); err != nil {
@@ -388,7 +388,7 @@ func TestLookup_Query(t *testing.T) {
 					}
 					t.Fatalf(
 						"%s error mismatch\ngot:  %q\nwant: %q",
-						prefix, tc.want.errRegex, e,
+						prefix, e, tc.want.errRegex,
 					)
 				}
 

--- a/service/latest_version/types/github/query_test.go
+++ b/service/latest_version/types/github/query_test.go
@@ -398,8 +398,8 @@ func TestLookup_HandleResponse(t *testing.T) {
 				}
 				lookup.AccessToken = lookup.accessToken()
 				if !tc.conditions.hadDefaultAccessToken {
-					lookup.Defaults.AccessToken = ""
-					lookup.HardDefaults.AccessToken = "Something"
+					lookup.typeDefaults.AccessToken = ""
+					lookup.typeHardDefaults.AccessToken = "Something"
 				}
 				if tc.lookupSetup != nil {
 					tc.lookupSetup(lookup)

--- a/service/latest_version/types/github/types.go
+++ b/service/latest_version/types/github/types.go
@@ -40,6 +40,9 @@ type Lookup struct {
 	UsePreRelease *bool  `json:"use_prerelease,omitempty" yaml:"use_prerelease,omitempty"` // Whether releases with the prerelease tag should be considered.
 
 	data Data // GitHub Conditional Request vars / Releases.
+
+	typeDefaults     *Defaults // GitHub-specific Defaults.
+	typeHardDefaults *Defaults // GitHub-specific Hard Defaults.
 }
 
 // LookupDecode is an unmarshal-only helper for [Lookup].
@@ -124,10 +127,12 @@ func (l *Lookup) Clone(svcStatus *status.Status) *Lookup {
 	}
 
 	return &Lookup{
-		Lookup:        *l.Lookup.Clone(svcStatus), //nolint:staticcheck
-		AccessToken:   l.AccessToken,
-		UsePreRelease: usePreRelease,
-		data:          *l.data.Copy(),
+		Lookup:           *l.Lookup.Clone(svcStatus), //nolint:staticcheck
+		AccessToken:      l.AccessToken,
+		UsePreRelease:    usePreRelease,
+		data:             *l.data.Copy(),
+		typeDefaults:     l.typeDefaults,
+		typeHardDefaults: l.typeHardDefaults,
 	}
 }
 
@@ -137,4 +142,19 @@ func (l *Lookup) Copy(svcStatus *status.Status) base.Interface {
 		return got
 	}
 	return nil
+}
+
+// ############
+// # DEFAULTS #
+// ############
+
+// SetTypeDefaults assigns the GitHub-specific Defaults/HardDefaults to the receiver.
+func (l *Lookup) SetTypeDefaults(defaults, hardDefaults *Defaults) {
+	l.typeDefaults = defaults
+	l.typeHardDefaults = hardDefaults
+}
+
+// GetTypeDefaults returns the receiver's GitHub-specific Defaults/HardDefaults.
+func (l *Lookup) GetTypeDefaults() (defaults, hardDefaults *Defaults) {
+	return l.typeDefaults, l.typeHardDefaults
 }

--- a/service/latest_version/types/github/types_test.go
+++ b/service/latest_version/types/github/types_test.go
@@ -352,6 +352,10 @@ func TestLookup_Copy(t *testing.T) {
 						},
 						tagFallback: true,
 					}
+					lv.SetTypeDefaults(
+						&Defaults{AccessToken: "soft"},
+						&Defaults{AccessToken: "hard"},
+					)
 				}
 
 				return lv, err
@@ -450,9 +454,63 @@ func TestLookup_Copy(t *testing.T) {
 			err = []test.FieldAssertion{
 				{Name: "Defaults", Got: got.Defaults, Want: tc.lookup.Defaults, Mode: test.CompareSamePointer},
 				{Name: "HardDefaults", Got: got.HardDefaults, Want: tc.lookup.HardDefaults, Mode: test.CompareSamePointer},
+				{Name: "typeDefaults", Got: got.typeDefaults, Want: tc.lookup.typeDefaults, Mode: test.CompareSamePointer},
+				{Name: "typeHardDefaults", Got: got.typeHardDefaults, Want: tc.lookup.typeHardDefaults, Mode: test.CompareSamePointer},
 			}
 			if testErr := test.AssertFields(t, err, prefix, "Lookup"); testErr != nil {
 				t.Fatal(testErr)
+			}
+		})
+	}
+}
+
+// ############
+// # DEFAULTS #
+// ############
+
+func TestLookup_TypeDefaults(t *testing.T) {
+	// GIVEN: a Lookup and a pair of type-specific Defaults.
+	tests := []struct {
+		name         string
+		defaults     *Defaults
+		hardDefaults *Defaults
+	}{
+		{
+			name:         "nil, nil",
+			defaults:     nil,
+			hardDefaults: nil,
+		},
+		{
+			name:         "non-nil, non-nil",
+			defaults:     &Defaults{AccessToken: "soft"},
+			hardDefaults: &Defaults{AccessToken: "hard"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			lookup := &Lookup{}
+
+			// WHEN: SetTypeDefaults is called.
+			lookup.SetTypeDefaults(tc.defaults, tc.hardDefaults)
+
+			prefix := fmt.Sprintf("%s\nLookup.GetTypeDefaults()", packageName)
+
+			// THEN: GetTypeDefaults returns the exact pointers that were set.
+			gotDefaults, gotHardDefaults := lookup.GetTypeDefaults()
+			if gotDefaults != tc.defaults {
+				t.Errorf(
+					"%s Defaults pointer mismatch\ngot:  %p\nwant: %p",
+					prefix, gotDefaults, tc.defaults,
+				)
+			}
+			if gotHardDefaults != tc.hardDefaults {
+				t.Errorf(
+					"%s HardDefaults pointer mismatch\ngot:  %p\nwant: %p",
+					prefix, gotHardDefaults, tc.hardDefaults,
+				)
 			}
 		})
 	}

--- a/service/latest_version/types/web/defaults.go
+++ b/service/latest_version/types/web/defaults.go
@@ -12,23 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package web provides a web-based lookup type.
 package web
 
-import (
-	"github.com/release-argus/Argus/util"
-)
-
-// GetType returns the type of the receiver.
-func (l *Lookup) GetType() string {
-	return Type
+// Defaults are the URL-specific default values for a Lookup.
+type Defaults struct {
+	AllowInvalidCerts *bool `json:"allow_invalid_certs,omitempty" yaml:"allow_invalid_certs,omitempty"` // Default - false = Disallows invalid HTTPS certificates.
 }
 
-// allowInvalidCerts resolves whether invalid TLS certificates are permitted.
-func (l *Lookup) allowInvalidCerts() bool {
-	return *util.FirstNonNilPtr(
-		l.AllowInvalidCerts,
-		l.typeDefaults.AllowInvalidCerts,
-		l.typeHardDefaults.AllowInvalidCerts,
-	)
+// IsZero implements the yaml.IsZeroer interface.
+func (d Defaults) IsZero() bool {
+	return d.AllowInvalidCerts == nil
+}
+
+// Default sets the values of the receiver to their default values.
+func (d *Defaults) Default() {
+	allowInvalidCerts := false
+	d.AllowInvalidCerts = &allowInvalidCerts
 }

--- a/service/latest_version/types/web/defaults_test.go
+++ b/service/latest_version/types/web/defaults_test.go
@@ -1,0 +1,81 @@
+// Copyright [2026] [Argus]
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build unit
+
+package web
+
+import (
+	"testing"
+
+	"github.com/release-argus/Argus/internal/test"
+)
+
+func TestDefaults_IsZero(t *testing.T) {
+	// GIVEN: Defaults.
+	tests := []struct {
+		name string
+		data *Defaults
+		want bool
+	}{
+		{
+			name: "empty",
+			data: &Defaults{},
+			want: true,
+		},
+		{
+			name: "non-empty/AllowInvalidCerts",
+			data: &Defaults{
+				AllowInvalidCerts: test.Ptr(true),
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// WHEN: IsZero is called.
+			got := tc.data.IsZero()
+
+			// THEN: the result is expected.
+			if got != tc.want {
+				t.Errorf(
+					"%s\nDefaults.IsZero() value mismatch\ngot:  %t\nwant: %t",
+					packageName, got, tc.want,
+				)
+			}
+		})
+	}
+}
+
+func TestDefaults_Default(t *testing.T) {
+	// GIVEN: a Defaults.
+	defaults := Defaults{}
+	want := Defaults{
+		AllowInvalidCerts: test.Ptr(false),
+	}
+
+	// WHEN: Default is called.
+	defaults.Default()
+
+	// THEN: it should set the defaults as expected.
+	if defaults.AllowInvalidCerts == nil || *defaults.AllowInvalidCerts != *want.AllowInvalidCerts {
+		t.Errorf(
+			"%s\nDefaults.Default() AllowInvalidCerts mismatch\ngot:  %v\nwant: %v",
+			packageName, defaults.AllowInvalidCerts, want.AllowInvalidCerts,
+		)
+	}
+}

--- a/service/latest_version/types/web/gets_test.go
+++ b/service/latest_version/types/web/gets_test.go
@@ -90,8 +90,8 @@ func TestLookup_AllowInvalidCerts(t *testing.T) {
 
 			lookup := testLookup(t, false)
 			lookup.AllowInvalidCerts = tc.rootValue
-			lookup.Defaults.AllowInvalidCerts = tc.defaultValue
-			lookup.HardDefaults.AllowInvalidCerts = tc.hardDefaultValue
+			lookup.typeDefaults.AllowInvalidCerts = tc.defaultValue
+			lookup.typeHardDefaults.AllowInvalidCerts = tc.hardDefaultValue
 
 			// WHEN: allowInvalidCerts is called.
 			got := lookup.allowInvalidCerts()

--- a/service/latest_version/types/web/help_test.go
+++ b/service/latest_version/types/web/help_test.go
@@ -90,6 +90,10 @@ func testLookup(t *testing.T, failing bool) *Lookup {
 		lvCfg,
 	)
 
+	var typeHardDefaults Defaults
+	typeHardDefaults.Default()
+	lookup.SetTypeDefaults(&Defaults{}, &typeHardDefaults)
+
 	if failing {
 		*lookup.AllowInvalidCerts = false
 	}
@@ -109,7 +113,6 @@ func plainDefaultsConfig(t *testing.T) base.DefaultsConfig {
 	defaults.Options = optDefaults
 	hardDefaults, _ := base.DecodeDefaults("yaml", nil)
 	hardDefaults.Default()
-	hardDefaults.AccessToken = test.GitHubToken(t)
 	hardDefaults.Options = optHardDefaults
 
 	defaults.Require.SetDefaults(&hardDefaults.Require)

--- a/service/latest_version/types/web/types.go
+++ b/service/latest_version/types/web/types.go
@@ -39,6 +39,9 @@ type Lookup struct {
 
 	AllowInvalidCerts *bool          `json:"allow_invalid_certs,omitempty" yaml:"allow_invalid_certs,omitempty"` // Allow invalid SSL certificates.
 	Headers           shared.Headers `json:"headers,omitempty" yaml:"headers,omitempty"`                         // OPTIONAL: request headers.
+
+	typeDefaults     *Defaults // URL-specific Defaults.
+	typeHardDefaults *Defaults // URL-specific Hard Defaults.
 }
 
 // LookupDecode is an unmarshal-only helper for [Lookup].
@@ -124,6 +127,8 @@ func (l *Lookup) Clone(svcStatus *status.Status) *Lookup {
 		Lookup:            *l.Lookup.Clone(svcStatus), //nolint:staticcheck
 		AllowInvalidCerts: l.AllowInvalidCerts,
 		Headers:           l.Headers.Copy(),
+		typeDefaults:      l.typeDefaults,
+		typeHardDefaults:  l.typeHardDefaults,
 	}
 }
 
@@ -142,4 +147,19 @@ func (l *Lookup) InheritSecrets(otherLookup base.BaseInterface, secretRefs *shar
 	}
 
 	l.Lookup.InheritSecrets(otherLookup, secretRefs)
+}
+
+// ############
+// # DEFAULTS #
+// ############
+
+// SetTypeDefaults assigns the URL-specific Defaults/HardDefaults to the receiver.
+func (l *Lookup) SetTypeDefaults(defaults, hardDefaults *Defaults) {
+	l.typeDefaults = defaults
+	l.typeHardDefaults = hardDefaults
+}
+
+// GetTypeDefaults returns the receiver's URL-specific Defaults/HardDefaults.
+func (l *Lookup) GetTypeDefaults() (defaults, hardDefaults *Defaults) {
+	return l.typeDefaults, l.typeHardDefaults
 }

--- a/service/latest_version/types/web/types_test.go
+++ b/service/latest_version/types/web/types_test.go
@@ -310,7 +310,7 @@ func TestLookup_Copy(t *testing.T) {
 			name: "filled",
 			lookup: test.Must(t, func() (*Lookup, error) {
 				svcStatus, _ := statustest.New("yaml", nil)
-				return Decode(
+				lv, err := Decode(
 					"yaml", []byte(test.TrimYAML(`
 						type: test
 						url: https://example.com
@@ -341,6 +341,14 @@ func TestLookup_Copy(t *testing.T) {
 					svcStatus,
 					lvCfg,
 				)
+				if err == nil {
+					lv.SetTypeDefaults(
+						&Defaults{AllowInvalidCerts: test.Ptr(true)},
+						&Defaults{AllowInvalidCerts: test.Ptr(false)},
+					)
+				}
+
+				return lv, err
 			}),
 			status: test.Must(t, func() (*status.Status, error) {
 				return statustest.New("yaml", nil)
@@ -436,6 +444,8 @@ func TestLookup_Copy(t *testing.T) {
 			err = []test.FieldAssertion{
 				{Name: "Defaults", Got: got.Defaults, Want: tc.lookup.Defaults, Mode: test.CompareSamePointer},
 				{Name: "HardDefaults", Got: got.HardDefaults, Want: tc.lookup.HardDefaults, Mode: test.CompareSamePointer},
+				{Name: "typeDefaults", Got: got.typeDefaults, Want: tc.lookup.typeDefaults, Mode: test.CompareSamePointer},
+				{Name: "typeHardDefaults", Got: got.typeHardDefaults, Want: tc.lookup.typeHardDefaults, Mode: test.CompareSamePointer},
 			}
 			if testErr := test.AssertFields(t, err, prefix, "Lookup"); testErr != nil {
 				t.Fatal(testErr)
@@ -558,6 +568,58 @@ func TestLookup_InheritSecrets(t *testing.T) {
 			if got := tc.lookup.String(""); got != tc.want {
 				t.Errorf("%s\nLookup.InheritSecrets(secrets=%+v) mismatch\ngot:  %q\nwant: %q",
 					packageName, tc.secretRefs, got, tc.want,
+				)
+			}
+		})
+	}
+}
+
+// ############
+// # DEFAULTS #
+// ############
+
+func TestLookup_TypeDefaults(t *testing.T) {
+	// GIVEN: a Lookup and a pair of type-specific Defaults.
+	tests := []struct {
+		name         string
+		defaults     *Defaults
+		hardDefaults *Defaults
+	}{
+		{
+			name:         "nil, nil",
+			defaults:     nil,
+			hardDefaults: nil,
+		},
+		{
+			name:         "non-nil, non-nil",
+			defaults:     &Defaults{AllowInvalidCerts: test.Ptr(true)},
+			hardDefaults: &Defaults{AllowInvalidCerts: test.Ptr(false)},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			lookup := &Lookup{}
+
+			// WHEN: SetTypeDefaults is called.
+			lookup.SetTypeDefaults(tc.defaults, tc.hardDefaults)
+
+			prefix := fmt.Sprintf("%s\nLookup.GetTypeDefaults()", packageName)
+
+			// THEN: GetTypeDefaults returns the exact pointers that were set.
+			gotDefaults, gotHardDefaults := lookup.GetTypeDefaults()
+			if gotDefaults != tc.defaults {
+				t.Errorf(
+					"%s Defaults pointer mismatch\ngot:  %p\nwant: %p",
+					prefix, gotDefaults, tc.defaults,
+				)
+			}
+			if gotHardDefaults != tc.hardDefaults {
+				t.Errorf(
+					"%s HardDefaults pointer mismatch\ngot:  %p\nwant: %p",
+					prefix, gotHardDefaults, tc.hardDefaults,
 				)
 			}
 		})

--- a/service/latest_version/types_test.go
+++ b/service/latest_version/types_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/release-argus/Argus/internal/test"
-	"github.com/release-argus/Argus/service/latest_version/types/base"
 	"github.com/release-argus/Argus/service/latest_version/types/web"
 )
 
@@ -41,25 +40,21 @@ func TestIsEqual(t *testing.T) {
 		},
 		{
 			name: "defaults ignored",
-			a: &web.Lookup{
-				Lookup: base.Lookup{
-					Defaults: &base.Defaults{
-						AllowInvalidCerts: test.Ptr(false),
-					},
-				},
-			},
+			a: func() Lookup {
+				l := &web.Lookup{}
+				l.SetTypeDefaults(&web.Defaults{AllowInvalidCerts: test.Ptr(false)}, nil)
+				return l
+			}(),
 			b:    &web.Lookup{},
 			want: true,
 		},
 		{
 			name: "hard_defaults ignored",
-			a: &web.Lookup{
-				Lookup: base.Lookup{
-					Defaults: &base.Defaults{
-						AllowInvalidCerts: test.Ptr(false),
-					},
-				},
-			},
+			a: func() Lookup {
+				l := &web.Lookup{}
+				l.SetTypeDefaults(nil, &web.Defaults{AllowInvalidCerts: test.Ptr(false)})
+				return l
+			}(),
 			b:    &web.Lookup{},
 			want: true,
 		},

--- a/service/types.go
+++ b/service/types.go
@@ -23,7 +23,6 @@ import (
 	deployedver "github.com/release-argus/Argus/service/deployed_version"
 	dvbase "github.com/release-argus/Argus/service/deployed_version/types/base"
 	latestver "github.com/release-argus/Argus/service/latest_version"
-	lvbase "github.com/release-argus/Argus/service/latest_version/types/base"
 	opt "github.com/release-argus/Argus/service/option"
 	"github.com/release-argus/Argus/service/status"
 	"github.com/release-argus/Argus/util"
@@ -204,7 +203,7 @@ func (s *Service) unmarshalLatestVersion(format string, data []byte) error {
 		s.LatestVersion,
 		&s.Options,
 		&s.Status,
-		lvbase.DefaultsConfig{
+		latestver.DefaultsConfig{
 			Soft: &s.Defaults.LatestVersion,
 			Hard: &s.HardDefaults.LatestVersion,
 		},

--- a/service/verify_test.go
+++ b/service/verify_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/release-argus/Argus/internal/test"
 	shoutrrrtest "github.com/release-argus/Argus/notify/shoutrrr/test"
+	latestver "github.com/release-argus/Argus/service/latest_version"
 	"github.com/release-argus/Argus/service/latest_version/filter"
 	"github.com/release-argus/Argus/service/latest_version/filter/docker"
 	lvbase "github.com/release-argus/Argus/service/latest_version/types/base"
@@ -128,7 +129,7 @@ func TestDefaults_CheckValues(t *testing.T) {
 	tests := []struct {
 		name          string
 		options       opt.Defaults
-		latestVersion lvbase.Defaults
+		latestVersion latestver.Defaults
 		errRegex      string
 	}{
 		{
@@ -136,14 +137,16 @@ func TestDefaults_CheckValues(t *testing.T) {
 			options: *test.Must(t, func() (*opt.Defaults, error) {
 				return opt.DecodeDefaults("yaml", []byte("interval: 10s"))
 			}),
-			latestVersion: lvbase.Defaults{
-				Require: filter.RequireDefaults{
-					Docker: *test.Must(t, func() (*docker.Defaults, error) {
-						return docker.DecodeDefaults(
-							"yaml", []byte("type: ghcr"),
-							nil,
-						)
-					}),
+			latestVersion: latestver.Defaults{
+				Common: lvbase.Defaults{
+					Require: filter.RequireDefaults{
+						Docker: *test.Must(t, func() (*docker.Defaults, error) {
+							return docker.DecodeDefaults(
+								"yaml", []byte("type: ghcr"),
+								nil,
+							)
+						}),
+					},
 				},
 			},
 		},
@@ -162,14 +165,16 @@ func TestDefaults_CheckValues(t *testing.T) {
 			options: *test.Must(t, func() (*opt.Defaults, error) {
 				return opt.DecodeDefaults("yaml", []byte("interval: 10s"))
 			}),
-			latestVersion: lvbase.Defaults{
-				Require: filter.RequireDefaults{
-					Docker: *test.Must(t, func() (*docker.Defaults, error) {
-						return docker.DecodeDefaults(
-							"yaml", []byte("type: randomType"),
-							nil,
-						)
-					}),
+			latestVersion: latestver.Defaults{
+				Common: lvbase.Defaults{
+					Require: filter.RequireDefaults{
+						Docker: *test.Must(t, func() (*docker.Defaults, error) {
+							return docker.DecodeDefaults(
+								"yaml", []byte("type: randomType"),
+								nil,
+							)
+						}),
+					},
 				},
 			},
 			errRegex: test.TrimYAML(`
@@ -184,14 +189,16 @@ func TestDefaults_CheckValues(t *testing.T) {
 			options: *test.Must(t, func() (*opt.Defaults, error) {
 				return opt.DecodeDefaults("yaml", []byte("interval: 10x"))
 			}),
-			latestVersion: lvbase.Defaults{
-				Require: filter.RequireDefaults{
-					Docker: *test.Must(t, func() (*docker.Defaults, error) {
-						return docker.DecodeDefaults(
-							"yaml", []byte("type: randomType"),
-							nil,
-						)
-					}),
+			latestVersion: latestver.Defaults{
+				Common: lvbase.Defaults{
+					Require: filter.RequireDefaults{
+						Docker: *test.Must(t, func() (*docker.Defaults, error) {
+							return docker.DecodeDefaults(
+								"yaml", []byte("type: randomType"),
+								nil,
+							)
+						}),
+					},
 				},
 			},
 			errRegex: test.TrimYAML(`

--- a/web/api/types/argus.go
+++ b/web/api/types/argus.go
@@ -462,23 +462,53 @@ func (r *LatestVersion) String() string {
 	return decode.ToJSONString(r)
 }
 
-// LatestVersionDefaults are default values for a LatestVersion.
+// LatestVersionDefaults are default values for a LatestVersion - fields common to
+// every registered type live under 'common', and fields specific to a single type
+// live under that type's own key.
 type LatestVersionDefaults struct {
-	Type              string                        `json:"type,omitempty" yaml:"type,omitempty"`                               // "github" | "url".
-	URL               string                        `json:"url,omitempty" yaml:"url,omitempty"`                                 // URL to query.
-	AccessToken       string                        `json:"access_token,omitempty" yaml:"access_token,omitempty"`               // GitHub access token to use.
-	AllowInvalidCerts *bool                         `json:"allow_invalid_certs,omitempty" yaml:"allow_invalid_certs,omitempty"` // Default - false = Disallows invalid HTTPS certificates.
-	UsePreRelease     *bool                         `json:"use_prerelease,omitempty" yaml:"use_prerelease,omitempty"`           // Whether to use GitHub prereleases.
-	Require           *LatestVersionRequireDefaults `json:"require,omitzero" yaml:"require,omitzero"`
+	Type   string                      `json:"type,omitempty" yaml:"type,omitempty"` // "github" | "url".
+	Common LatestVersionCommonDefaults `json:"common,omitzero" yaml:"common,omitzero"`
+	GitHub LatestVersionGitHubDefaults `json:"github,omitzero" yaml:"github,omitzero"`
+	URL    LatestVersionURLDefaults    `json:"url,omitzero" yaml:"url,omitzero"`
 }
 
 // IsZero implements the yaml.IsZeroer interface.
 func (l LatestVersionDefaults) IsZero() bool {
-	return l.URL == "" &&
-		l.AccessToken == "" &&
-		l.AllowInvalidCerts == nil &&
-		l.UsePreRelease == nil &&
-		(l.Require == nil || l.Require.IsZero())
+	return l.Type == "" &&
+		l.Common.IsZero() &&
+		l.GitHub.IsZero() &&
+		l.URL.IsZero()
+}
+
+// LatestVersionCommonDefaults are default values common to every latest_version type.
+type LatestVersionCommonDefaults struct {
+	Require *LatestVersionRequireDefaults `json:"require,omitzero" yaml:"require,omitzero"`
+}
+
+// IsZero implements the yaml.IsZeroer interface.
+func (l LatestVersionCommonDefaults) IsZero() bool {
+	return l.Require == nil || l.Require.IsZero()
+}
+
+// LatestVersionGitHubDefaults are GitHub-specific default values for a LatestVersion.
+type LatestVersionGitHubDefaults struct {
+	AccessToken   string `json:"access_token,omitempty" yaml:"access_token,omitempty"`     // GitHub access token to use.
+	UsePreRelease *bool  `json:"use_prerelease,omitempty" yaml:"use_prerelease,omitempty"` // Whether to use GitHub prereleases.
+}
+
+// IsZero implements the yaml.IsZeroer interface.
+func (l LatestVersionGitHubDefaults) IsZero() bool {
+	return l.AccessToken == "" && l.UsePreRelease == nil
+}
+
+// LatestVersionURLDefaults are URL-specific default values for a LatestVersion.
+type LatestVersionURLDefaults struct {
+	AllowInvalidCerts *bool `json:"allow_invalid_certs,omitempty" yaml:"allow_invalid_certs,omitempty"` // Default - false = Disallows invalid HTTPS certificates.
+}
+
+// IsZero implements the yaml.IsZeroer interface.
+func (l LatestVersionURLDefaults) IsZero() bool {
+	return l.AllowInvalidCerts == nil
 }
 
 // LatestVersionRequire contains commands, regex, etc. that must pass before considering a release valid.

--- a/web/api/types/argus_test.go
+++ b/web/api/types/argus_test.go
@@ -901,7 +901,9 @@ func TestDefaults_String(t *testing.T) {
 			defaults: &Defaults{
 				Service: ServiceDefaults{
 					LatestVersion: LatestVersionDefaults{
-						AccessToken: "foo",
+						GitHub: LatestVersionGitHubDefaults{
+							AccessToken: "foo",
+						},
 					},
 				},
 				Notify: Notifiers{
@@ -919,7 +921,9 @@ func TestDefaults_String(t *testing.T) {
 				{
 					"service": {
 						"latest_version": {
-							"access_token": "foo"
+							"github": {
+								"access_token": "foo"
+							}
 						}
 					},
 					"notify": {
@@ -1469,7 +1473,7 @@ func TestNotifiers_Flatten(t *testing.T) {
 			// AND: defined fields are censored as expected.
 			for i := range *tc.want {
 				prefix := fmt.Sprintf(
-					"%s\nNotifiers.Flatten() Notify[%q]",
+					"%s\nNotifiers.Flatten() Notify[%d]",
 					packageName, i,
 				)
 
@@ -1739,7 +1743,9 @@ func TestServiceDefaults_IsZero(t *testing.T) {
 			name: "non-empty/LatestVersion",
 			defaults: ServiceDefaults{
 				LatestVersion: LatestVersionDefaults{
-					AccessToken: "hi",
+					GitHub: LatestVersionGitHubDefaults{
+						AccessToken: "hi",
+					},
 				},
 			},
 			want: false,
@@ -1793,7 +1799,9 @@ func TestServiceDefaults_IsZero(t *testing.T) {
 					Interval: "1s",
 				},
 				LatestVersion: LatestVersionDefaults{
-					AccessToken: "hi",
+					GitHub: LatestVersionGitHubDefaults{
+						AccessToken: "hi",
+					},
 				},
 				Notify: []string{"a"},
 				Command: Commands{
@@ -2060,50 +2068,52 @@ func TestLatestVersionDefaults_IsZero(t *testing.T) {
 		want     bool
 	}{
 		{
-			name: "empty",
-			defaults: LatestVersionDefaults{
-				URL:               "",
-				AccessToken:       "",
-				AllowInvalidCerts: nil,
-				UsePreRelease:     nil,
-				Require:           nil,
-			},
-			want: true,
+			name:     "empty",
+			defaults: LatestVersionDefaults{},
+			want:     true,
 		},
 		{
-			name: "non-empty/URL",
+			name: "non-empty/Type",
 			defaults: LatestVersionDefaults{
-				URL: "a",
+				Type: "github",
 			},
 			want: false,
 		},
 		{
-			name: "non-empty/AccessToken",
+			name: "non-empty/GitHub.AccessToken",
 			defaults: LatestVersionDefaults{
-				AccessToken: "a",
+				GitHub: LatestVersionGitHubDefaults{
+					AccessToken: "a",
+				},
 			},
 			want: false,
 		},
 		{
-			name: "non-empty/AllowInvalidCerts",
+			name: "non-empty/GitHub.UsePreRelease",
 			defaults: LatestVersionDefaults{
-				AllowInvalidCerts: test.Ptr(false),
+				GitHub: LatestVersionGitHubDefaults{
+					UsePreRelease: test.Ptr(false),
+				},
 			},
 			want: false,
 		},
 		{
-			name: "non-empty/UsePreRelease",
+			name: "non-empty/URL.AllowInvalidCerts",
 			defaults: LatestVersionDefaults{
-				UsePreRelease: test.Ptr(false),
+				URL: LatestVersionURLDefaults{
+					AllowInvalidCerts: test.Ptr(false),
+				},
 			},
 			want: false,
 		},
 		{
-			name: "non-empty/Require",
+			name: "non-empty/Common.Require",
 			defaults: LatestVersionDefaults{
-				Require: &LatestVersionRequireDefaults{
-					Docker: RequireDockerDefaults{
-						Tag: "a",
+				Common: LatestVersionCommonDefaults{
+					Require: &LatestVersionRequireDefaults{
+						Docker: RequireDockerDefaults{
+							Tag: "a",
+						},
 					},
 				},
 			},
@@ -2112,13 +2122,19 @@ func TestLatestVersionDefaults_IsZero(t *testing.T) {
 		{
 			name: "non-empty/all",
 			defaults: LatestVersionDefaults{
-				URL:               "a",
-				AccessToken:       "a",
-				AllowInvalidCerts: test.Ptr(false),
-				UsePreRelease:     test.Ptr(false),
-				Require: &LatestVersionRequireDefaults{
-					Docker: RequireDockerDefaults{
-						Tag: "a",
+				Type: "github",
+				GitHub: LatestVersionGitHubDefaults{
+					AccessToken:   "a",
+					UsePreRelease: test.Ptr(false),
+				},
+				URL: LatestVersionURLDefaults{
+					AllowInvalidCerts: test.Ptr(false),
+				},
+				Common: LatestVersionCommonDefaults{
+					Require: &LatestVersionRequireDefaults{
+						Docker: RequireDockerDefaults{
+							Tag: "a",
+						},
 					},
 				},
 			},

--- a/web/api/v1/convert.go
+++ b/web/api/v1/convert.go
@@ -51,11 +51,17 @@ func convertAndCensorDefaults(input *config.Defaults) apitype.Defaults {
 				SemanticVersioning: input.Service.Options.SemanticVersioning,
 			},
 			LatestVersion: apitype.LatestVersionDefaults{
-				Type:              input.Service.LatestVersion.Type,
-				AccessToken:       util.ValueUnlessZero(input.Service.LatestVersion.AccessToken, util.SecretValue),
-				AllowInvalidCerts: input.Service.LatestVersion.AllowInvalidCerts,
-				UsePreRelease:     input.Service.LatestVersion.UsePreRelease,
-				Require:           convertAndCensorLatestVersionRequireDefaults(&input.Service.LatestVersion.Require),
+				Type: input.Service.LatestVersion.Type,
+				Common: apitype.LatestVersionCommonDefaults{
+					Require: convertAndCensorLatestVersionRequireDefaults(&input.Service.LatestVersion.Common.Require),
+				},
+				GitHub: apitype.LatestVersionGitHubDefaults{
+					AccessToken:   util.ValueUnlessZero(input.Service.LatestVersion.GitHub.AccessToken, util.SecretValue),
+					UsePreRelease: input.Service.LatestVersion.GitHub.UsePreRelease,
+				},
+				URL: apitype.LatestVersionURLDefaults{
+					AllowInvalidCerts: input.Service.LatestVersion.URL.AllowInvalidCerts,
+				},
 			},
 			DeployedVersionLookup: apitype.DeployedVersionLookupDefaults{
 				Type:              input.Service.DeployedVersionLookup.Type,

--- a/web/api/v1/convert_test.go
+++ b/web/api/v1/convert_test.go
@@ -75,7 +75,7 @@ func TestConvertAndCensorDefaults(t *testing.T) {
 			input: &config.Defaults{
 				Service: service.Defaults{
 					Options:               opt.Defaults{},
-					LatestVersion:         lvbase.Defaults{},
+					LatestVersion:         latestver.Defaults{},
 					DeployedVersionLookup: dvbase.Defaults{},
 					Dashboard:             dashboard.Defaults{},
 				},
@@ -84,7 +84,9 @@ func TestConvertAndCensorDefaults(t *testing.T) {
 				Service: apitype.ServiceDefaults{
 					Options: apitype.ServiceOptions{},
 					LatestVersion: apitype.LatestVersionDefaults{
-						Require: &apitype.LatestVersionRequireDefaults{},
+						Common: apitype.LatestVersionCommonDefaults{
+							Require: &apitype.LatestVersionRequireDefaults{},
+						},
 					},
 					Command:               apitype.Commands{},
 					DeployedVersionLookup: apitype.DeployedVersionLookupDefaults{},
@@ -230,60 +232,68 @@ func TestConvertAndCensorDefaults(t *testing.T) {
 			name: "censor service.latest_version",
 			input: &config.Defaults{
 				Service: service.Defaults{
-					LatestVersion: lvbase.Defaults{
-						Type:        "github",
-						AccessToken: "censor",
-						Require: *test.Must(t, func() (*filter.RequireDefaults, error) {
-							return filter.DecodeDefaults(
-								"yaml", []byte(test.TrimYAML(`
-									docker:
-										type: hub
-										tag: t
-										registry:
-											ghcr:
-												auth:
-													username: something
-													token: ghp_X
-											hub:
-												auth:
-													username: something
-													token: hub_X
-											quay:
-												auth:
-													username: something
-													token: quay_X
-								`)),
-							)
-						}),
+					LatestVersion: latestver.Defaults{
+						Type: "github",
+						GitHub: lvgithub.Defaults{
+							AccessToken: "censor",
+						},
+						Common: lvbase.Defaults{
+							Require: *test.Must(t, func() (*filter.RequireDefaults, error) {
+								return filter.DecodeDefaults(
+									"yaml", []byte(test.TrimYAML(`
+										docker:
+											type: hub
+											tag: t
+											registry:
+												ghcr:
+													auth:
+														username: something
+														token: ghp_X
+												hub:
+													auth:
+														username: something
+														token: hub_X
+												quay:
+													auth:
+														username: something
+														token: quay_X
+									`)),
+								)
+							}),
+						},
 					},
 				},
 			},
 			want: apitype.Defaults{
 				Service: apitype.ServiceDefaults{
 					LatestVersion: apitype.LatestVersionDefaults{
-						Type:        "github",
-						AccessToken: util.SecretValue,
-						Require: &apitype.LatestVersionRequireDefaults{
-							Docker: apitype.RequireDockerDefaults{
-								Type: "hub",
-								Tag:  "t",
-								Registry: apitype.RequireDockerRegistriesDefaults{
-									GHCR: &apitype.RequireDockerRegistryDefaultsToken{
-										RequireDockerRegistryDefaultsAuth: apitype.RequireDockerRegistryDefaultsAuth{
-											Token: util.SecretValue,
-										},
-									},
-									Hub: &apitype.RequireDockerCheckRegistryDefaultsTokenWithUsername{
-										RequireDockerRegistryDefaultsAuthWithUsername: apitype.RequireDockerRegistryDefaultsAuthWithUsername{
-											Username: "something",
+						Type: "github",
+						GitHub: apitype.LatestVersionGitHubDefaults{
+							AccessToken: util.SecretValue,
+						},
+						Common: apitype.LatestVersionCommonDefaults{
+							Require: &apitype.LatestVersionRequireDefaults{
+								Docker: apitype.RequireDockerDefaults{
+									Type: "hub",
+									Tag:  "t",
+									Registry: apitype.RequireDockerRegistriesDefaults{
+										GHCR: &apitype.RequireDockerRegistryDefaultsToken{
 											RequireDockerRegistryDefaultsAuth: apitype.RequireDockerRegistryDefaultsAuth{
 												Token: util.SecretValue,
 											},
 										},
-									},
-									Quay: &apitype.RequireDockerRegistryDefaultsToken{
-										RequireDockerRegistryDefaultsAuth: apitype.RequireDockerRegistryDefaultsAuth{
-											Token: util.SecretValue,
+										Hub: &apitype.RequireDockerCheckRegistryDefaultsTokenWithUsername{
+											RequireDockerRegistryDefaultsAuthWithUsername: apitype.RequireDockerRegistryDefaultsAuthWithUsername{
+												Username: "something",
+												RequireDockerRegistryDefaultsAuth: apitype.RequireDockerRegistryDefaultsAuth{
+													Token: util.SecretValue,
+												},
+											},
+										},
+										Quay: &apitype.RequireDockerRegistryDefaultsToken{
+											RequireDockerRegistryDefaultsAuth: apitype.RequireDockerRegistryDefaultsAuth{
+												Token: util.SecretValue,
+											},
 										},
 									},
 								},
@@ -903,7 +913,7 @@ func TestConvertAndCensorLatestVersionRequireDefaults(t *testing.T) {
 
 func TestConvertAndCensorLatestVersionRequire(t *testing.T) {
 	configDefaults, _ := plainDefaults(t)
-	defaults := configDefaults.Service.LatestVersion.Require
+	defaults := configDefaults.Service.LatestVersion.Common.Require
 	// GIVEN: a filter.Require.
 	tests := []struct {
 		name  string
@@ -2463,13 +2473,19 @@ var stringifiedConvertedDefaults = test.TrimJSON(`{
 		},
 		"latest_version": {
 			"type": "github",
-			"allow_invalid_certs": false,
-			"use_prerelease": false,
-			"require": {
-				"docker": {
-					"type": "hub",
-					"tag": "{{ version }}"
+			"common": {
+				"require": {
+					"docker": {
+						"type": "hub",
+						"tag": "{{ version }}"
+					}
 				}
+			},
+			"github": {
+				"use_prerelease": false
+			},
+			"url": {
+				"allow_invalid_certs": false
 			}
 		},
 		"deployed_version": {

--- a/web/api/v1/help_test.go
+++ b/web/api/v1/help_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/release-argus/Argus/config/decode"
 	shoutrrrtest "github.com/release-argus/Argus/notify/shoutrrr/test"
 	dvtest "github.com/release-argus/Argus/service/deployed_version/test"
+	latestver "github.com/release-argus/Argus/service/latest_version"
 	"github.com/release-argus/Argus/service/latest_version/filter"
 	"github.com/release-argus/Argus/service/latest_version/filter/docker"
 	lvtest "github.com/release-argus/Argus/service/latest_version/test"
@@ -122,16 +123,18 @@ func plainDefaults(t *testing.T) (*config.Defaults, *config.Defaults) {
 	)
 	defaults := config.Defaults{
 		Service: service.Defaults{
-			LatestVersion: lvbase.Defaults{
-				Require: filter.RequireDefaults{
-					Docker: *dockerDefaults,
+			LatestVersion: latestver.Defaults{
+				Common: lvbase.Defaults{
+					Require: filter.RequireDefaults{
+						Docker: *dockerDefaults,
+					},
 				},
 			},
 		},
 	}
 	hardDefaults := config.Defaults{}
 	hardDefaults.Default()
-	hardDefaults.Service.LatestVersion.AccessToken = test.GitHubToken(t)
+	hardDefaults.Service.LatestVersion.GitHub.AccessToken = test.GitHubToken(t)
 	defaults.SetDefaults(&hardDefaults)
 
 	return &defaults, &hardDefaults
@@ -164,7 +167,7 @@ func testAPI(t *testing.T, path string) API {
 	testYAML_Argus(path)
 
 	cfg := testLoad(t, path)
-	cfg.HardDefaults.Service.LatestVersion.AccessToken = test.GitHubToken(t)
+	cfg.HardDefaults.Service.LatestVersion.GitHub.AccessToken = test.GitHubToken(t)
 
 	t.Cleanup(func() {
 		_ = os.RemoveAll(cfg.Settings.Data.DatabaseFile)

--- a/web/api/v1/http-api-config.go
+++ b/web/api/v1/http-api-config.go
@@ -49,8 +49,8 @@ func (api *API) httpConfig(w http.ResponseWriter, r *http.Request) {
 		},
 	}
 
-	// Defaults.Service.LatestVersion.Require.
-	serviceLatestVersionRequireDefaults := convertAndCensorLatestVersionRequireDefaults(&api.Config.Defaults.Service.LatestVersion.Require)
+	// Defaults.Service.LatestVersion.Common.Require.
+	serviceLatestVersionRequireDefaults := convertAndCensorLatestVersionRequireDefaults(&api.Config.Defaults.Service.LatestVersion.Common.Require)
 	// Defaults.Service.Notify.
 	serviceNotifyDefaults := util.SortedKeys(api.Config.Defaults.Service.Notify)
 	// Defaults.Service.Command.
@@ -76,10 +76,17 @@ func (api *API) httpConfig(w http.ResponseWriter, r *http.Request) {
 				AutoApprove: api.Config.Defaults.Service.Dashboard.AutoApprove,
 			},
 			LatestVersion: apitype.LatestVersionDefaults{
-				AccessToken:       util.ValueUnlessZero(api.Config.Defaults.Service.LatestVersion.AccessToken, util.SecretValue),
-				AllowInvalidCerts: api.Config.Defaults.Service.LatestVersion.AllowInvalidCerts,
-				UsePreRelease:     api.Config.Defaults.Service.LatestVersion.UsePreRelease,
-				Require:           serviceLatestVersionRequireDefaults,
+				Type: api.Config.Defaults.Service.LatestVersion.Type,
+				Common: apitype.LatestVersionCommonDefaults{
+					Require: serviceLatestVersionRequireDefaults,
+				},
+				GitHub: apitype.LatestVersionGitHubDefaults{
+					AccessToken:   util.ValueUnlessZero(api.Config.Defaults.Service.LatestVersion.GitHub.AccessToken, util.SecretValue),
+					UsePreRelease: api.Config.Defaults.Service.LatestVersion.GitHub.UsePreRelease,
+				},
+				URL: apitype.LatestVersionURLDefaults{
+					AllowInvalidCerts: api.Config.Defaults.Service.LatestVersion.URL.AllowInvalidCerts,
+				},
 			},
 			Notify:  serviceNotifyDefaults,
 			Command: serviceCommandDefaults,

--- a/web/api/v1/http-api-config_test.go
+++ b/web/api/v1/http-api-config_test.go
@@ -33,6 +33,8 @@ import (
 	"github.com/release-argus/Argus/service/latest_version/filter"
 	lvtest "github.com/release-argus/Argus/service/latest_version/test"
 	lvbase "github.com/release-argus/Argus/service/latest_version/types/base"
+	lvgithub "github.com/release-argus/Argus/service/latest_version/types/github"
+	lvweb "github.com/release-argus/Argus/service/latest_version/types/web"
 	opt "github.com/release-argus/Argus/service/option"
 	"github.com/release-argus/Argus/webhook"
 )
@@ -99,32 +101,39 @@ func TestHTTP_Config(t *testing.T) {
 							Interval: "1h",
 						},
 					},
-					LatestVersion: lvbase.Defaults{
-						AccessToken:       "foo",
-						AllowInvalidCerts: test.Ptr(true),
-						UsePreRelease:     test.Ptr(false),
-						Require: *test.Must(t, func() (*filter.RequireDefaults, error) {
-							return filter.DecodeDefaults(
-								"yaml", []byte(test.TrimYAML(`
-									docker:
-										type: hub
-										tag: t
-										registry:
-											ghcr:
-												auth:
-													username: something
-													token: ghp_X
-											hub:
-												auth:
-													username: something
-													token: hub_X
-											quay:
-												auth:
-													username: something
-													token: quay_X
-								`)),
-							)
-						}),
+					LatestVersion: latestver.Defaults{
+						Type: "github",
+						GitHub: lvgithub.Defaults{
+							AccessToken:   "foo",
+							UsePreRelease: test.Ptr(false),
+						},
+						URL: lvweb.Defaults{
+							AllowInvalidCerts: test.Ptr(true),
+						},
+						Common: lvbase.Defaults{
+							Require: *test.Must(t, func() (*filter.RequireDefaults, error) {
+								return filter.DecodeDefaults(
+									"yaml", []byte(test.TrimYAML(`
+										docker:
+											type: hub
+											tag: t
+											registry:
+												ghcr:
+													auth:
+														username: something
+														token: ghp_X
+												hub:
+													auth:
+														username: something
+														token: hub_X
+												quay:
+													auth:
+														username: something
+														token: quay_X
+									`)),
+								)
+							}),
+						},
 					},
 				},
 			},
@@ -141,32 +150,39 @@ func TestHTTP_Config(t *testing.T) {
 								"interval": "1h"
 							},
 							"latest_version": {
-								"access_token": ` + secretValueMarshaled + `,
-								"allow_invalid_certs": true,
-								"use_prerelease": false,
-								"require": {
-									"docker": {
-										"type": "hub",
-										"tag": "t",
-										"registry": {
-											"ghcr": {
-												"auth": {
-													"token": ` + secretValueMarshaled + `
-												}
-											},
-											"hub": {
-												"auth": {
-													"username": "something",
-													"token": ` + secretValueMarshaled + `
-												}
-											},
-											"quay": {
-												"auth": {
-													"token": ` + secretValueMarshaled + `
+								"type": "github",
+								"common": {
+									"require": {
+										"docker": {
+											"type": "hub",
+											"tag": "t",
+											"registry": {
+												"ghcr": {
+													"auth": {
+														"token": ` + secretValueMarshaled + `
+													}
+												},
+												"hub": {
+													"auth": {
+														"username": "something",
+														"token": ` + secretValueMarshaled + `
+													}
+												},
+												"quay": {
+													"auth": {
+														"token": ` + secretValueMarshaled + `
+													}
 												}
 											}
 										}
 									}
+								},
+								"github": {
+									"access_token": ` + secretValueMarshaled + `,
+									"use_prerelease": false
+								},
+								"url": {
+									"allow_invalid_certs": true
 								}
 							}
 						}
@@ -189,32 +205,38 @@ func TestHTTP_Config(t *testing.T) {
 							Interval: "1h",
 						},
 					},
-					LatestVersion: lvbase.Defaults{
-						AccessToken:       "foo",
-						AllowInvalidCerts: test.Ptr(true),
-						UsePreRelease:     test.Ptr(false),
-						Require: *test.Must(t, func() (*filter.RequireDefaults, error) {
-							return filter.DecodeDefaults(
-								"yaml", []byte(test.TrimYAML(`
-									docker:
-										type: hub
-										tag: t
-										registry:
-											ghcr:
-												auth:
-													username: something
-													token: ghp_X
-											hub:
-												auth:
-													username: something
-													token: hub_X
-											quay:
-												auth:
-													username: something
-													token: quay_X
-								`)),
-							)
-						}),
+					LatestVersion: latestver.Defaults{
+						GitHub: lvgithub.Defaults{
+							AccessToken:   "foo",
+							UsePreRelease: test.Ptr(false),
+						},
+						URL: lvweb.Defaults{
+							AllowInvalidCerts: test.Ptr(true),
+						},
+						Common: lvbase.Defaults{
+							Require: *test.Must(t, func() (*filter.RequireDefaults, error) {
+								return filter.DecodeDefaults(
+									"yaml", []byte(test.TrimYAML(`
+										docker:
+											type: hub
+											tag: t
+											registry:
+												ghcr:
+													auth:
+														username: something
+														token: ghp_X
+												hub:
+													auth:
+														username: something
+														token: hub_X
+												quay:
+													auth:
+														username: something
+														token: quay_X
+									`)),
+								)
+							}),
+						},
 					},
 					Notify: map[string]struct{}{
 						"n1": {},
@@ -243,32 +265,38 @@ func TestHTTP_Config(t *testing.T) {
 								"interval": "1h"
 							},
 							"latest_version": {
-								"access_token": ` + secretValueMarshaled + `,
-								"allow_invalid_certs": true,
-								"use_prerelease": false,
-								"require": {
-									"docker": {
-										"type": "hub",
-										"tag": "t",
-										"registry": {
-											"ghcr": {
-												"auth": {
-													"token": ` + secretValueMarshaled + `
-												}
-											},
-											"hub": {
-												"auth": {
-													"username": "something",
-													"token": ` + secretValueMarshaled + `
-												}
-											},
-											"quay": {
-												"auth": {
-													"token": ` + secretValueMarshaled + `
+								"common": {
+									"require": {
+										"docker": {
+											"type": "hub",
+											"tag": "t",
+											"registry": {
+												"ghcr": {
+													"auth": {
+														"token": ` + secretValueMarshaled + `
+													}
+												},
+												"hub": {
+													"auth": {
+														"username": "something",
+														"token": ` + secretValueMarshaled + `
+													}
+												},
+												"quay": {
+													"auth": {
+														"token": ` + secretValueMarshaled + `
+													}
 												}
 											}
 										}
 									}
+								},
+								"github": {
+									"access_token": ` + secretValueMarshaled + `,
+									"use_prerelease": false
+								},
+								"url": {
+									"allow_invalid_certs": true
 								}
 							},
 							"notify": ["n1"],
@@ -301,32 +329,38 @@ func TestHTTP_Config(t *testing.T) {
 							Interval: "1h",
 						},
 					},
-					LatestVersion: lvbase.Defaults{
-						AccessToken:       "foo",
-						AllowInvalidCerts: test.Ptr(true),
-						UsePreRelease:     test.Ptr(false),
-						Require: *test.Must(t, func() (*filter.RequireDefaults, error) {
-							return filter.DecodeDefaults(
-								"yaml", []byte(test.TrimYAML(`
-									docker:
-										type: hub
-										tag: t
-										registry:
-											ghcr:
-												auth:
-													username: something
-													token: ghp_X
-											hub:
-												auth:
-													username: something
-													token: hub_X
-											quay:
-												auth:
-													username: something
-													token: quay_X
-								`)),
-							)
-						}),
+					LatestVersion: latestver.Defaults{
+						GitHub: lvgithub.Defaults{
+							AccessToken:   "foo",
+							UsePreRelease: test.Ptr(false),
+						},
+						URL: lvweb.Defaults{
+							AllowInvalidCerts: test.Ptr(true),
+						},
+						Common: lvbase.Defaults{
+							Require: *test.Must(t, func() (*filter.RequireDefaults, error) {
+								return filter.DecodeDefaults(
+									"yaml", []byte(test.TrimYAML(`
+										docker:
+											type: hub
+											tag: t
+											registry:
+												ghcr:
+													auth:
+														username: something
+														token: ghp_X
+												hub:
+													auth:
+														username: something
+														token: hub_X
+												quay:
+													auth:
+														username: something
+														token: quay_X
+									`)),
+								)
+							}),
+						},
 					},
 					Notify: map[string]struct{}{
 						"n1": {},
@@ -369,32 +403,38 @@ func TestHTTP_Config(t *testing.T) {
 								"interval": "1h"
 							},
 							"latest_version": {
-								"access_token": ` + secretValueMarshaled + `,
-								"allow_invalid_certs": true,
-								"use_prerelease": false,
-								"require": {
-									"docker": {
-										"type": "hub",
-										"tag": "t",
-										"registry": {
-											"ghcr": {
-												"auth": {
-													"token": ` + secretValueMarshaled + `
-												}
-											},
-											"hub": {
-												"auth": {
-													"username": "something",
-													"token": ` + secretValueMarshaled + `
-												}
-											},
-											"quay": {
-												"auth": {
-													"token": ` + secretValueMarshaled + `
+								"common": {
+									"require": {
+										"docker": {
+											"type": "hub",
+											"tag": "t",
+											"registry": {
+												"ghcr": {
+													"auth": {
+														"token": ` + secretValueMarshaled + `
+													}
+												},
+												"hub": {
+													"auth": {
+														"username": "something",
+														"token": ` + secretValueMarshaled + `
+													}
+												},
+												"quay": {
+													"auth": {
+														"token": ` + secretValueMarshaled + `
+													}
 												}
 											}
 										}
 									}
+								},
+								"github": {
+									"access_token": ` + secretValueMarshaled + `,
+									"use_prerelease": false
+								},
+								"url": {
+									"allow_invalid_certs": true
 								}
 							},
 							"notify": ["n1"],
@@ -456,32 +496,38 @@ func TestHTTP_Config(t *testing.T) {
 								"interval": "1h"
 							},
 							"latest_version": {
-								"access_token": ` + secretValueMarshaled + `,
-								"allow_invalid_certs": true,
-								"use_prerelease": false,
-								"require": {
-									"docker": {
-										"type": "hub",
-										"tag": "t",
-										"registry": {
-											"ghcr": {
-												"auth": {
-													"token": ` + secretValueMarshaled + `
-												}
-											},
-											"hub": {
-												"auth": {
-													"username": "something",
-													"token": ` + secretValueMarshaled + `
-												}
-											},
-											"quay": {
-												"auth": {
-													"token": ` + secretValueMarshaled + `
+								"common": {
+									"require": {
+										"docker": {
+											"type": "hub",
+											"tag": "t",
+											"registry": {
+												"ghcr": {
+													"auth": {
+														"token": ` + secretValueMarshaled + `
+													}
+												},
+												"hub": {
+													"auth": {
+														"username": "something",
+														"token": ` + secretValueMarshaled + `
+													}
+												},
+												"quay": {
+													"auth": {
+														"token": ` + secretValueMarshaled + `
+													}
 												}
 											}
 										}
 									}
+								},
+								"github": {
+									"access_token": ` + secretValueMarshaled + `,
+									"use_prerelease": false
+								},
+								"url": {
+									"allow_invalid_certs": true
 								}
 							},
 							"notify": ["n1"],
@@ -573,32 +619,38 @@ func TestHTTP_Config(t *testing.T) {
 								"interval": "1h"
 							},
 							"latest_version": {
-								"access_token": ` + secretValueMarshaled + `,
-								"allow_invalid_certs": true,
-								"use_prerelease": false,
-								"require": {
-									"docker": {
-										"type": "hub",
-										"tag": "t",
-										"registry": {
-											"ghcr": {
-												"auth": {
-													"token": ` + secretValueMarshaled + `
-												}
-											},
-											"hub": {
-												"auth": {
-													"username": "something",
-													"token": ` + secretValueMarshaled + `
-												}
-											},
-											"quay": {
-												"auth": {
-													"token": ` + secretValueMarshaled + `
+								"common": {
+									"require": {
+										"docker": {
+											"type": "hub",
+											"tag": "t",
+											"registry": {
+												"ghcr": {
+													"auth": {
+														"token": ` + secretValueMarshaled + `
+													}
+												},
+												"hub": {
+													"auth": {
+														"username": "something",
+														"token": ` + secretValueMarshaled + `
+													}
+												},
+												"quay": {
+													"auth": {
+														"token": ` + secretValueMarshaled + `
+													}
 												}
 											}
 										}
 									}
+								},
+								"github": {
+									"access_token": ` + secretValueMarshaled + `,
+									"use_prerelease": false
+								},
+								"url": {
+									"allow_invalid_certs": true
 								}
 							},
 							"notify": ["n1"],

--- a/web/api/v1/http-api-edit.go
+++ b/web/api/v1/http-api-edit.go
@@ -30,7 +30,6 @@ import (
 	deployedver "github.com/release-argus/Argus/service/deployed_version"
 	dvbase "github.com/release-argus/Argus/service/deployed_version/types/base"
 	latestver "github.com/release-argus/Argus/service/latest_version"
-	lvbase "github.com/release-argus/Argus/service/latest_version/types/base"
 	opt "github.com/release-argus/Argus/service/option"
 	"github.com/release-argus/Argus/service/shared"
 	"github.com/release-argus/Argus/service/status"
@@ -80,21 +79,23 @@ func (api *API) httpLatestVersionRefreshUncreated(w http.ResponseWriter, r *http
 	options, _ := opt.Decode(
 		"json", []byte("{}"),
 		opt.DefaultsConfig{
-			Soft: api.Config.Defaults.Service.LatestVersion.Options,
-			Hard: api.Config.HardDefaults.Service.LatestVersion.Options,
+			Soft: api.Config.Defaults.Service.LatestVersion.Common.Options,
+			Hard: api.Config.HardDefaults.Service.LatestVersion.Common.Options,
 		},
 	)
 	options.SemanticVersioning = util.StringToBoolPtr(queryParams.Get("semantic_versioning"))
+
+	lvDefaults := latestver.DefaultsConfig{
+		Soft: &api.Config.Defaults.Service.LatestVersion,
+		Hard: &api.Config.HardDefaults.Service.LatestVersion,
+	}
 
 	// Create the LatestVersionLookup.
 	lv, err := latestver.Decode(
 		"json", []byte(overrides),
 		options,
 		&svcStatus,
-		lvbase.DefaultsConfig{
-			Soft: &api.Config.Defaults.Service.LatestVersion,
-			Hard: &api.Config.HardDefaults.Service.LatestVersion,
-		},
+		lvDefaults,
 	)
 	if err == nil {
 		err = lv.CheckValues()
@@ -110,6 +111,7 @@ func (api *API) httpLatestVersionRefreshUncreated(w http.ResponseWriter, r *http
 	version, _, err := latestver.Refresh(
 		lv,
 		nil, nil, nil,
+		lvDefaults,
 	)
 	if err != nil {
 		failRequest(&w, err, http.StatusBadRequest)
@@ -168,8 +170,8 @@ func (api *API) httpDeployedVersionRefreshUncreated(w http.ResponseWriter, r *ht
 	options, _ := opt.Decode(
 		"json", []byte("{}"),
 		opt.DefaultsConfig{
-			Soft: api.Config.Defaults.Service.LatestVersion.Options,
-			Hard: api.Config.HardDefaults.Service.LatestVersion.Options,
+			Soft: api.Config.Defaults.Service.LatestVersion.Common.Options,
+			Hard: api.Config.HardDefaults.Service.LatestVersion.Common.Options,
 		},
 	)
 	options.SemanticVersioning = util.StringToBoolPtr(queryParams.Get("semantic_versioning"))
@@ -287,6 +289,10 @@ func (api *API) httpLatestVersionRefresh(w http.ResponseWriter, r *http.Request)
 		overrideBytes,
 		semanticVersioning,
 		secretRefs,
+		latestver.DefaultsConfig{
+			Soft: &api.Config.Defaults.Service.LatestVersion,
+			Hard: &api.Config.HardDefaults.Service.LatestVersion,
+		},
 	)
 	if announce {
 		svc.HandleUpdateActions(true)

--- a/web/api/v1/http-api-edit_test.go
+++ b/web/api/v1/http-api-edit_test.go
@@ -2389,7 +2389,7 @@ func TestHTTP_ServiceEdit__edit__secrets(t *testing.T) {
 								- key: X-C
 								  value: c
 					`)),
-					"lv-github",
+					"lv-url",
 					svcCfg,
 					notifyCfg,
 					whCfg,
@@ -2415,7 +2415,7 @@ func TestHTTP_ServiceEdit__edit__secrets(t *testing.T) {
 			wants: wants{
 				statusCode: http.StatusOK,
 				serviceYAML: test.TrimYAML(`
-					name: lv-github
+					name: lv-url
 					comment: foo
 					latest_version:
 						type: url

--- a/web/api/v1/http_test.go
+++ b/web/api/v1/http_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/release-argus/Argus/notify/shoutrrr"
 	"github.com/release-argus/Argus/service"
 	latestver "github.com/release-argus/Argus/service/latest_version"
-	lvbase "github.com/release-argus/Argus/service/latest_version/types/base"
 	"github.com/release-argus/Argus/service/option"
 	statustest "github.com/release-argus/Argus/service/status/test"
 	"github.com/release-argus/Argus/util"
@@ -246,7 +245,7 @@ func TestHTTP_SetupRoutesAPI__disableRoutes(t *testing.T) {
 						"yaml", []byte(`url: `+test.ArgusGitHubRepo),
 						&option.Options{},
 						svcStatus,
-						lvbase.DefaultsConfig{
+						latestver.DefaultsConfig{
 							Soft: &cfg.Defaults.Service.LatestVersion,
 							Hard: &cfg.HardDefaults.Service.LatestVersion,
 						},

--- a/web/ui/package-lock.json
+++ b/web/ui/package-lock.json
@@ -3850,9 +3850,9 @@
 			}
 		},
 		"node_modules/baseline-browser-mapping": {
-			"version": "2.10.40",
-			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
-			"integrity": "sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==",
+			"version": "2.10.42",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.42.tgz",
+			"integrity": "sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
@@ -3908,9 +3908,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001800",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001800.tgz",
-			"integrity": "sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==",
+			"version": "1.0.30001802",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001802.tgz",
+			"integrity": "sha512-vmv8ub2xwTNmljSKf82mtCk5JH7hC+YgzLj3P5zotvA0tPQ9016tdNNOG8WRca1IxOnhSsivB+J0z5FeE5LOUw==",
 			"dev": true,
 			"funding": [
 				{

--- a/web/ui/react-app/src/components/modals/service-edit/latest-version-require.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/latest-version-require.tsx
@@ -4,6 +4,7 @@ import { HelpTooltip } from '@/components/generic';
 import { FieldLabel, FieldSelect, FieldText } from '@/components/generic/field';
 import type { TooltipWithAriaProps } from '@/components/generic/tooltip';
 import Command from '@/components/modals/service-edit/command';
+import { normaliseForSelect } from '@/components/modals/service-edit/util';
 import {
 	Accordion,
 	AccordionContent,
@@ -43,35 +44,24 @@ const EditServiceLatestVersionRequire = () => {
 	const values = useWatch({ name: name }) as LatestVersionRequire;
 
 	const defaults = schemaDataDefaults?.latest_version?.require;
-	const defaultDockerRegistry: RequireDockerFilterDefaults['type'] =
+	const defaultType: RequireDockerFilterDefaults['type'] =
 		defaults?.docker?.type ?? nullString;
 
 	// Add default to docker registry options.
 	const dockerRegistryOptions = useMemo(() => {
-		// No default.
-		if (defaultDockerRegistry === nullString)
-			return latestVersionRequireDockerTypeOptions;
+		const defaultScheme = normaliseForSelect(
+			latestVersionRequireDockerTypeOptions,
+			defaultType,
+		);
 
-		// Find default value.
-		const defaultLower = defaultDockerRegistry.toLowerCase();
-		const defaultDockerRegistryLabel =
-			latestVersionRequireDockerTypeOptions.find(
-				(option) => option.value.toLowerCase() === defaultLower,
-			);
-
-		// Known default registry.
-		if (defaultDockerRegistryLabel)
+		if (defaultScheme)
 			return [
-				{
-					label: `${defaultDockerRegistryLabel.label} (default)`,
-					value: nullString,
-				},
+				{ label: `${defaultScheme.label} (default)`, value: nullString },
 				...latestVersionRequireDockerTypeOptions,
 			];
 
-		// Unknown default registry, return without this default.
 		return latestVersionRequireDockerTypeOptions;
-	}, [defaultDockerRegistry]);
+	}, [defaultType]);
 
 	// Show the 'username' field if 'Docker Hub' type.
 	const dockerRegistry = useWatch({
@@ -79,7 +69,7 @@ const EditServiceLatestVersionRequire = () => {
 	}) as DockerType | NullString;
 	const selectedDockerRegistry =
 		dockerRegistry === nullString
-			? (defaultDockerRegistry as NonNull<DockerFilterType>)
+			? (defaultType as NonNull<DockerFilterType>)
 			: dockerRegistry;
 	// Only Docker Hub has a username field.
 	const showUsernameField =
@@ -93,7 +83,8 @@ const EditServiceLatestVersionRequire = () => {
 	// `auth` varies by registry (token / token+username / none for ECR), so read
 	// it through the widest shape — every field is optional.
 	const dockerAuth = (values.docker as WithDockerAuth)?.auth;
-	const dockerDefaultsAuth = (dockerDefaults as WithDockerAuth | undefined)?.auth;
+	const dockerDefaultsAuth = (dockerDefaults as WithDockerAuth | undefined)
+		?.auth;
 
 	// Target release assets or webpages.
 	const latestVersionType = useWatch({

--- a/web/ui/react-app/src/components/modals/service-edit/latest-version.tsx
+++ b/web/ui/react-app/src/components/modals/service-edit/latest-version.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 import { BooleanWithDefault } from '@/components/generic';
 import {
@@ -8,6 +8,7 @@ import {
 } from '@/components/generic/field';
 import EditServiceLatestVersionRequire from '@/components/modals/service-edit/latest-version-require';
 import FormURLCommands from '@/components/modals/service-edit/latest-version-urlcommands';
+import { normaliseForSelect } from '@/components/modals/service-edit/util';
 import VersionWithLink from '@/components/modals/service-edit/version-with-link';
 import VersionWithRefresh from '@/components/modals/service-edit/version-with-refresh';
 import {
@@ -21,6 +22,7 @@ import {
 	type LatestVersionLookupType,
 	latestVersionLookupTypeOptions,
 } from '@/utils/api/types/config/service/latest-version';
+import { nullString } from '@/utils/api/types/config-edit/shared/null-string';
 
 /**
  * The `latest_version` form fields.
@@ -29,7 +31,7 @@ const EditServiceLatestVersion = () => {
 	const name = 'latest_version';
 	const urlFieldName = `${name}.url`;
 	const { getValues, trigger } = useFormContext();
-	const { schemaDataDefaults } = useSchemaContext();
+	const { schemaDataDefaults, typeDataDefaults } = useSchemaContext();
 
 	const latestVersionType = useWatch({
 		name: `${name}.type`,
@@ -41,7 +43,24 @@ const EditServiceLatestVersion = () => {
 		if (getValues(urlFieldName)) void trigger(urlFieldName);
 	}, [latestVersionType]);
 
-	const defaults = schemaDataDefaults?.latest_version;
+	const typeDefaults = typeDataDefaults?.latest_version?.[latestVersionType];
+	const defaultType = schemaDataDefaults?.latest_version?.type;
+
+	// Add default to type options.
+	const typeOptions = useMemo(() => {
+		const defaultScheme = normaliseForSelect(
+			latestVersionLookupTypeOptions,
+			defaultType,
+		);
+
+		if (defaultScheme)
+			return [
+				{ label: `${defaultScheme.label} (default)`, value: nullString },
+				...latestVersionLookupTypeOptions,
+			];
+
+		return latestVersionLookupTypeOptions;
+	}, [defaultType]);
 
 	const urlTooltipText =
 		latestVersionType === LATEST_VERSION_LOOKUP_TYPE.GITHUB.value
@@ -56,7 +75,7 @@ const EditServiceLatestVersion = () => {
 					colSize={{ sm: 4, xs: 4 }}
 					label="Type"
 					name={`${name}.type`}
-					options={latestVersionLookupTypeOptions}
+					options={typeOptions}
 				/>
 				<VersionWithLink
 					colSize={{ sm: 8, xs: 8 }}
@@ -72,7 +91,7 @@ const EditServiceLatestVersion = () => {
 					<>
 						<FieldText
 							colSize={{ sm: 12 }}
-							defaultVal={defaults?.access_token}
+							defaultVal={typeDefaults?.access_token}
 							key="access_token"
 							label="Access Token"
 							name={`${name}.access_token`}
@@ -83,7 +102,7 @@ const EditServiceLatestVersion = () => {
 							}}
 						/>
 						<BooleanWithDefault
-							defaultValue={defaults?.use_prerelease}
+							defaultValue={typeDefaults?.use_prerelease}
 							label="Use pre-releases"
 							name={`${name}.use_prerelease`}
 							tooltip={{
@@ -96,7 +115,7 @@ const EditServiceLatestVersion = () => {
 				) : (
 					<>
 						<BooleanWithDefault
-							defaultValue={defaults?.allow_invalid_certs}
+							defaultValue={typeDefaults?.allow_invalid_certs}
 							label="Allow Invalid Certs"
 							name={`${name}.allow_invalid_certs`}
 						/>

--- a/web/ui/react-app/src/utils/api/types/config-edit/service/form/builder--latest-version.ts
+++ b/web/ui/react-app/src/utils/api/types/config-edit/service/form/builder--latest-version.ts
@@ -25,7 +25,6 @@ import {
 	latestVersionLookupRequireDockerTypeSchema,
 	latestVersionLookupRequireDockerTypeSchemaAmazonECR,
 	latestVersionLookupRequireDockerTypeSchemaDockerHub,
-	type latestVersionLookupSchema,
 	latestVersionLookupSchemaDefault,
 	latestVersionLookupSchemaGitHub,
 	latestVersionLookupSchemaURL,
@@ -221,7 +220,8 @@ export const buildDockerFilterSchemaWithFallbacks = (
 				typeof latestVersionLookupRequireDockerTypeSchemaDockerHub
 			>;
 			const argTyped = arg as DockerUsernameTyped;
-			const defaultsTyped = schemaDefaults as Partial<DockerFilterUsernameToken>;
+			const defaultsTyped =
+				schemaDefaults as Partial<DockerFilterUsernameToken>;
 			const hasUsername = !!(
 				argTyped.auth?.username || defaultsTyped.auth?.username
 			)?.trim();
@@ -355,10 +355,7 @@ export const buildLatestVersionLookupSchemaWithFallbacks = (
 	data?: LatestVersionLookup,
 	defaults?: LatestVersionLookupDefaults,
 	hardDefaults?: LatestVersionLookupDefaults,
-): BuilderResponse<
-	typeof latestVersionLookupSchema,
-	typeof latestVersionLookupSchemaDefault
-> => {
+) => {
 	const path = 'latest_version';
 	const combinedDefaults = applyDefaultsRecursive<LatestVersionLookupDefaults>(
 		defaults ?? null,
@@ -369,14 +366,8 @@ export const buildLatestVersionLookupSchemaWithFallbacks = (
 		: undefined;
 
 	// url_commands.
-	const {
-		schema: urlCommandsSchema,
-		schemaData: urlCommandsSchemaData,
-		schemaDataDefaults: urlCommandsSchemaDataDefaults,
-	} = buildURLCommandsSchemaWithFallbacks(
-		data?.url_commands,
-		combinedDefaults?.url_commands,
-	);
+	const { schema: urlCommandsSchema, schemaData: urlCommandsSchemaData } =
+		buildURLCommandsSchemaWithFallbacks(data?.url_commands, []);
 	// require.
 	const {
 		schema: requireSchema,
@@ -384,17 +375,43 @@ export const buildLatestVersionLookupSchemaWithFallbacks = (
 		schemaDataDefaults: requireSchemaDataDefaults,
 	} = buildLatestVersionRequireSchemaWithFallbacks(
 		data?.require,
-		combinedDefaults?.require,
+		combinedDefaults.common?.require,
 	);
 	// headers (URL-type only).
-	const {
-		schema: headersSchema,
-		schemaData: headersSchemaData,
-		schemaDataDefaults: headersSchemaDataDefaults,
-	} = buildHeadersSchemaWithFallbacks(
-		data && 'headers' in data ? data.headers : [],
-		'headers' in combinedDefaults ? combinedDefaults.headers : [],
-	);
+	const { schema: headersSchema, schemaData: headersSchemaData } =
+		buildHeadersSchemaWithFallbacks(
+			data && 'headers' in data ? data.headers : [],
+			[],
+		);
+
+	const buildTypeDefaults = <T extends LatestVersionLookupType>(
+		type: T,
+		typeDefaults: LatestVersionLookupDefaults[T],
+	) =>
+		safeParse({
+			data: {
+				...typeDefaults,
+				require: requireSchemaDataDefaults,
+				type: type,
+			},
+			fallback: {
+				require: requireSchemaDataDefaults,
+				type: type,
+			},
+			path: `${path} (defaults-${type})`,
+			schema: latestVersionLookupSchemaDefault,
+		});
+
+	const schemaDataTypeDefaults = {
+		[LATEST_VERSION_LOOKUP_TYPE.GITHUB.value]: buildTypeDefaults(
+			LATEST_VERSION_LOOKUP_TYPE.GITHUB.value,
+			combinedDefaults.github,
+		),
+		[LATEST_VERSION_LOOKUP_TYPE.URL.value]: buildTypeDefaults(
+			LATEST_VERSION_LOOKUP_TYPE.URL.value,
+			combinedDefaults.url,
+		),
+	};
 
 	// Schemas shared between multiple types.
 	const sharedSchemas = {
@@ -414,20 +431,16 @@ export const buildLatestVersionLookupSchemaWithFallbacks = (
 		latestVersionLookupSchemaGitHub.extend({
 			...sharedSchemas,
 			url: stringDefault.superRefine((arg, ctx) => {
-				const url = arg || (defaults?.url ?? hardDefaults?.url ?? '');
-
-				validateRequired({ arg: url, ctx: ctx });
-				validateGitHubRepo({ arg: url, ctx: ctx });
+				validateRequired({ arg: arg, ctx: ctx });
+				validateGitHubRepo({ arg: arg, ctx: ctx });
 			}),
 		}),
 		latestVersionLookupSchemaURL.extend({
 			...sharedSchemas,
 			headers: headersSchema,
 			url: z.string().superRefine((arg, ctx) => {
-				const url = arg || (defaults?.url ?? hardDefaults?.url ?? '');
-
-				validateRequired({ arg: url, ctx: ctx });
-				validateURL({ arg: url, ctx: ctx });
+				validateRequired({ arg: arg, ctx: ctx });
+				validateURL({ arg: arg, ctx: ctx });
 			}),
 		}),
 	]);
@@ -466,27 +479,13 @@ export const buildLatestVersionLookupSchemaWithFallbacks = (
 		schema: schemaRaw,
 	});
 
-	// Defaults for the schema.
-	const schemaDataDefaults = safeParse({
-		data: {
-			...combinedDefaults,
-			headers: headersSchemaDataDefaults,
-			require: requireSchemaDataDefaults,
-			type: defaultType,
-			url_commands: urlCommandsSchemaDataDefaults,
-		},
-		fallback: {
-			headers: headersSchemaDataDefaults,
-			require: requireSchemaDataDefaults,
-			type: fallbackData.type as LatestVersionLookupType,
-		},
-		path: path,
-		schema: latestVersionLookupSchemaDefault,
-	});
-
 	return {
 		schema: schema,
 		schemaData: schemaData,
-		schemaDataDefaults: schemaDataDefaults,
+		schemaDataDefaults: {
+			require: requireSchemaDataDefaults,
+			type: defaultType,
+		},
+		schemaDataTypeDefaults: schemaDataTypeDefaults,
 	};
 };

--- a/web/ui/react-app/src/utils/api/types/config-edit/service/form/builder.ts
+++ b/web/ui/react-app/src/utils/api/types/config-edit/service/form/builder.ts
@@ -66,6 +66,7 @@ export const buildServiceSchemaWithFallbacks = (
 		schema: latestVersionSchema,
 		schemaData: latestVersionSchemaData,
 		schemaDataDefaults: latestVersionSchemaDataDefaults,
+		schemaDataTypeDefaults: latestVersionTypeDataDefaults,
 	} = buildLatestVersionLookupSchemaWithFallbacks(
 		data?.latest_version,
 		defaults?.service.latest_version,
@@ -231,6 +232,7 @@ export const buildServiceSchemaWithFallbacks = (
 
 	// Type-specific defaults.
 	const typeDataDefaults = {
+		latest_version: latestVersionTypeDataDefaults,
 		notify: notifyTypeDataDefaults,
 		webhook: webhookTypeDataDefaults,
 	};

--- a/web/ui/react-app/src/utils/api/types/config-edit/service/types/latest-version.ts
+++ b/web/ui/react-app/src/utils/api/types/config-edit/service/types/latest-version.ts
@@ -264,7 +264,6 @@ export const latestVersionLookupSchemaDefault = z
 		headers: headersSchema.optional(),
 		require: latestVersionRequireSchemaDefaults.optional(),
 		type: LatestVersionTypeEnum.nullable().optional(),
-		url: stringDefault,
 		url_commands: urlCommandsSchema.optional(),
 		use_prerelease: z.boolean().nullable().optional(),
 	})

--- a/web/ui/react-app/src/utils/api/types/config/service/latest-version.ts
+++ b/web/ui/react-app/src/utils/api/types/config/service/latest-version.ts
@@ -21,15 +21,25 @@ export type LatestVersionLookupBase = {
 	require?: LatestVersionRequire;
 };
 
-export type LatestVersionLookupDefaults = {
-	type?: LatestVersionLookupType | null;
-	url?: string;
-	url_commands?: URLCommand[];
+// Fields common to latest_version types.
+export type LatestVersionLookupCommonDefaults = {
 	require?: LatestVersionRequireDefaults;
+};
+// GitHub-specific defaults.
+export type LatestVersionLookupGitHubDefaults = {
 	access_token?: string;
 	use_prerelease?: boolean;
+};
+// URL-specific defaults.
+export type LatestVersionLookupURLDefaults = {
 	allow_invalid_certs?: boolean | null;
-	headers?: Headers;
+};
+
+export type LatestVersionLookupDefaults = {
+	type?: LatestVersionLookupType | null;
+	common?: LatestVersionLookupCommonDefaults;
+	github?: LatestVersionLookupGitHubDefaults;
+	url?: LatestVersionLookupURLDefaults;
 };
 
 /* URL Command */

--- a/web/ui/react-app/tests/fixtures/service.ts
+++ b/web/ui/react-app/tests/fixtures/service.ts
@@ -230,7 +230,9 @@ const fillLatestVersion = async (
 		.first();
 
 	await section.locator('#latest_version\\.type').click();
-	await dialog.getByRole('option', { name: type }).click();
+	await dialog
+		.getByRole('option', { name: new RegExp(`^${type}$`, 'i') })
+		.click();
 
 	if (type === 'github') {
 		await section


### PR DESCRIPTION
defaults.service.latest_version.X is now split into (env as well):
- defaults.service.latest_version.type
- defaults.service.latest_version.common.require
- defaults.service.latest_version.github.access_token
- defaults.service.latest_version.github.use_prerelease
- defaults.service.latest_version.web.allow_invalid_certs

```yaml
defaults:
  service:
    latest_version
      type: github
      require:
        type: hub
      access_token: ABC
      use_prerelease: false
      allow_invalid_certs: false
```
is now (auto-conversions)

```yaml
defaults:
  service:
    latest_version
      type: github
      common:
        require:
          type: hub
      github:
        access_token: ABC
        use_prerelease: false
      url:
        allow_invalid_certs: false
```