### PR TITLE
build(deps): bump Go from 1.25.0 to 1.26.0

### DIFF
--- a/config/decode/marshal_test.go
+++ b/config/decode/marshal_test.go
@@ -124,9 +124,9 @@ func TestUnsupportedFormatError_Error(t *testing.T) {
 }
 
 type testStruct struct {
-	A string `json:"a,omitempty" yaml:"a,omitempty"`
-	B int    `json:"b,omitempty" yaml:"b,omitempty"`
-	C bool   `json:"c,omitempty" yaml:"c,omitempty"`
+	A string `json:"a,omitzero" yaml:"a,omitzero"`
+	B int    `json:"b,omitzero" yaml:"b,omitzero"`
+	C bool   `json:"c,omitzero" yaml:"c,omitzero"`
 }
 
 func TestUnmarshal(t *testing.T) {

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -29,7 +29,7 @@ import (
 // Defaults holds default configuration for services, notifiers, and webhooks.
 type Defaults struct {
 	Service service.Defaults           `json:"service,omitzero" yaml:"service,omitzero"`
-	Notify  shoutrrr.ShoutrrrsDefaults `json:"notify,omitzero" yaml:"notify,omitzero"`
+	Notify  shoutrrr.ShoutrrrsDefaults `json:"notify,omitempty" yaml:"notify,omitempty"`
 	WebHook webhook.Defaults           `json:"webhook,omitzero" yaml:"webhook,omitzero"`
 }
 

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -82,6 +82,11 @@ func (d *Defaults) Default() bool {
 	return true
 }
 
+// MigrateDeprecated renames deprecated fields to their new locations.
+func (d *Defaults) MigrateDeprecated() {
+	d.Service.MigrateDeprecated()
+}
+
 // SetDefaults assigns defaults to the receiver.
 func (d *Defaults) SetDefaults(dflts *Defaults) {
 	// TODO: Store HardDefaults inside Defaults.

--- a/config/env_test.go
+++ b/config/env_test.go
@@ -41,9 +41,9 @@ type testStruct struct {
 	Int testInterface `yaml:"iface"`
 }
 type testStructChild struct {
-	String string  `yaml:"string,omitempty"`
-	Int    int     `yaml:"int,omitempty"`
-	Float  float64 `yaml:"float,omitempty"`
+	String string  `yaml:"string,omitzero"`
+	Int    int     `yaml:"int,omitzero"`
+	Float  float64 `yaml:"float,omitzero"`
 }
 
 func TestMigrateDeprecatedEnvVars(t *testing.T) {

--- a/config/settings.go
+++ b/config/settings.go
@@ -87,9 +87,9 @@ var (
 
 // SettingsBase holds the base settings for the binary.
 type SettingsBase struct {
-	Data DataSettings `json:"data,omitempty" yaml:"data,omitempty"` // Data settings
-	Log  LogSettings  `json:"log,omitempty" yaml:"log,omitempty"`   // Log settings
-	Web  WebSettings  `json:"web,omitempty" yaml:"web,omitempty"`   // Web settings
+	Data DataSettings `json:"data,omitzero" yaml:"data,omitzero"` // Data settings
+	Log  LogSettings  `json:"log,omitzero" yaml:"log,omitzero"`   // Log settings
+	Web  WebSettings  `json:"web,omitzero" yaml:"web,omitzero"`   // Web settings
 }
 
 // IsZero implements the yaml.IsZeroer interface.
@@ -149,8 +149,8 @@ func (s *SettingsBase) MapEnvToStruct() error {
 
 // DataSettings holds data-related settings for the binary.
 type DataSettings struct {
-	DatabaseFile string `json:"database_file,omitempty" yaml:"database_file,omitempty"` // Database path.
-	Readonly     *bool  `json:"readonly,omitempty" yaml:"readonly,omitempty"`           // Disable saving config changes to disk.
+	DatabaseFile string `json:"database_file,omitzero" yaml:"database_file,omitzero"` // Database path.
+	Readonly     *bool  `json:"readonly,omitzero" yaml:"readonly,omitzero"`           // Disable saving config changes to disk.
 }
 
 // IsZero implements the yaml.IsZeroer interface.
@@ -161,8 +161,8 @@ func (s DataSettings) IsZero() bool {
 
 // LogSettings holds log-related settings for the binary.
 type LogSettings struct {
-	Timestamps *bool  `json:"timestamps,omitempty" yaml:"timestamps,omitempty"` // Timestamps in CLI output.
-	Level      string `json:"level,omitempty" yaml:"level,omitempty"`           // Log level.
+	Timestamps *bool  `json:"timestamps,omitzero" yaml:"timestamps,omitzero"` // Timestamps in CLI output.
+	Level      string `json:"level,omitzero" yaml:"level,omitzero"`           // Log level.
 }
 
 // IsZero implements the yaml.IsZeroer interface.
@@ -173,9 +173,9 @@ func (s LogSettings) IsZero() bool {
 
 // WebSettingsBasicAuth contains the basic auth credentials to use (if any).
 type WebSettingsBasicAuth struct {
-	Username     string   `json:"username,omitempty" yaml:"username,omitempty"`
+	Username     string   `json:"username,omitzero" yaml:"username,omitzero"`
 	UsernameHash [32]byte `json:"-" yaml:"-"` // SHA256 hash.
-	Password     string   `json:"password,omitempty" yaml:"password,omitempty"`
+	Password     string   `json:"password,omitzero" yaml:"password,omitzero"`
 	PasswordHash [32]byte `json:"-" yaml:"-"` // SHA256 hash.
 }
 
@@ -203,20 +203,20 @@ func (b *WebSettingsBasicAuth) CheckValues() {
 
 // FaviconSettings contains the favicon override settings.
 type FaviconSettings struct {
-	SVG string `json:"svg,omitempty" yaml:"svg,omitempty"`
-	PNG string `json:"png,omitempty" yaml:"png,omitempty"`
+	SVG string `json:"svg,omitzero" yaml:"svg,omitzero"`
+	PNG string `json:"png,omitzero" yaml:"png,omitzero"`
 }
 
 // WebSettings holds web server settings for the binary.
 type WebSettings struct {
-	ListenHost     string                `json:"listen_host,omitempty" yaml:"listen_host,omitempty"`         // Web listen host.
-	ListenPort     string                `json:"listen_port,omitempty" yaml:"listen_port,omitempty"`         // Web listen port.
-	RoutePrefix    string                `json:"route_prefix,omitempty" yaml:"route_prefix,omitempty"`       // Web endpoint prefix.
-	CertFile       string                `json:"cert_file,omitempty" yaml:"cert_file,omitempty"`             // HTTPS certificate path.
-	KeyFile        string                `json:"pkey_file,omitempty" yaml:"pkey_file,omitempty"`             // HTTPS privkey path.
-	BasicAuth      *WebSettingsBasicAuth `json:"basic_auth,omitempty" yaml:"basic_auth,omitempty"`           // Basic auth creds.
+	ListenHost     string                `json:"listen_host,omitzero" yaml:"listen_host,omitzero"`           // Web listen host.
+	ListenPort     string                `json:"listen_port,omitzero" yaml:"listen_port,omitzero"`           // Web listen port.
+	RoutePrefix    string                `json:"route_prefix,omitzero" yaml:"route_prefix,omitzero"`         // Web endpoint prefix.
+	CertFile       string                `json:"cert_file,omitzero" yaml:"cert_file,omitzero"`               // HTTPS certificate path.
+	KeyFile        string                `json:"pkey_file,omitzero" yaml:"pkey_file,omitzero"`               // HTTPS privkey path.
+	BasicAuth      *WebSettingsBasicAuth `json:"basic_auth,omitzero" yaml:"basic_auth,omitzero"`             // Basic auth creds.
 	DisabledRoutes []string              `json:"disabled_routes,omitempty" yaml:"disabled_routes,omitempty"` // Disabled API routes.
-	Favicon        *FaviconSettings      `json:"favicon,omitempty" yaml:"favicon,omitempty"`                 // Favicon settings.
+	Favicon        *FaviconSettings      `json:"favicon,omitzero" yaml:"favicon,omitzero"`                   // Favicon settings.
 }
 
 // IsZero implements the yaml.IsZeroer interface.

--- a/config/types.go
+++ b/config/types.go
@@ -32,12 +32,12 @@ var extractServiceSubtree = polymorphic.Extract
 
 // Config for Argus.
 type Config struct {
-	File         string                     `json:"-" yaml:"-"`                                   // Path to the config file (--config.file='').
-	Settings     Settings                   `json:"settings,omitempty" yaml:"settings,omitempty"` // Settings for the program.
-	HardDefaults Defaults                   `json:"-" yaml:"-"`                                   // Hardcoded default values for the various parameters.
-	Defaults     Defaults                   `json:"defaults,omitempty" yaml:"defaults,omitempty"` // Default values for the various parameters.
-	Notify       shoutrrr.ShoutrrrsDefaults `json:"notify,omitempty" yaml:"notify,omitempty"`     // Shoutrrr messages to send on a new release.
-	WebHook      webhook.WebHooksDefaults   `json:"webhook,omitempty" yaml:"webhook,omitempty"`   // WebHooks to send on a new release.
+	File         string                     `json:"-" yaml:"-"`                                 // Path to the config file (--config.file='').
+	Settings     Settings                   `json:"settings,omitzero" yaml:"settings,omitzero"` // Settings for the program.
+	HardDefaults Defaults                   `json:"-" yaml:"-"`                                 // Hardcoded default values for the various parameters.
+	Defaults     Defaults                   `json:"defaults,omitzero" yaml:"defaults,omitzero"` // Default values for the various parameters.
+	Notify       shoutrrr.ShoutrrrsDefaults `json:"notify,omitempty" yaml:"notify,omitempty"`   // Shoutrrr messages to send on a new release.
+	WebHook      webhook.WebHooksDefaults   `json:"webhook,omitempty" yaml:"webhook,omitempty"` // WebHooks to send on a new release.
 
 	OrderMu sync.RWMutex     `json:"-" yaml:"-"`                                 // Mutex for the Order/Service slice.
 	Order   []string         `json:"-" yaml:"-"`                                 // Ordered slice of all Service id's.
@@ -49,10 +49,10 @@ type Config struct {
 
 // ConfigDecode is an unmarshal-only helper for [Config].
 type ConfigDecode struct {
-	Settings Settings                   `json:"settings,omitempty" yaml:"settings,omitempty"`
+	Settings Settings                   `json:"settings,omitzero" yaml:"settings,omitzero"`
 	Notify   shoutrrr.ShoutrrrsDefaults `json:"notify,omitempty" yaml:"notify,omitempty"`
 	WebHook  webhook.WebHooksDefaults   `json:"webhook,omitempty" yaml:"webhook,omitempty"`
-	Defaults Defaults                   `json:"defaults,omitempty" yaml:"defaults,omitempty"`
+	Defaults Defaults                   `json:"defaults,omitzero" yaml:"defaults,omitzero"`
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface.

--- a/config/types.go
+++ b/config/types.go
@@ -116,6 +116,9 @@ func (c *Config) Decode(raw []byte) error {
 		return err //nolint:wrapcheck
 	}
 
+	// Migrate deprecated keys before wiring the defaults chain / decoding services.
+	c.Defaults.MigrateDeprecated()
+
 	// Set defaults/hardDefaults.
 	c.InitDefaults()
 

--- a/db/init_test.go
+++ b/db/init_test.go
@@ -23,6 +23,7 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -536,7 +537,7 @@ func TestAPI_RemoveUnknownServices(t *testing.T) {
 				)
 				err = rows.Scan(&id, &lv, &lvt, &dv, &dvt, &av)
 				svc := tAPI.config.Service[id]
-				if svc == nil || !util.Contains(tAPI.config.Order, id) {
+				if svc == nil || !slices.Contains(tAPI.config.Order, id) {
 					t.Errorf(
 						"%s %q should have been removed from the table",
 						prefix, id,

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/release-argus/Argus
 
-go 1.25.0
+go 1.26.0
 
 toolchain go1.26.4
 

--- a/internal/test/help_test.go
+++ b/internal/test/help_test.go
@@ -21,9 +21,9 @@ import "github.com/goccy/go-yaml"
 var packageName = "test"
 
 type testStruct struct {
-	String string `json:"string,omitempty" yaml:"string,omitempty"`
-	Int    int    `json:"int,omitempty" yaml:"int,omitempty"`
-	Bool   bool   `json:"bool,omitempty" yaml:"bool,omitempty"`
+	String string `json:"string,omitzero" yaml:"string,omitzero"`
+	Int    int    `json:"int,omitzero" yaml:"int,omitzero"`
+	Bool   bool   `json:"bool,omitzero" yaml:"bool,omitzero"`
 }
 
 func (t *testStruct) Foo() string { return t.String }

--- a/notify/shoutrrr/defaults_test.go
+++ b/notify/shoutrrr/defaults_test.go
@@ -18,9 +18,8 @@ package shoutrrr
 
 import (
 	"fmt"
+	"slices"
 	"testing"
-
-	"github.com/release-argus/Argus/util"
 )
 
 func TestShoutrrrsDefaults_Init(t *testing.T) {
@@ -93,7 +92,7 @@ func TestShoutrrrsDefaults_Defaults(t *testing.T) {
 
 	// AND: no unexpected types are initialised.
 	for typ := range defaults {
-		if !util.Contains(SupportedTypes, typ) {
+		if !slices.Contains(SupportedTypes, typ) {
 			t.Errorf(
 				"%s initialised an unexpected notify type: %q",
 				prefix, typ,

--- a/notify/shoutrrr/new.go
+++ b/notify/shoutrrr/new.go
@@ -31,7 +31,7 @@ type TestPayload struct {
 	ServiceName       string                  `json:"service_name"`
 	Name              string                  `json:"name"`
 	NamePrevious      string                  `json:"name_previous"`
-	Type              string                  `json:"type,omitempty"`
+	Type              string                  `json:"type"`
 	Options           MapStringStringOmitNull `json:"options"`
 	URLFields         MapStringStringOmitNull `json:"url_fields"`
 	Params            MapStringStringOmitNull `json:"params"`

--- a/notify/shoutrrr/shoutrrr.go
+++ b/notify/shoutrrr/shoutrrr.go
@@ -18,6 +18,7 @@ package shoutrrr
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"math/rand"
 	net_url "net/url"
 	"strings"
@@ -318,9 +319,7 @@ func (s *Shoutrrr) BuildParams(info serviceinfo.ServiceInfo) *types.Params {
 	params := make(types.Params, len(s.Params)+len(s.Main.Params))
 
 	// Service Params.
-	for key, value := range s.Params {
-		params[key] = value
-	}
+	maps.Copy(params, s.Params)
 
 	// Main Params.
 	for key, value := range s.Main.Params {

--- a/notify/shoutrrr/types.go
+++ b/notify/shoutrrr/types.go
@@ -49,7 +49,7 @@ type Shoutrrrs map[string]*Shoutrrr
 
 // Base is the base Shoutrrr.
 type Base struct {
-	Type      string                  `json:"type,omitempty" yaml:"type,omitempty"`             // Notification type, e.g. slack.
+	Type      string                  `json:"type,omitzero" yaml:"type,omitzero"`               // Notification type, e.g. slack.
 	Options   MapStringStringOmitNull `json:"options,omitempty" yaml:"options,omitempty"`       // Options.
 	URLFields MapStringStringOmitNull `json:"url_fields,omitempty" yaml:"url_fields,omitempty"` // URL Fields.
 	Params    MapStringStringOmitNull `json:"params,omitempty" yaml:"params,omitempty"`         // Query/Param Props.
@@ -59,7 +59,7 @@ type Base struct {
 type Shoutrrr struct {
 	Base `json:",inline" yaml:",inline"`
 
-	ID string `json:"name,omitempty" yaml:"-"` // ID for this Shoutrrr sender.
+	ID string `json:"name,omitzero" yaml:"-"` // ID for this Shoutrrr sender.
 
 	Failed        *status.FailsShoutrrr `json:"-" yaml:"-"` // Whether the last send attempt failed.
 	ServiceStatus *status.Status        `json:"-" yaml:"-"` // Status of the Service (used for templating commands).

--- a/notify/shoutrrr/verify.go
+++ b/notify/shoutrrr/verify.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"math"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -231,7 +232,7 @@ func (d *Defaults) CheckValues(id string) (error, bool) {
 	}
 
 	// Verify valid type.
-	if !util.Contains(SupportedTypes, typeName) {
+	if !slices.Contains(SupportedTypes, typeName) {
 		errs = append(
 			errs,
 			polymorphic.InvalidTypeError{
@@ -414,7 +415,7 @@ func (b *Base) normaliseParamSelect(key string, value string, allowed []string) 
 func (s *Shoutrrr) checkValuesType() error {
 	// Check we have a Type.
 	sType := s.GetType()
-	if !util.Contains(SupportedTypes, sType) {
+	if !slices.Contains(SupportedTypes, sType) {
 		sTypeWithoutID := util.FirstNonDefault(s.Type, s.Main.Type)
 		if sTypeWithoutID == "" {
 			return &decode.FieldError{
@@ -437,7 +438,7 @@ func (s *Shoutrrr) checkValuesType() error {
 	}
 
 	// Invalid/Unknown type.
-	if !util.Contains(SupportedTypes, sType) {
+	if !slices.Contains(SupportedTypes, sType) {
 		return polymorphic.InvalidTypeError{
 			Key:     "type",
 			Value:   sType,

--- a/service/api.go
+++ b/service/api.go
@@ -34,16 +34,16 @@ import (
 // secretRefs contains the indexes to use for SecretValues.
 type secretRefs struct {
 	ID                    string                           `json:"id"`
-	LatestVersion         shared.VSecretRef                `json:"latest_version,omitempty"`
-	DeployedVersionLookup shared.VSecretRef                `json:"deployed_version,omitempty"`
+	LatestVersion         shared.VSecretRef                `json:"latest_version,omitzero"`
+	DeployedVersionLookup shared.VSecretRef                `json:"deployed_version,omitzero"`
 	Notify                map[string]shared.OldStringIndex `json:"notify,omitempty"`
 	WebHook               map[string]shared.WHSecretRef    `json:"webhook,omitempty"`
 }
 
 type secretRefsIncoming struct {
 	ID                    string                  `json:"id"`
-	LatestVersion         shared.VSecretRef       `json:"latest_version,omitempty"`
-	DeployedVersionLookup shared.VSecretRef       `json:"deployed_version,omitempty"`
+	LatestVersion         shared.VSecretRef       `json:"latest_version,omitzero"`
+	DeployedVersionLookup shared.VSecretRef       `json:"deployed_version,omitzero"`
 	Notify                []shared.OldStringIndex `json:"notify,omitempty"`
 	WebHook               []shared.WHSecretRef    `json:"webhook,omitempty"`
 }

--- a/service/dashboard/dashboard.go
+++ b/service/dashboard/dashboard.go
@@ -28,10 +28,10 @@ import (
 
 // OptionsBase are the base options for the Dashboard.
 type OptionsBase struct {
-	AutoApprove *bool  `json:"auto_approve,omitempty" yaml:"auto_approve,omitempty"` // Default - true = Require approval before sending WebHooks for new releases.
-	Icon        string `json:"icon,omitempty" yaml:"icon,omitempty"`                 // Icon URL to use for messages/Web UI.
-	IconLinkTo  string `json:"icon_link_to,omitempty" yaml:"icon_link_to,omitempty"` // URL to redirect Icon clicks to.
-	WebURL      string `json:"web_url,omitempty" yaml:"web_url,omitempty"`           // URL to provide on the Web UI.
+	AutoApprove *bool  `json:"auto_approve,omitzero" yaml:"auto_approve,omitzero"` // Default - true = Require approval before sending WebHooks for new releases.
+	Icon        string `json:"icon,omitzero" yaml:"icon,omitzero"`                 // Icon URL to use for messages/Web UI.
+	IconLinkTo  string `json:"icon_link_to,omitzero" yaml:"icon_link_to,omitzero"` // URL to redirect Icon clicks to.
+	WebURL      string `json:"web_url,omitzero" yaml:"web_url,omitzero"`           // URL to provide on the Web UI.
 }
 
 // Options are options for the Dashboard.

--- a/service/defaults.go
+++ b/service/defaults.go
@@ -52,12 +52,12 @@ func (d Defaults) IsZero() bool {
 
 // DefaultsDecode is an unmarshal-only helper for [Defaults].
 type DefaultsDecode struct {
-	Options               opt.Defaults              `json:"options,omitempty" yaml:"options,omitempty"`
-	DeployedVersionLookup deployedver_base.Defaults `json:"deployed_version,omitempty" yaml:"deployed_version,omitempty"`
+	Options               opt.Defaults              `json:"options,omitzero" yaml:"options,omitzero"`
+	DeployedVersionLookup deployedver_base.Defaults `json:"deployed_version,omitzero" yaml:"deployed_version,omitzero"`
 	Notify                map[string]struct{}       `json:"notify,omitempty" yaml:"notify,omitempty"`
 	Command               command.Commands          `json:"command,omitempty" yaml:"command,omitempty"`
 	WebHook               map[string]struct{}       `json:"webhook,omitempty" yaml:"webhook,omitempty"`
-	Dashboard             dashboard.Defaults        `json:"dashboard,omitempty" yaml:"dashboard,omitempty"`
+	Dashboard             dashboard.Defaults        `json:"dashboard,omitzero" yaml:"dashboard,omitzero"`
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface.

--- a/service/defaults.go
+++ b/service/defaults.go
@@ -139,6 +139,11 @@ func (d *Defaults) Default() {
 	d.Init()
 }
 
+// MigrateDeprecated renames deprecated fields to their new locations.
+func (d *Defaults) MigrateDeprecated() {
+	d.LatestVersion.MigrateDeprecated()
+}
+
 // SetDefaults assigns defaults to the receiver.
 func (d *Defaults) SetDefaults(dflts *Defaults) {
 	d.LatestVersion.SetDefaults(&dflts.LatestVersion)

--- a/service/deployed_version/help_test.go
+++ b/service/deployed_version/help_test.go
@@ -55,7 +55,7 @@ func TestMain(m *testing.M) {
 
 type mockLookup struct {
 	base.Lookup
-	OverrideErr string `json:"override_err,omitempty" yaml:"override_err,omitempty"`
+	OverrideErr string `json:"override_err,omitzero" yaml:"override_err,omitzero"`
 }
 
 func (f *mockLookup) ApplyOverrides(format string, data []byte) error {

--- a/service/deployed_version/types/base/base.go
+++ b/service/deployed_version/types/base/base.go
@@ -30,7 +30,7 @@ import (
 
 // Lookup is the base struct for an [Interface].
 type Lookup struct {
-	Type string `json:"type,omitempty" yaml:"type,omitempty"` // "url".
+	Type string `json:"type,omitzero" yaml:"type,omitzero"` // "url".
 
 	Options *opt.Options   `json:"-" yaml:"-"` // Options.
 	Status  *status.Status `json:"-" yaml:"-"` // Service Status.

--- a/service/deployed_version/types/base/defaults.go
+++ b/service/deployed_version/types/base/defaults.go
@@ -18,12 +18,12 @@ package base
 import (
 	"errors"
 	"net/http"
+	"slices"
 	"strings"
 
 	"github.com/release-argus/Argus/config/decode"
 	"github.com/release-argus/Argus/service/deployed_version/types/web/constants"
 	opt "github.com/release-argus/Argus/service/option"
-	"github.com/release-argus/Argus/util"
 	"github.com/release-argus/Argus/util/polymorphic"
 )
 
@@ -39,9 +39,9 @@ type DefaultsConfig struct {
 
 // Defaults are the default values for a Lookup.
 type Defaults struct {
-	Type              string `json:"type,omitempty" yaml:"type,omitempty"`                               // "manual" | "url".
-	AllowInvalidCerts *bool  `json:"allow_invalid_certs,omitempty" yaml:"allow_invalid_certs,omitempty"` // False = Disallows invalid HTTPS certificates.
-	Method            string `json:"method,omitempty" yaml:"method,omitempty"`                           // HTTP method.
+	Type              string `json:"type,omitzero" yaml:"type,omitzero"`                               // "manual" | "url".
+	AllowInvalidCerts *bool  `json:"allow_invalid_certs,omitzero" yaml:"allow_invalid_certs,omitzero"` // False = Disallows invalid HTTPS certificates.
+	Method            string `json:"method,omitzero" yaml:"method,omitzero"`                           // HTTP method.
 
 	Options *opt.Defaults `json:"-" yaml:"-"` // Options for the Lookup.
 }
@@ -101,7 +101,7 @@ func (d *Defaults) CheckValues() error {
 	var errs []error
 	// Method.
 	d.Method = strings.ToUpper(d.Method)
-	if d.Method != "" && !util.Contains(constants.SupportedMethods, d.Method) {
+	if d.Method != "" && !slices.Contains(constants.SupportedMethods, d.Method) {
 		errs = append(
 			errs,
 			polymorphic.InvalidTypeError{

--- a/service/deployed_version/types/manual/types.go
+++ b/service/deployed_version/types/manual/types.go
@@ -39,7 +39,7 @@ type Lookup struct {
 	base.Lookup `json:",inline" yaml:",inline"`
 
 	mu      sync.RWMutex // Lock for the Lookup.
-	Version string       `json:"version,omitempty" yaml:"version,omitempty"` // OPTIONAL: Version to initialise with/set to.
+	Version string       `json:"version,omitzero" yaml:"version,omitzero"` // OPTIONAL: Version to initialise with/set to.
 }
 
 // #########

--- a/service/deployed_version/types/web/types.go
+++ b/service/deployed_version/types/web/types.go
@@ -38,17 +38,17 @@ var Type = "url"
 type Lookup struct {
 	base.Lookup `json:",inline" yaml:",inline"`
 
-	Method            string `json:"method,omitempty" yaml:"method,omitempty"`                           // REQUIRED: HTTP method.
-	URL               string `json:"url,omitempty" yaml:"url,omitempty"`                                 // REQUIRED: url to query.
-	AllowInvalidCerts *bool  `json:"allow_invalid_certs,omitempty" yaml:"allow_invalid_certs,omitempty"` // Default - false = Disallows invalid HTTPS certificates.
-	TargetHeader      string `json:"target_header,omitempty" yaml:"target_header,omitempty"`             // OPTIONAL: header to target for the version.
+	Method            string `json:"method,omitzero" yaml:"method,omitzero"`                           // REQUIRED: HTTP method.
+	URL               string `json:"url,omitzero" yaml:"url,omitzero"`                                 // REQUIRED: url to query.
+	AllowInvalidCerts *bool  `json:"allow_invalid_certs,omitzero" yaml:"allow_invalid_certs,omitzero"` // Default - false = Disallows invalid HTTPS certificates.
+	TargetHeader      string `json:"target_header,omitzero" yaml:"target_header,omitzero"`             // OPTIONAL: header to target for the version.
 
-	BasicAuth     *BasicAuth     `json:"basic_auth,omitempty" yaml:"basic_auth,omitempty"`         // OPTIONAL: basic auth credentials.
-	Headers       shared.Headers `json:"headers,omitempty" yaml:"headers,omitempty"`               // OPTIONAL: request headers.
-	Body          string         `json:"body,omitempty" yaml:"body,omitempty"`                     // OPTIONAL: request body.
-	JSON          string         `json:"json,omitempty" yaml:"json,omitempty"`                     // OPTIONAL: JSON key to use e.g. version_current.
-	Regex         string         `json:"regex,omitempty" yaml:"regex,omitempty"`                   // OPTIONAL: regex for the version.
-	RegexTemplate string         `json:"regex_template,omitempty" yaml:"regex_template,omitempty"` // OPTIONAL: template to apply to the RegEx match.
+	BasicAuth     *BasicAuth     `json:"basic_auth,omitzero" yaml:"basic_auth,omitzero"`         // OPTIONAL: basic auth credentials.
+	Headers       shared.Headers `json:"headers,omitempty" yaml:"headers,omitempty"`             // OPTIONAL: request headers.
+	Body          string         `json:"body,omitzero" yaml:"body,omitzero"`                     // OPTIONAL: request body.
+	JSON          string         `json:"json,omitzero" yaml:"json,omitzero"`                     // OPTIONAL: JSON key to use e.g. version_current.
+	Regex         string         `json:"regex,omitzero" yaml:"regex,omitzero"`                   // OPTIONAL: regex for the version.
+	RegexTemplate string         `json:"regex_template,omitzero" yaml:"regex_template,omitzero"` // OPTIONAL: template to apply to the RegEx match.
 }
 
 // BasicAuth to use on the HTTP(s) request.

--- a/service/deployed_version/types/web/verify.go
+++ b/service/deployed_version/types/web/verify.go
@@ -19,11 +19,11 @@ import (
 	"errors"
 	"net/http"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/release-argus/Argus/config/decode"
 	"github.com/release-argus/Argus/service/deployed_version/types/web/constants"
-	"github.com/release-argus/Argus/util"
 	"github.com/release-argus/Argus/util/polymorphic"
 )
 
@@ -45,7 +45,7 @@ func (l *Lookup) CheckValues() error {
 	// Method.
 	l.Method = strings.ToUpper(l.Method)
 	method := l.method()
-	if !util.Contains(constants.SupportedMethods, method) {
+	if !slices.Contains(constants.SupportedMethods, method) {
 		errs = append(
 			errs,
 			polymorphic.InvalidTypeError{

--- a/service/latest_version/defaults.go
+++ b/service/latest_version/defaults.go
@@ -89,8 +89,8 @@ func (d *Defaults) SetDefaults(dflts *Defaults) {
 	d.Common.SetDefaults(&dflts.Common)
 }
 
-// CheckValues migrates deprecated fields, then validates the fields of the receiver.
-func (d *Defaults) CheckValues() error {
+// MigrateDeprecated renames deprecated fields to their new locations.
+func (d *Defaults) MigrateDeprecated() {
 	// Deprecated: access_token -> github.access_token.
 	if d.AccessTokenDeprecated != "" && d.GitHub.AccessToken == "" {
 		d.GitHub.AccessToken = d.AccessTokenDeprecated
@@ -118,7 +118,10 @@ func (d *Defaults) CheckValues() error {
 		logx.Deprecated("Renaming 'defaults.service.latest_version.require' to 'defaults.service.latest_version.common.require'")
 	}
 	d.RequireDeprecated = nil
+}
 
+// CheckValues validates the fields of the receiver.
+func (d *Defaults) CheckValues() error {
 	return d.Common.CheckValues() //nolint:wrapcheck
 }
 

--- a/service/latest_version/defaults.go
+++ b/service/latest_version/defaults.go
@@ -34,18 +34,18 @@ type DefaultsConfig struct {
 // type live under 'common', and fields specific to a single type live under that
 // type's own key.
 type Defaults struct {
-	Type string `json:"type,omitempty" yaml:"type,omitempty"` // "github" | "url".
+	Type string `json:"type,omitzero" yaml:"type,omitzero"` // "github" | "url".
 
 	Common base.Defaults   `json:"common,omitzero" yaml:"common,omitzero"`
 	GitHub github.Defaults `json:"github,omitzero" yaml:"github,omitzero"`
 	URL    web.Defaults    `json:"url,omitzero" yaml:"url,omitzero"`
 
 	// Deprecated: moved to 'github.access_token'.
-	AccessTokenDeprecated string `json:"access_token,omitempty" yaml:"access_token,omitempty"`
+	AccessTokenDeprecated string `json:"access_token,omitzero" yaml:"access_token,omitzero"`
 	// Deprecated: moved to 'github.use_prerelease'.
-	UsePreReleaseDeprecated *bool `json:"use_prerelease,omitempty" yaml:"use_prerelease,omitempty"`
+	UsePreReleaseDeprecated *bool `json:"use_prerelease,omitzero" yaml:"use_prerelease,omitzero"`
 	// Deprecated: moved to 'url.allow_invalid_certs'.
-	AllowInvalidCertsDeprecated *bool `json:"allow_invalid_certs,omitempty" yaml:"allow_invalid_certs,omitempty"`
+	AllowInvalidCertsDeprecated *bool `json:"allow_invalid_certs,omitzero" yaml:"allow_invalid_certs,omitzero"`
 	// Deprecated: moved to 'common.require'.
 	RequireDeprecated *filter.RequireDefaults `json:"require,omitzero" yaml:"require,omitzero"`
 }

--- a/service/latest_version/defaults_test.go
+++ b/service/latest_version/defaults_test.go
@@ -325,7 +325,7 @@ func TestDefaults_SetDefaults(t *testing.T) {
 	}
 }
 
-func TestDefaults_CheckValues(t *testing.T) {
+func TestDefaults_MigrateDeprecated(t *testing.T) {
 	// GIVEN: a Defaults, possibly with deprecated fields set.
 	tests := []struct {
 		name                 string
@@ -425,15 +425,10 @@ func TestDefaults_CheckValues(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			prefix := fmt.Sprintf("%s\nDefaults.CheckValues()", packageName)
+			prefix := fmt.Sprintf("%s\nDefaults.MigrateDeprecated()", packageName)
 
-			// WHEN: CheckValues is called.
-			if err := tc.input.CheckValues(); err != nil {
-				t.Fatalf(
-					"%s unexpected error: %v",
-					prefix, err,
-				)
-			}
+			// WHEN: MigrateDeprecated is called.
+			tc.input.MigrateDeprecated()
 
 			// THEN: the deprecated fields were migrated to their new home.
 			if tc.wantAccessToken != "" && tc.input.GitHub.AccessToken != tc.wantAccessToken {
@@ -459,7 +454,7 @@ func TestDefaults_CheckValues(t *testing.T) {
 				}
 			}
 			if tc.wantRequire != nil {
-				if got, want := test.StringifyPtr(&tc.input.Common.Require), test.StringifyPtr(tc.wantRequire); got != want {
+				if got, want := tc.input.Common.Require.Docker.String(""), tc.wantRequire.Docker.String(""); got != want {
 					t.Errorf(
 						"%s Require mismatch\ngot:  %v\nwant: %v",
 						prefix, got, want,
@@ -489,6 +484,55 @@ func TestDefaults_CheckValues(t *testing.T) {
 					prefix, tc.input.RequireDeprecated)
 			}
 		})
+	}
+}
+
+func TestDefaults_MigrateDeprecated__PreservesDefaultsChainForSetDefaults(t *testing.T) {
+	// GIVEN: HardDefaults with the Docker tag template set, and the deprecated
+	// 'latest_version.require' key still in its old (pre-'common.require')
+	// spot, as a user upgrading from an old config would have:
+	hd := &Defaults{}
+	hd.Default()
+
+	d := &Defaults{
+		RequireDeprecated: &filter.RequireDefaults{
+			Docker: docker.Defaults{
+				Type: "quay",
+			},
+		},
+	}
+
+	// WHEN: MigrateDeprecated runs on it and SetDefaults wires the (now-migrated) chain.
+	d.MigrateDeprecated()
+	d.SetDefaults(hd)
+
+	prefix := fmt.Sprintf("%s\nDefaults.MigrateDeprecated()+SetDefaults()", packageName)
+
+	// THEN: the migrated Common.Require.Docker must chain to the hard defaults.
+	if d.Common.Require.Docker.Defaults != &hd.Common.Require.Docker {
+		t.Errorf(
+			"%s broke the Require defaults chain\ngot:  %p\nwant: %p",
+			prefix, d.Common.Require.Docker.Defaults, &hd.Common.Require.Docker,
+		)
+	}
+	want := hd.Common.Require.Docker.Tag
+	if want == "" {
+		t.Errorf("%s HardDefaults.Common.Require.Docker.Tag should be set! got an empty string", prefix)
+	}
+	if got := d.Common.Require.Docker.GetTag(); got != want {
+		t.Errorf(
+			"%s lost the hard-default Docker tag template\ngot:  %q\nwant: %q",
+			prefix, got, want,
+		)
+	}
+
+	// AND: the migrated Type ('quay', not the hard default 'hub') must be
+	// what a per-service require.docker inherits when it omits its own type.
+	if got, want := d.Common.Require.Docker.GetType(), "quay"; got != want {
+		t.Errorf(
+			"%s lost the migrated Docker type\ngot:  %q\nwant: %q",
+			prefix, got, want,
+		)
 	}
 }
 

--- a/service/latest_version/filter/docker/container_detail.go
+++ b/service/latest_version/filter/docker/container_detail.go
@@ -22,15 +22,15 @@ import "github.com/release-argus/Argus/util"
 
 // ContainerDetail holds the image and tag for a Docker registry query.
 type ContainerDetail struct {
-	Image    string                   `json:"image,omitempty" yaml:"image,omitempty"` // Image of the container.
-	Tag      string                   `json:"tag,omitempty" yaml:"tag,omitempty"`     // Tag of the Image.
-	Defaults *ContainerDetailDefaults `json:"-" yaml:"-"`                             // Tag default chain.
+	Image    string                   `json:"image,omitzero" yaml:"image,omitzero"` // Image of the container.
+	Tag      string                   `json:"tag,omitzero" yaml:"tag,omitzero"`     // Tag of the Image.
+	Defaults *ContainerDetailDefaults `json:"-" yaml:"-"`                           // Tag default chain.
 }
 
 // ContainerDetailDefaults holds default container values.
 type ContainerDetailDefaults struct {
-	Tag      string                   `json:"tag,omitempty" yaml:"tag,omitempty"` // Default Tag template.
-	Defaults *ContainerDetailDefaults `json:"-" yaml:"-"`                         // Next link in the defaults chain.
+	Tag      string                   `json:"tag,omitzero" yaml:"tag,omitzero"` // Default Tag template.
+	Defaults *ContainerDetailDefaults `json:"-" yaml:"-"`                       // Next link in the defaults chain.
 }
 
 // #########

--- a/service/latest_version/filter/docker/convert.go
+++ b/service/latest_version/filter/docker/convert.go
@@ -31,9 +31,9 @@ func (o *oldDockerRegistryDefaults) IsZero() bool {
 
 // Deprecated: oldDockerDefaults captures all old Docker registry defaults (<=0.29.4).
 type oldDockerDefaults struct {
-	RegistryGHCR *oldDockerRegistryDefaults `json:"ghcr,omitempty" yaml:"ghcr,omitempty"`
-	RegistryHub  *oldDockerRegistryDefaults `json:"hub,omitempty" yaml:"hub,omitempty"`
-	RegistryQuay *oldDockerRegistryDefaults `json:"quay,omitempty" yaml:"quay,omitempty"`
+	RegistryGHCR *oldDockerRegistryDefaults `json:"ghcr,omitzero" yaml:"ghcr,omitzero"`
+	RegistryHub  *oldDockerRegistryDefaults `json:"hub,omitzero" yaml:"hub,omitzero"`
+	RegistryQuay *oldDockerRegistryDefaults `json:"quay,omitzero" yaml:"quay,omitzero"`
 }
 
 // IsZero implements the yaml.IsZeroer interface.

--- a/service/latest_version/filter/docker/defaults.go
+++ b/service/latest_version/filter/docker/defaults.go
@@ -15,8 +15,9 @@
 package docker
 
 import (
+	"slices"
+
 	"github.com/release-argus/Argus/config/decode"
-	"github.com/release-argus/Argus/util"
 	"github.com/release-argus/Argus/util/polymorphic"
 )
 
@@ -26,7 +27,7 @@ import (
 
 // Defaults are the default values for DockerCheck.
 type Defaults struct {
-	Type                    string                          `json:"type,omitempty" yaml:"type,omitempty"` // Type of the Docker registry.
+	Type                    string                          `json:"type,omitzero" yaml:"type,omitzero"` // Type of the Docker registry.
 	ContainerDetailDefaults `json:",inline" yaml:",inline"` // Default Tag template.
 	Registry                RegistryDefaultsSet             `json:"registry,omitzero" yaml:"registry,omitzero"` // Registry-specific defaults.
 	Defaults                *Defaults                       `json:"-" yaml:"-"`                                 // Defaults to fall back on.
@@ -156,7 +157,7 @@ func (d *Defaults) CheckValues() error {
 	}
 
 	// Type.
-	if d.Type != "" && !util.Contains(PossibleTypes, d.Type) {
+	if d.Type != "" && !slices.Contains(PossibleTypes, d.Type) {
 		return polymorphic.InvalidTypeError{
 			Key:     "type",
 			Value:   d.Type,

--- a/service/latest_version/filter/docker/registry_common.go
+++ b/service/latest_version/filter/docker/registry_common.go
@@ -33,14 +33,14 @@ import (
 
 // CommonRegistryDefaults holds shared default fields for registry checkers.
 type CommonRegistryDefaults struct {
-	Auth RegistryAuthDefaults `json:"auth,omitempty" yaml:"auth,omitempty"`
+	Auth RegistryAuthDefaults `json:"auth,omitzero" yaml:"auth,omitzero"`
 }
 
 // CommonRegistry holds shared fields for a registry checkers.
 type CommonRegistry struct {
-	Type            string                          `json:"type,omitempty" yaml:"type,omitempty"` // Type of registry to check.
+	Type            string                          `json:"type,omitzero" yaml:"type,omitzero"` // Type of registry to check.
 	ContainerDetail `json:",inline" yaml:",inline"` // Image/Tag to check.
-	Auth            RegistryAuth                    `json:"auth,omitempty" yaml:"auth,omitempty"` // Auth details.
+	Auth            RegistryAuth                    `json:"auth,omitzero" yaml:"auth,omitzero"` // Auth details.
 
 	// defaults form a fallback chain:
 	//
@@ -52,7 +52,7 @@ type CommonRegistry struct {
 
 // CommonRegistryDecode is an unmarshal-only helper for [CommonRegistry].
 type CommonRegistryDecode struct {
-	Type            string          `json:"type,omitempty" yaml:"type,omitempty"`
+	Type            string          `json:"type,omitzero" yaml:"type,omitzero"`
 	ContainerDetail ContainerDetail `json:",inline" yaml:",inline"`
 }
 

--- a/service/latest_version/filter/docker/registry_ecr_integration_test.go
+++ b/service/latest_version/filter/docker/registry_ecr_integration_test.go
@@ -65,7 +65,7 @@ func TestECRRegistry_Check(t *testing.T) {
 				},
 			},
 			version:  "latest",
-			errRegex: `^` + test.ArgusDockerECRRepo + `:latest-unknown - tag not found$`,
+			errRegex: `^` + test.ArgusDockerECRRepo + `:latest-unknown - (tag not found|\{.*Rate exceeded.*\})$`,
 		},
 		{
 			name: "unknown image",

--- a/service/latest_version/filter/docker/registry_ghcr.go
+++ b/service/latest_version/filter/docker/registry_ghcr.go
@@ -234,7 +234,7 @@ func (r *GHCRRegistry) Check(version string) error {
 
 // GHCRAuthDefaults holds authentication defaults for GHCR.
 type GHCRAuthDefaults struct {
-	Token      string       `json:"token,omitempty" yaml:"token,omitempty"` // Personal access token used to obtain GHCR query tokens.
+	Token      string       `json:"token,omitzero" yaml:"token,omitzero"` // Personal access token used to obtain GHCR query tokens.
 	mu         sync.RWMutex // Protects query token cache state.
 	queryToken string       // Cached GHCR bearer token used for registry queries.
 	validUntil time.Time    // Expiry time for the cached bearer token.

--- a/service/latest_version/filter/docker/registry_hub.go
+++ b/service/latest_version/filter/docker/registry_hub.go
@@ -257,8 +257,8 @@ func (r *HubRegistry) Check(version string) error {
 
 // HubAuthDefaults holds authentication defaults for Docker Hub.
 type HubAuthDefaults struct {
-	Username string `json:"username,omitempty" yaml:"username,omitempty"` // Username to get a new token for.
-	Token    string `json:"token,omitempty" yaml:"token,omitempty"`       // Personal access token used to obtain Docker Hub query tokens.
+	Username string `json:"username,omitzero" yaml:"username,omitzero"` // Username to get a new token for.
+	Token    string `json:"token,omitzero" yaml:"token,omitzero"`       // Personal access token used to obtain Docker Hub query tokens.
 
 	mu         sync.RWMutex // Protects query token cache state.
 	queryToken string       // Cached Docker Hub bearer token used for registry queries.

--- a/service/latest_version/filter/docker/registry_quay.go
+++ b/service/latest_version/filter/docker/registry_quay.go
@@ -237,7 +237,7 @@ func (r *QuayRegistry) Check(version string) error {
 
 // QuayAuthDefaults holds authentication defaults for Quay.
 type QuayAuthDefaults struct {
-	Token string `json:"token,omitempty" yaml:"token,omitempty"` // Token for registry queries.
+	Token string `json:"token,omitzero" yaml:"token,omitzero"` // Token for registry queries.
 
 	// defaults form a fallback chain:
 	//

--- a/service/latest_version/filter/require.go
+++ b/service/latest_version/filter/require.go
@@ -29,11 +29,11 @@ import (
 
 // Require defines validation requirements that must be met for a version to be considered valid.
 type Require struct {
-	Status       *status.Status  `json:"-" yaml:"-"`                                             // Service Status.
-	RegexContent string          `json:"regex_content,omitempty" yaml:"regex_content,omitempty"` // "abc-[a-z]+-{{ version }}_amd64.deb" This regex must exist in the body of the URL to trigger new version actions.
-	RegexVersion string          `json:"regex_version,omitempty" yaml:"regex_version,omitempty"` // "v*[0-9.]+" The version found must match this release to trigger new version actions.
-	Command      command.Command `json:"command,omitempty" yaml:"command,omitempty"`             // Require Command to pass.
-	Docker       docker.Registry `json:"docker,omitempty" yaml:"docker,omitempty"`               // Docker image tag requirements.
+	Status       *status.Status  `json:"-" yaml:"-"`                                           // Service Status.
+	RegexContent string          `json:"regex_content,omitzero" yaml:"regex_content,omitzero"` // "abc-[a-z]+-{{ version }}_amd64.deb" This regex must exist in the body of the URL to trigger new version actions.
+	RegexVersion string          `json:"regex_version,omitzero" yaml:"regex_version,omitzero"` // "v*[0-9.]+" The version found must match this release to trigger new version actions.
+	Command      command.Command `json:"command,omitempty" yaml:"command,omitempty"`           // Require Command to pass.
+	Docker       docker.Registry `json:"docker,omitzero" yaml:"docker,omitzero"`               // Docker image tag requirements.
 
 	defaults *RequireDefaults // Defaults for Require.
 }
@@ -46,9 +46,9 @@ func (r *Require) IsZero() bool {
 
 // RequireDecode is an unmarshal-only helper for [Require].
 type RequireDecode struct {
-	RegexContent string          `json:"regex_content,omitempty" yaml:"regex_content,omitempty"` // "abc-[a-z]+-{{ version }}_amd64.deb" This regex must exist in the body of the URL to trigger new version actions.
-	RegexVersion string          `json:"regex_version,omitempty" yaml:"regex_version,omitempty"` // "v*[0-9.]+" The version found must match this release to trigger new version actions.
-	Command      command.Command `json:"command,omitempty" yaml:"command,omitempty"`             // Require Command to pass.
+	RegexContent string          `json:"regex_content,omitzero" yaml:"regex_content,omitzero"` // "abc-[a-z]+-{{ version }}_amd64.deb" This regex must exist in the body of the URL to trigger new version actions.
+	RegexVersion string          `json:"regex_version,omitzero" yaml:"regex_version,omitzero"` // "v*[0-9.]+" The version found must match this release to trigger new version actions.
+	Command      command.Command `json:"command,omitempty" yaml:"command,omitempty"`           // Require Command to pass.
 }
 
 // String returns a string representation of the receiver.

--- a/service/latest_version/filter/urlcommand.go
+++ b/service/latest_version/filter/urlcommand.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/release-argus/Argus/config/decode"
@@ -34,13 +35,13 @@ type URLCommands []URLCommand
 
 // URLCommand is a command to filter versions from the URL body.
 type URLCommand struct {
-	Type     string `json:"type" yaml:"type"`                             // regex/replace/split.
-	Regex    string `json:"regex,omitempty" yaml:"regex,omitempty"`       // regex: regexp.MustCompile(Regex).
-	Text     string `json:"text,omitempty" yaml:"text,omitempty"`         // split: strings.Split(tgtString, "Text").
-	Old      string `json:"old,omitempty" yaml:"old,omitempty"`           // replace: strings.ReplaceAll(tgtString, "Old", "New").
-	New      string `json:"new,omitempty" yaml:"new,omitempty"`           // replace: strings.ReplaceAll(tgtString, "Old", "New").
-	Index    *int   `json:"index,omitempty" yaml:"index,omitempty"`       // regex/split: re.FindAllString(URL_content, -1)[Index]  /  strings.Split("text")[Index].
-	Template string `json:"template,omitempty" yaml:"template,omitempty"` // regex: template.
+	Type     string `json:"type" yaml:"type"`                           // regex/replace/split.
+	Regex    string `json:"regex,omitzero" yaml:"regex,omitzero"`       // regex: regexp.MustCompile(Regex).
+	Text     string `json:"text,omitzero" yaml:"text,omitzero"`         // split: strings.Split(tgtString, "Text").
+	Old      string `json:"old,omitzero" yaml:"old,omitzero"`           // replace: strings.ReplaceAll(tgtString, "Old", "New").
+	New      string `json:"new,omitzero" yaml:"new,omitzero"`           // replace: strings.ReplaceAll(tgtString, "Old", "New").
+	Index    *int   `json:"index,omitzero" yaml:"index,omitzero"`       // regex/split: re.FindAllString(URL_content, -1)[Index]  /  strings.Split("text")[Index].
+	Template string `json:"template,omitzero" yaml:"template,omitzero"` // regex: template.
 }
 
 // ############
@@ -170,7 +171,7 @@ func (s *URLCommands) CheckValues() error {
 
 // CheckValues validates the fields of the receiver.
 func (c *URLCommand) CheckValues() error {
-	if !util.Contains(urlCommandTypes, c.Type) {
+	if !slices.Contains(urlCommandTypes, c.Type) {
 		return polymorphic.InvalidTypeError{
 			Key:     "type",
 			Value:   c.Type,

--- a/service/latest_version/help_test.go
+++ b/service/latest_version/help_test.go
@@ -54,7 +54,7 @@ func TestMain(m *testing.M) {
 
 type mockLookup struct {
 	base.Lookup
-	OverrideErr string `json:"override_err,omitempty" yaml:"override_err,omitempty"`
+	OverrideErr string `json:"override_err,omitzero" yaml:"override_err,omitzero"`
 }
 
 func (f *mockLookup) ApplyOverrides(format string, data []byte) error {

--- a/service/latest_version/test/lookup.go
+++ b/service/latest_version/test/lookup.go
@@ -35,7 +35,7 @@ import (
 // MockLookup is a configurable latest version lookup stub for tests.
 type MockLookup struct {
 	base.Lookup
-	OverrideErr string `json:"override_err,omitempty" yaml:"override_err,omitempty"`
+	OverrideErr string `json:"override_err,omitzero" yaml:"override_err,omitzero"`
 }
 
 func (f *MockLookup) ApplyOverrides(format string, data []byte) error {

--- a/service/latest_version/types/base/base.go
+++ b/service/latest_version/types/base/base.go
@@ -28,10 +28,10 @@ import (
 
 // Lookup is the base struct for an [Interface].
 type Lookup struct {
-	Type        string             `json:"type,omitempty" yaml:"type,omitempty"`                 // "github" | "url".
-	URL         string             `json:"url,omitempty" yaml:"url,omitempty"`                   // "owner/repo" or "https://github.com/owner/repo".
+	Type        string             `json:"type,omitzero" yaml:"type,omitzero"`                   // "github" | "url".
+	URL         string             `json:"url,omitzero" yaml:"url,omitzero"`                     // "owner/repo" or "https://github.com/owner/repo".
 	URLCommands filter.URLCommands `json:"url_commands,omitempty" yaml:"url_commands,omitempty"` // Commands to filter the release from the URL request.
-	Require     *filter.Require    `json:"require,omitempty" yaml:"require,omitempty"`           // Options to require before considering a release valid.
+	Require     *filter.Require    `json:"require,omitzero" yaml:"require,omitzero"`             // Options to require before considering a release valid.
 
 	Options *opt.Options   `json:"-" yaml:"-"` // Options.
 	Status  *status.Status `json:"-" yaml:"-"` // Service Status.
@@ -42,8 +42,8 @@ type Lookup struct {
 
 // LookupDecode is an unmarshal-only helper for [Lookup].
 type LookupDecode struct {
-	Type        string             `json:"type,omitempty" yaml:"type,omitempty"`
-	URL         string             `json:"url,omitempty" yaml:"url,omitempty"`
+	Type        string             `json:"type,omitzero" yaml:"type,omitzero"`
+	URL         string             `json:"url,omitzero" yaml:"url,omitzero"`
 	URLCommands filter.URLCommands `json:"url_commands,omitempty" yaml:"url_commands,omitempty"`
 }
 

--- a/service/latest_version/types/github/api_type/types.go
+++ b/service/latest_version/types/github/api_type/types.go
@@ -23,13 +23,13 @@ import (
 
 // Release is the format of a Release on api.github.com/repos/OWNER/REPO/releases.
 type Release struct {
-	URL             string          `json:"url,omitempty"`
-	AssetsURL       string          `json:"assets_url,omitempty"`
+	URL             string          `json:"url,omitzero"`
+	AssetsURL       string          `json:"assets_url,omitzero"`
 	SemanticVersion *semver.Version `json:"-"`
-	TagName         string          `json:"tag_name,omitempty"`
-	Name            string          `json:"name,omitempty"` // Tag name on /tags queries.
+	TagName         string          `json:"tag_name,omitzero"`
+	Name            string          `json:"name,omitzero"` // Tag name on /tags queries.
 	PreRelease      bool            `json:"prerelease"`
-	PublishedAt     string          `json:"published_at,omitempty"`
+	PublishedAt     string          `json:"published_at,omitzero"`
 	Assets          []Asset         `json:"assets,omitempty"`
 }
 
@@ -48,11 +48,11 @@ func ReleaseSort(a, b Release) bool {
 
 // Asset is the format of an Asset on api.github.com/repos/OWNER/REPO/releases.
 type Asset struct {
-	URL                string `json:"url,omitempty"`
+	URL                string `json:"url,omitzero"`
 	ID                 uint   `json:"id"`
-	Name               string `json:"name,omitempty"`
-	CreatedAt          string `json:"created_at,omitempty"`
-	BrowserDownloadURL string `json:"browser_download_url,omitempty"`
+	Name               string `json:"name,omitzero"`
+	CreatedAt          string `json:"created_at,omitzero"`
+	BrowserDownloadURL string `json:"browser_download_url,omitzero"`
 }
 
 // String implements fmt.Stringer and returns a JSON representation.
@@ -65,5 +65,5 @@ func (a *Asset) String() string {
 
 // Message is the format of a Message from a GitHub API response.
 type Message struct {
-	Message string `json:"message,omitempty"`
+	Message string `json:"message,omitzero"`
 }

--- a/service/latest_version/types/github/defaults.go
+++ b/service/latest_version/types/github/defaults.go
@@ -16,8 +16,8 @@ package github
 
 // Defaults are the GitHub-specific default values for a Lookup.
 type Defaults struct {
-	AccessToken   string `json:"access_token,omitempty" yaml:"access_token,omitempty"`     // Access token to use.
-	UsePreRelease *bool  `json:"use_prerelease,omitempty" yaml:"use_prerelease,omitempty"` // Whether releases with prerelease tag are considered.
+	AccessToken   string `json:"access_token,omitzero" yaml:"access_token,omitzero"`     // Access token to use.
+	UsePreRelease *bool  `json:"use_prerelease,omitzero" yaml:"use_prerelease,omitzero"` // Whether releases with prerelease tag are considered.
 }
 
 // IsZero implements the yaml.IsZeroer interface.

--- a/service/latest_version/types/github/githubdata.go
+++ b/service/latest_version/types/github/githubdata.go
@@ -71,7 +71,7 @@ type Data struct {
 
 // DataJSON is the JSON representation of cached GitHub release data.
 type DataJSON struct {
-	ETag     string            `json:"etag,omitempty"`
+	ETag     string            `json:"etag,omitzero"`
 	Releases []ghtypes.Release `json:"releases,omitempty"`
 }
 

--- a/service/latest_version/types/github/types.go
+++ b/service/latest_version/types/github/types.go
@@ -36,8 +36,8 @@ var Type = "github"
 type Lookup struct {
 	base.Lookup `json:",inline" yaml:",inline"`
 
-	AccessToken   string `json:"access_token,omitempty" yaml:"access_token,omitempty"`     // GitHub access token to use.
-	UsePreRelease *bool  `json:"use_prerelease,omitempty" yaml:"use_prerelease,omitempty"` // Whether releases with the prerelease tag should be considered.
+	AccessToken   string `json:"access_token,omitzero" yaml:"access_token,omitzero"`     // GitHub access token to use.
+	UsePreRelease *bool  `json:"use_prerelease,omitzero" yaml:"use_prerelease,omitzero"` // Whether releases with the prerelease tag should be considered.
 
 	data Data // GitHub Conditional Request vars / Releases.
 
@@ -47,8 +47,8 @@ type Lookup struct {
 
 // LookupDecode is an unmarshal-only helper for [Lookup].
 type LookupDecode struct {
-	AccessToken   string `json:"access_token,omitempty" yaml:"access_token,omitempty"`
-	UsePreRelease *bool  `json:"use_prerelease,omitempty" yaml:"use_prerelease,omitempty"`
+	AccessToken   string `json:"access_token,omitzero" yaml:"access_token,omitzero"`
+	UsePreRelease *bool  `json:"use_prerelease,omitzero" yaml:"use_prerelease,omitzero"`
 }
 
 // ############

--- a/service/latest_version/types/web/defaults.go
+++ b/service/latest_version/types/web/defaults.go
@@ -16,7 +16,7 @@ package web
 
 // Defaults are the URL-specific default values for a Lookup.
 type Defaults struct {
-	AllowInvalidCerts *bool `json:"allow_invalid_certs,omitempty" yaml:"allow_invalid_certs,omitempty"` // Default - false = Disallows invalid HTTPS certificates.
+	AllowInvalidCerts *bool `json:"allow_invalid_certs,omitzero" yaml:"allow_invalid_certs,omitzero"` // Default - false = Disallows invalid HTTPS certificates.
 }
 
 // IsZero implements the yaml.IsZeroer interface.

--- a/service/latest_version/types/web/types.go
+++ b/service/latest_version/types/web/types.go
@@ -37,8 +37,8 @@ var Type = "url"
 type Lookup struct {
 	base.Lookup `json:",inline" yaml:",inline"`
 
-	AllowInvalidCerts *bool          `json:"allow_invalid_certs,omitempty" yaml:"allow_invalid_certs,omitempty"` // Allow invalid SSL certificates.
-	Headers           shared.Headers `json:"headers,omitempty" yaml:"headers,omitempty"`                         // OPTIONAL: request headers.
+	AllowInvalidCerts *bool          `json:"allow_invalid_certs,omitzero" yaml:"allow_invalid_certs,omitzero"` // Allow invalid SSL certificates.
+	Headers           shared.Headers `json:"headers,omitempty" yaml:"headers,omitempty"`                       // OPTIONAL: request headers.
 
 	typeDefaults     *Defaults // URL-specific Defaults.
 	typeHardDefaults *Defaults // URL-specific Hard Defaults.
@@ -46,7 +46,7 @@ type Lookup struct {
 
 // LookupDecode is an unmarshal-only helper for [Lookup].
 type LookupDecode struct {
-	AllowInvalidCerts *bool          `json:"allow_invalid_certs,omitempty" yaml:"allow_invalid_certs,omitempty"`
+	AllowInvalidCerts *bool          `json:"allow_invalid_certs,omitzero" yaml:"allow_invalid_certs,omitzero"`
 	Headers           shared.Headers `json:"headers,omitempty" yaml:"headers,omitempty"`
 }
 

--- a/service/option/option.go
+++ b/service/option/option.go
@@ -35,8 +35,8 @@ type DefaultsConfig struct {
 
 // Base is the base struct for Options.
 type Base struct {
-	Interval           string `json:"interval,omitempty" yaml:"interval,omitempty"`                       // AhBmCs = Sleep A hours, B minutes, and C seconds between queries.
-	SemanticVersioning *bool  `json:"semantic_versioning,omitempty" yaml:"semantic_versioning,omitempty"` // Default - true = Version has to follow semantic versioning (https://semver.org/), and be greater than the previous to trigger anything.
+	Interval           string `json:"interval,omitzero" yaml:"interval,omitzero"`                       // AhBmCs = Sleep A hours, B minutes, and C seconds between queries.
+	SemanticVersioning *bool  `json:"semantic_versioning,omitzero" yaml:"semantic_versioning,omitzero"` // Default - true = Version has to follow semantic versioning (https://semver.org/), and be greater than the previous to trigger anything.
 }
 
 // IsZero implements the yaml.IsZeroer interface.
@@ -69,7 +69,7 @@ func (d *Defaults) Default() {
 type Options struct {
 	Base `json:",inline" yaml:",inline"`
 
-	Active *bool `json:"active,omitempty" yaml:"active,omitempty"` // Disable the service.
+	Active *bool `json:"active,omitzero" yaml:"active,omitzero"` // Disable the service.
 
 	Defaults     *Defaults `json:"-" yaml:"-"` // Defaults.
 	HardDefaults *Defaults `json:"-" yaml:"-"` // Hard Defaults.

--- a/service/shared/types.go
+++ b/service/shared/types.go
@@ -17,13 +17,13 @@ package shared
 
 // OldIntIndex is an integer index reference used when restoring SecretValues.
 type OldIntIndex struct {
-	OldIndex *int `json:"old_index,omitempty"`
+	OldIndex *int `json:"old_index,omitzero"`
 }
 
 // OldStringIndex is a named string index reference used when restoring SecretValues.
 type OldStringIndex struct {
-	Name     string `json:"name,omitempty"`
-	OldIndex string `json:"old_index,omitempty"`
+	Name     string `json:"name,omitzero"`
+	OldIndex string `json:"old_index,omitzero"`
 }
 
 // VSecretRef contains the reference for the Headers SecretValues.
@@ -33,7 +33,7 @@ type VSecretRef struct {
 
 // WHSecretRef contains the reference for the WebHook SecretValues.
 type WHSecretRef struct {
-	Name     string        `json:"name,omitempty"`
-	OldIndex string        `json:"old_index,omitempty"`
+	Name     string        `json:"name,omitzero"`
+	OldIndex string        `json:"old_index,omitzero"`
 	Headers  []OldIntIndex `json:"headers,omitempty"`
 }

--- a/service/status/fails.go
+++ b/service/status/fails.go
@@ -16,6 +16,7 @@
 package status
 
 import (
+	"maps"
 	"strconv"
 	"strings"
 	"sync"
@@ -330,9 +331,7 @@ func (f *Fails) Copy(from *Fails) {
 	defer from.Shoutrrr.mu.RUnlock()
 
 	f.Shoutrrr.fails = make(map[string]*bool, len(from.Shoutrrr.fails))
-	for key, fail := range from.Shoutrrr.fails {
-		f.Shoutrrr.fails[key] = fail
-	}
+	maps.Copy(f.Shoutrrr.fails, from.Shoutrrr.fails)
 
 	// WebHook.
 	f.WebHook.mu.Lock()
@@ -341,9 +340,7 @@ func (f *Fails) Copy(from *Fails) {
 	defer from.WebHook.mu.RUnlock()
 
 	f.WebHook.fails = make(map[string]*bool, len(from.WebHook.fails))
-	for key, fail := range from.WebHook.fails {
-		f.WebHook.fails[key] = fail
-	}
+	maps.Copy(f.WebHook.fails, from.WebHook.fails)
 }
 
 // resetFails clears command, shoutrrr, and webhook failure tracking.

--- a/service/status/info/info.go
+++ b/service/status/info/info.go
@@ -21,18 +21,18 @@ import "sync"
 type ServiceInfo struct {
 	mu *sync.RWMutex // Mutex for thread-safe access
 
-	ID      string `json:"id,omitempty"`      // Service ID.
-	Name    string `json:"name,omitempty"`    // Service Name.
-	Comment string `json:"comment,omitempty"` // Service Comment.
-	URL     string `json:"url,omitempty"`     // Service URL.
+	ID      string `json:"id,omitzero"`      // Service ID.
+	Name    string `json:"name,omitzero"`    // Service Name.
+	Comment string `json:"comment,omitzero"` // Service Comment.
+	URL     string `json:"url,omitzero"`     // Service URL.
 
-	Icon       string `json:"icon,omitempty"`         // Icon URL.
-	IconLinkTo string `json:"icon_link_to,omitempty"` // URL to redirect Icon clicks to.
-	WebURL     string `json:"web_url,omitempty"`      // Web URL.
+	Icon       string `json:"icon,omitzero"`         // Icon URL.
+	IconLinkTo string `json:"icon_link_to,omitzero"` // URL to redirect Icon clicks to.
+	WebURL     string `json:"web_url,omitzero"`      // Web URL.
 
-	ApprovedVersion string `json:"approved_version,omitempty"` // The version of the Service that has been approved for deployment.
-	DeployedVersion string `json:"deployed_version,omitempty"` // The deployed version of the Service.
-	LatestVersion   string `json:"latest_version,omitempty"`   // The latest version of the Service.
+	ApprovedVersion string `json:"approved_version,omitzero"` // The version of the Service that has been approved for deployment.
+	DeployedVersion string `json:"deployed_version,omitzero"` // The deployed version of the Service.
+	LatestVersion   string `json:"latest_version,omitzero"`   // The latest version of the Service.
 
 	Tags []string `json:"tags,omitempty"` // Tags for the Service.
 }

--- a/service/track_test.go
+++ b/service/track_test.go
@@ -19,6 +19,7 @@ package service
 import (
 	"fmt"
 	"regexp"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -30,7 +31,6 @@ import (
 
 	"github.com/release-argus/Argus/internal/logx"
 	"github.com/release-argus/Argus/internal/test"
-	"github.com/release-argus/Argus/util"
 	apitype "github.com/release-argus/Argus/web/api/types"
 	"github.com/release-argus/Argus/web/metric"
 )
@@ -91,7 +91,7 @@ func TestServices_Track(t *testing.T) {
 			// THEN: the function exits straight away.
 			time.Sleep(2 * time.Second)
 			for i := range *services {
-				if !util.Contains(tc.ordering, i) {
+				if !slices.Contains(tc.ordering, i) {
 					if wantLatestVersion := ""; (*services)[i].Status.LatestVersion() != wantLatestVersion {
 						t.Fatalf(
 							"%s query on Services[%q] shouldn't have happened as not in ordering\ngot:  latest_version=%q\nwant: latest_version=%q\norder: %v",

--- a/service/types.go
+++ b/service/types.go
@@ -43,12 +43,12 @@ type Services map[string]*Service
 // Service is a source to track latest and deployed versions of a service.
 // It also has the ability to run commands, send notifications and send WebHooks on new releases.
 type Service struct {
-	ID                    string             `json:"-" yaml:"-"`                                                   // Key/Name of the Service.
-	Name                  string             `json:"name,omitempty" yaml:"name,omitempty"`                         // Name of the Service.
-	Comment               string             `json:"comment,omitempty" yaml:"comment,omitempty"`                   // Comment on the Service.
-	Options               opt.Options        `json:"options,omitempty" yaml:"options,omitempty"`                   // Options to give the Service.
-	LatestVersion         latestver.Lookup   `json:"latest_version,omitempty" yaml:"latest_version,omitempty"`     // Vars to scrape the latest version of the Service.
-	DeployedVersionLookup deployedver.Lookup `json:"deployed_version,omitempty" yaml:"deployed_version,omitempty"` // Vars to scrape the Service's current deployed version.
+	ID                    string             `json:"-" yaml:"-"`                                                 // Key/Name of the Service.
+	Name                  string             `json:"name,omitzero" yaml:"name,omitzero"`                         // Name of the Service.
+	Comment               string             `json:"comment,omitzero" yaml:"comment,omitzero"`                   // Comment on the Service.
+	Options               opt.Options        `json:"options,omitzero" yaml:"options,omitzero"`                   // Options to give the Service.
+	LatestVersion         latestver.Lookup   `json:"latest_version,omitzero" yaml:"latest_version,omitzero"`     // Vars to scrape the latest version of the Service.
+	DeployedVersionLookup deployedver.Lookup `json:"deployed_version,omitzero" yaml:"deployed_version,omitzero"` // Vars to scrape the Service's current deployed version.
 
 	Notify             shoutrrr.Shoutrrrs `json:"notify,omitempty" yaml:"notify,omitempty"` // Service-specific Shoutrrr vars.
 	NotifyFromDefaults bool               `json:"-" yaml:"-"`
@@ -60,7 +60,7 @@ type Service struct {
 	WebHook             webhook.WebHooks `json:"webhook,omitempty" yaml:"webhook,omitempty"` // Service-specific WebHook vars.
 	WebHookFromDefaults bool             `json:"-" yaml:"-"`
 
-	Dashboard dashboard.Options `json:"dashboard,omitempty" yaml:"dashboard,omitempty"` // Options for the dashboard.
+	Dashboard dashboard.Options `json:"dashboard,omitzero" yaml:"dashboard,omitzero"` // Options for the dashboard.
 
 	Status status.Status `json:"-" yaml:"-"` // Track the Status of this source (version and regex misses).
 
@@ -70,26 +70,26 @@ type Service struct {
 
 // serviceMarshal is a marshal-only helper for [Service].
 type serviceMarshal struct {
-	Name                  string             `json:"name,omitempty" yaml:"name,omitempty"`
-	Comment               string             `json:"comment,omitempty" yaml:"comment,omitempty"`
-	Options               opt.Options        `json:"options,omitempty" yaml:"options,omitempty"`
-	LatestVersion         latestver.Lookup   `json:"latest_version,omitempty" yaml:"latest_version,omitempty"`
-	DeployedVersionLookup deployedver.Lookup `json:"deployed_version,omitempty" yaml:"deployed_version,omitempty"`
+	Name                  string             `json:"name,omitzero" yaml:"name,omitzero"`
+	Comment               string             `json:"comment,omitzero" yaml:"comment,omitzero"`
+	Options               opt.Options        `json:"options,omitzero" yaml:"options,omitzero"`
+	LatestVersion         latestver.Lookup   `json:"latest_version,omitzero" yaml:"latest_version,omitzero"`
+	DeployedVersionLookup deployedver.Lookup `json:"deployed_version,omitzero" yaml:"deployed_version,omitzero"`
 	Notify                shoutrrr.Shoutrrrs `json:"notify,omitempty" yaml:"notify,omitempty"`
 	Command               command.Commands   `json:"command,omitempty" yaml:"command,omitempty"`
 	WebHook               webhook.WebHooks   `json:"webhook,omitempty" yaml:"webhook,omitempty"`
-	Dashboard             dashboard.Options  `json:"dashboard,omitempty" yaml:"dashboard,omitempty"`
+	Dashboard             dashboard.Options  `json:"dashboard,omitzero" yaml:"dashboard,omitzero"`
 }
 
 // serviceDecode is an unmarshal-only helper for [Service].
 type serviceDecode struct {
-	Name      string             `json:"name,omitempty" yaml:"name,omitempty"`
-	Comment   string             `json:"comment,omitempty" yaml:"comment,omitempty"`
-	Options   opt.Options        `json:"options,omitempty" yaml:"options,omitempty"`
+	Name      string             `json:"name,omitzero" yaml:"name,omitzero"`
+	Comment   string             `json:"comment,omitzero" yaml:"comment,omitzero"`
+	Options   opt.Options        `json:"options,omitzero" yaml:"options,omitzero"`
 	Notify    shoutrrr.Shoutrrrs `json:"notify,omitempty" yaml:"notify,omitempty"`
 	Command   command.Commands   `json:"command,omitempty" yaml:"command,omitempty"`
 	WebHook   webhook.WebHooks   `json:"webhook,omitempty" yaml:"webhook,omitempty"`
-	Dashboard dashboard.Options  `json:"dashboard,omitempty" yaml:"dashboard,omitempty"`
+	Dashboard dashboard.Options  `json:"dashboard,omitzero" yaml:"dashboard,omitzero"`
 }
 
 // MarshalJSON implements the json.Marshaler interface.

--- a/testing/service.go
+++ b/testing/service.go
@@ -17,11 +17,11 @@ package testing
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/release-argus/Argus/config"
 	"github.com/release-argus/Argus/internal/logx"
-	"github.com/release-argus/Argus/util"
 )
 
 // ServiceTest queries the service and returns the found version.
@@ -40,7 +40,7 @@ func ServiceTest(flag *string, cfg *config.Config) bool {
 	)
 
 	// Check service exists.
-	if !util.Contains(cfg.Order, *flag) {
+	if !slices.Contains(cfg.Order, *flag) {
 		logx.Fatal(
 			fmt.Sprintf(
 				"Service %q could not be found in config.service\nDid you mean one of these?\n  - %s",

--- a/testing/shoutrrr.go
+++ b/testing/shoutrrr.go
@@ -17,6 +17,7 @@ package testing
 
 import (
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 
@@ -161,7 +162,7 @@ func getAllShoutrrrNames(cfg *config.Config) (all []string) {
 	if cfg.Service != nil {
 		for _, svc := range cfg.Service {
 			for key := range svc.Notify {
-				if !util.Contains(all, key) {
+				if !slices.Contains(all, key) {
 					all = append(all, key)
 				}
 			}

--- a/util/maps.go
+++ b/util/maps.go
@@ -39,9 +39,7 @@ func MergeMaps[K comparable](m1, m2 map[K]string) map[K]string {
 // CopyMap returns a copy of the map.
 func CopyMap[K comparable, V any](m map[K]V) map[K]V {
 	out := make(map[K]V, len(m))
-	for k, v := range m {
-		out[k] = v
-	}
+	maps.Copy(out, m)
 	return out
 }
 

--- a/util/send.go
+++ b/util/send.go
@@ -32,7 +32,7 @@ func RetryWithBackoff(
 ) error {
 	var errs []error
 
-	for try := uint8(0); try < maxTries; try++ {
+	for try := range maxTries {
 		// Stop retrying?
 		if shouldStop != nil && shouldStop() {
 			return nil

--- a/util/slices.go
+++ b/util/slices.go
@@ -17,16 +17,6 @@ package util
 
 import "bytes"
 
-// Contains returns whether `s` contains `e`.
-func Contains[T comparable](s []T, e T) bool {
-	for _, v := range s {
-		if v == e {
-			return true
-		}
-	}
-	return false
-}
-
 // CopySlice returns a copy of the slice.
 func CopySlice[T any](s []T) []T {
 	newList := make([]T, len(s))

--- a/util/slices_test.go
+++ b/util/slices_test.go
@@ -24,52 +24,6 @@ import (
 	"github.com/release-argus/Argus/internal/test"
 )
 
-func TestContains(t *testing.T) {
-	// GIVEN: lists of strings.
-	tests := []struct {
-		name        string
-		list        []string
-		contain     string
-		doesContain bool
-	}{
-		{
-			name:        "[]string does contain",
-			list:        []string{"hello", "hi", "hiya"},
-			contain:     "hi",
-			doesContain: true,
-		},
-		{
-			name:        "[]string does not contain",
-			list:        []string{"hello", "hi", "hiya"},
-			contain:     "howdy",
-			doesContain: false,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			// WHEN: Contains is run on this slice.
-			var found bool
-			found = Contains(tc.list, tc.contain)
-
-			prefix := fmt.Sprintf(
-				"%s\nContains(list=%v, contain=%q)",
-				packageName, tc.list, tc.contain,
-			)
-
-			// THEN: true is returned if it does contain the item.
-			if found != tc.doesContain {
-				t.Errorf(
-					"%s mismatch\ngot:  %t\nwant: %t",
-					prefix, found, tc.doesContain,
-				)
-			}
-		})
-	}
-}
-
 func TestCopySlice(t *testing.T) {
 	// GIVEN: a set of int slices.
 	tests := []struct {

--- a/web/api/types/argus.go
+++ b/web/api/types/argus.go
@@ -27,19 +27,19 @@ import (
 
 // ServiceSummary is the Summary of a Service.
 type ServiceSummary struct {
-	ID                  string    `json:"id,omitempty" yaml:"id,omitempty"`
-	Name                *string   `json:"name,omitempty" yaml:"name,omitempty"`                                   // Name for this Service.
-	Active              *bool     `json:"active,omitempty" yaml:"active,omitempty"`                               // Active Service?
-	Comment             *string   `json:"comment,omitempty" yaml:"comment,omitempty"`                             // Comment on the Service.
-	Type                string    `json:"type,omitempty" yaml:"type,omitempty"`                                   // "github"|"URL".
-	WebURL              *string   `json:"url,omitempty" yaml:"url,omitempty"`                                     // URL to provide on the Web UI.
-	Icon                *string   `json:"icon,omitempty" yaml:"icon,omitempty"`                                   // Service.Dashboard.Icon / Service.Notify.*.Params.Icon / Service.Notify.*.Defaults.Params.Icon.
-	IconLinkTo          *string   `json:"icon_link_to,omitempty" yaml:"icon_link_to,omitempty"`                   // URL to redirect Icon clicks to.
-	DeployedVersionType *string   `json:"deployed_version_type,omitempty" yaml:"deployed_version_type,omitempty"` // "manual"|"url", empty string if no DeployedVersionLookup.
-	Command             *int      `json:"command,omitempty" yaml:"command,omitempty"`                             // Amount of Commands to send on a new release.
-	WebHook             *int      `json:"webhook,omitempty" yaml:"webhook,omitempty"`                             // Amount of WebHooks to send on a new release.
-	Status              *Status   `json:"status,omitempty" yaml:"status,omitempty"`                               // Track the Status of this source (version and regex misses).
-	Tags                *[]string `json:"tags,omitempty" yaml:"tags,omitempty"`                                   // Tags for the Service.
+	ID                  string    `json:"id,omitzero" yaml:"id,omitzero"`
+	Name                *string   `json:"name,omitzero" yaml:"name,omitzero"`                                   // Name for this Service.
+	Active              *bool     `json:"active,omitzero" yaml:"active,omitzero"`                               // Active Service?
+	Comment             *string   `json:"comment,omitzero" yaml:"comment,omitzero"`                             // Comment on the Service.
+	Type                string    `json:"type,omitzero" yaml:"type,omitzero"`                                   // "github"|"URL".
+	WebURL              *string   `json:"url,omitzero" yaml:"url,omitzero"`                                     // URL to provide on the Web UI.
+	Icon                *string   `json:"icon,omitzero" yaml:"icon,omitzero"`                                   // Service.Dashboard.Icon / Service.Notify.*.Params.Icon / Service.Notify.*.Defaults.Params.Icon.
+	IconLinkTo          *string   `json:"icon_link_to,omitzero" yaml:"icon_link_to,omitzero"`                   // URL to redirect Icon clicks to.
+	DeployedVersionType *string   `json:"deployed_version_type,omitzero" yaml:"deployed_version_type,omitzero"` // "manual"|"url", empty string if no DeployedVersionLookup.
+	Command             *int      `json:"command,omitzero" yaml:"command,omitzero"`                             // Amount of Commands to send on a new release.
+	WebHook             *int      `json:"webhook,omitzero" yaml:"webhook,omitzero"`                             // Amount of WebHooks to send on a new release.
+	Status              *Status   `json:"status,omitempty" yaml:"status,omitempty"`                             // Track the Status of this source (version and regex misses).
+	Tags                *[]string `json:"tags,omitzero" yaml:"tags,omitzero"`                                   // Tags for the Service.
 }
 
 // IsZero implements the yaml.IsZeroer interface.
@@ -142,18 +142,6 @@ func (s *ServiceSummary) RemoveUnchanged(oldData *ServiceSummary) {
 	s.WebHook = nilIfUnchanged(oldData.WebHook, s.WebHook)
 }
 
-// StatusFails is the fail status of each notifier/webhook.
-type StatusFails struct {
-	Notify  *[]bool `json:"notify,omitempty" yaml:"notify,omitempty"`   // Track whether any of the Notifiers failed.
-	WebHook *[]bool `json:"webhook,omitempty" yaml:"webhook,omitempty"` // Track whether any of the WebHooks failed.
-}
-
-// StatusFailsSummary is the overall fail status of notifiers/webhooks.
-type StatusFailsSummary struct {
-	Notify  *bool `json:"notify,omitempty" yaml:"notify,omitempty"`   // Track whether any of the Notifiers failed.
-	WebHook *bool `json:"webhook,omitempty" yaml:"webhook,omitempty"` // Track whether any of the WebHooks failed.
-}
-
 // ActionSummary is the summary of all Actions for a Service.
 type ActionSummary struct {
 	Command map[string]CommandSummary `json:"command" yaml:"command"` // Summary of all Commands.
@@ -162,39 +150,39 @@ type ActionSummary struct {
 
 // WebHookSummary is the summary of a WebHook.
 type WebHookSummary struct {
-	Failed       *bool     `json:"failed,omitempty" yaml:"failed,omitempty"`               // Whether this WebHook failed to send successfully for the LatestVersion.
+	Failed       *bool     `json:"failed,omitzero" yaml:"failed,omitzero"`                 // Whether this WebHook failed to send successfully for the LatestVersion.
 	NextRunnable time.Time `json:"next_runnable,omitempty" yaml:"next_runnable,omitempty"` // Time the WebHook can next run (for staggering).
 }
 
 // BuildInfo is information from build time.
 type BuildInfo struct {
-	Version   string `json:"version,omitempty" yaml:"version,omitempty"`
-	BuildDate string `json:"build_date,omitempty" yaml:"build_date,omitempty"`
-	GoVersion string `json:"go_version,omitempty" yaml:"go_version,omitempty"`
+	Version   string `json:"version,omitzero" yaml:"version,omitzero"`
+	BuildDate string `json:"build_date,omitzero" yaml:"build_date,omitzero"`
+	GoVersion string `json:"go_version,omitzero" yaml:"go_version,omitzero"`
 }
 
 // RuntimeInfo defines current runtime information.
 type RuntimeInfo struct {
-	StartTime      time.Time `json:"start_time,omitempty" yaml:"start_time,omitempty"`
-	CWD            string    `json:"cwd,omitempty" yaml:"cwd,omitempty"`
-	GoRoutineCount int       `json:"goroutines,omitempty" yaml:"goroutines,omitempty"`
-	GOMAXPROCS     int       `json:"GOMAXPROCS,omitempty" yaml:"GOMAXPROCS,omitempty"`
-	GoGC           string    `json:"GOGC,omitempty" yaml:"GOGC,omitempty"`
-	GoDebug        string    `json:"GODEBUG,omitempty" yaml:"GODEBUG,omitempty"`
+	StartTime      time.Time `json:"start_time,omitzero" yaml:"start_time,omitzero"`
+	CWD            string    `json:"cwd,omitzero" yaml:"cwd,omitzero"`
+	GoRoutineCount int       `json:"goroutines,omitzero" yaml:"goroutines,omitzero"`
+	GOMAXPROCS     int       `json:"GOMAXPROCS,omitzero" yaml:"GOMAXPROCS,omitzero"`
+	GoGC           string    `json:"GOGC,omitzero" yaml:"GOGC,omitzero"`
+	GoDebug        string    `json:"GODEBUG,omitzero" yaml:"GODEBUG,omitzero"`
 }
 
 // Flags define the runtime flags.
 type Flags struct {
-	ConfigFile       string `json:"config.file,omitempty" yaml:"config.file,omitempty"`
-	LogLevel         string `json:"log.level,omitempty" yaml:"log.level,omitempty"`
-	LogTimestamps    *bool  `json:"log.timestamps,omitempty" yaml:"log.timestamps,omitempty"`
-	DataDatabaseFile string `json:"data.database-file,omitempty" yaml:"data.database-file,omitempty"`
-	DataReadonly     bool   `json:"data.readonly,omitempty" yaml:"data.readonly,omitempty"`
-	WebListenHost    string `json:"web.listen-host,omitempty" yaml:"web.listen-host,omitempty"`
-	WebListenPort    string `json:"web.listen-port,omitempty" yaml:"web.listen-port,omitempty"`
+	ConfigFile       string `json:"config.file,omitzero" yaml:"config.file,omitzero"`
+	LogLevel         string `json:"log.level,omitzero" yaml:"log.level,omitzero"`
+	LogTimestamps    *bool  `json:"log.timestamps,omitzero" yaml:"log.timestamps,omitzero"`
+	DataDatabaseFile string `json:"data.database-file,omitzero" yaml:"data.database-file,omitzero"`
+	DataReadonly     bool   `json:"data.readonly" yaml:"data.readonly"`
+	WebListenHost    string `json:"web.listen-host,omitzero" yaml:"web.listen-host,omitzero"`
+	WebListenPort    string `json:"web.listen-port,omitzero" yaml:"web.listen-port,omitzero"`
 	WebCertFile      string `json:"web.cert-file" yaml:"web.cert-file"`
 	WebPKeyFile      string `json:"web.pkey-file" yaml:"web.pkey-file"`
-	WebRoutePrefix   string `json:"web.route-prefix,omitempty" yaml:"web.route-prefix,omitempty"`
+	WebRoutePrefix   string `json:"web.route-prefix,omitzero" yaml:"web.route-prefix,omitzero"`
 }
 
 // Defaults are the global defaults for vars.
@@ -248,8 +236,8 @@ func (s *Settings) IsZero() bool {
 
 // DataSettings contains data settings for the program.
 type DataSettings struct {
-	DatabaseFile string `json:"database_file,omitempty" yaml:"database_file,omitempty"` // Database file path.
-	Readonly     *bool  `json:"readonly,omitempty" yaml:"readonly,omitempty"`           // Disable saving config changes to disk.
+	DatabaseFile string `json:"database_file,omitzero" yaml:"database_file,omitzero"` // Database file path.
+	Readonly     *bool  `json:"readonly,omitzero" yaml:"readonly,omitzero"`           // Disable saving config changes to disk.
 }
 
 // IsZero implements the yaml.IsZeroer interface.
@@ -260,8 +248,8 @@ func (d DataSettings) IsZero() bool {
 
 // LogSettings contains web settings for the program.
 type LogSettings struct {
-	Timestamps *bool  `json:"timestamps,omitempty" yaml:"timestamps,omitempty"` // Timestamps in command-line tool output.
-	Level      string `json:"level,omitempty" yaml:"level,omitempty"`           // Log level.
+	Timestamps *bool  `json:"timestamps,omitzero" yaml:"timestamps,omitzero"` // Timestamps in command-line tool output.
+	Level      string `json:"level,omitzero" yaml:"level,omitzero"`           // Log level.
 }
 
 // IsZero implements the yaml.IsZeroer interface.
@@ -272,11 +260,11 @@ func (l LogSettings) IsZero() bool {
 
 // WebSettings contains web settings for the program.
 type WebSettings struct {
-	ListenHost     string   `json:"listen_host,omitempty" yaml:"listen_host,omitempty"`         // Web listen host.
-	ListenPort     string   `json:"listen_port,omitempty" yaml:"listen_port,omitempty"`         // Web listen port.
-	CertFile       string   `json:"cert_file,omitempty" yaml:"cert_file,omitempty"`             // HTTPS certificate path.
-	KeyFile        string   `json:"pkey_file,omitempty" yaml:"pkey_file,omitempty"`             // HTTPS privkey path.
-	RoutePrefix    string   `json:"route_prefix,omitempty" yaml:"route_prefix,omitempty"`       // Web endpoint prefix.
+	ListenHost     string   `json:"listen_host,omitzero" yaml:"listen_host,omitzero"`           // Web listen host.
+	ListenPort     string   `json:"listen_port,omitzero" yaml:"listen_port,omitzero"`           // Web listen port.
+	CertFile       string   `json:"cert_file,omitzero" yaml:"cert_file,omitzero"`               // HTTPS certificate path.
+	KeyFile        string   `json:"pkey_file,omitzero" yaml:"pkey_file,omitzero"`               // HTTPS privkey path.
+	RoutePrefix    string   `json:"route_prefix,omitzero" yaml:"route_prefix,omitzero"`         // Web endpoint prefix.
 	DisabledRoutes []string `json:"disabled_routes,omitempty" yaml:"disabled_routes,omitempty"` // Disabled API routes.
 }
 
@@ -328,8 +316,8 @@ func (n *Notifiers) Flatten() []Notify {
 
 // Notify is a message notifier source.
 type Notify struct {
-	ID        string            `json:"name,omitempty" yaml:"name,omitempty"`             // ID for this Notify sender.
-	Type      string            `json:"type,omitempty" yaml:"type,omitempty"`             // Notification type, e.g. slack.
+	ID        string            `json:"name,omitzero" yaml:"name,omitzero"`               // ID for this Notify sender.
+	Type      string            `json:"type,omitzero" yaml:"type,omitzero"`               // Notification type, e.g. slack.
 	Options   map[string]string `json:"options,omitempty" yaml:"options,omitempty"`       // Options.
 	URLFields map[string]string `json:"url_fields,omitempty" yaml:"url_fields,omitempty"` // URL Fields.
 	Params    map[string]string `json:"params,omitempty" yaml:"params,omitempty"`         // Param props.
@@ -366,16 +354,16 @@ type Services map[string]*Service
 
 // Service defines a software source to track and where/what to notify.
 type Service struct {
-	Name                  string                 `json:"name,omitempty" yaml:"name,omitempty"`                         // Name for this Service.
-	Comment               string                 `json:"comment,omitempty" yaml:"comment,omitempty"`                   // Extra detail on the Service..
-	Options               ServiceOptions         `json:"options,omitzero" yaml:"options,omitzero"`                     // Options to give the Service Lookup's.
-	LatestVersion         *LatestVersion         `json:"latest_version,omitempty" yaml:"latest_version,omitempty"`     // Latest version lookup for the Service.
-	Notify                Notifiers              `json:"notify,omitempty" yaml:"notify,omitempty"`                     // Service-specific Notify configuration.
-	Command               Commands               `json:"command,omitempty" yaml:"command,omitempty"`                   // CLI Commands to run on new release.
-	WebHook               WebHooks               `json:"webhook,omitempty" yaml:"webhook,omitempty"`                   // Service-specific WebHook configuration.
-	DeployedVersionLookup *DeployedVersionLookup `json:"deployed_version,omitempty" yaml:"deployed_version,omitempty"` // Configuration to scrape the Service's current deployed version.
-	Dashboard             DashboardOptions       `json:"dashboard,omitzero" yaml:"dashboard,omitzero"`                 // Dashboard options.
-	Status                *Status                `json:"status,omitempty" yaml:"status,omitempty"`                     // Track the Status of this source (version and regex misses).
+	Name                  string                 `json:"name,omitzero" yaml:"name,omitzero"`                         // Name for this Service.
+	Comment               string                 `json:"comment,omitzero" yaml:"comment,omitzero"`                   // Extra detail on the Service..
+	Options               ServiceOptions         `json:"options,omitzero" yaml:"options,omitzero"`                   // Options to give the Service Lookup's.
+	LatestVersion         *LatestVersion         `json:"latest_version,omitzero" yaml:"latest_version,omitzero"`     // Latest version lookup for the Service.
+	Notify                Notifiers              `json:"notify,omitempty" yaml:"notify,omitempty"`                   // Service-specific Notify configuration.
+	Command               Commands               `json:"command,omitempty" yaml:"command,omitempty"`                 // CLI Commands to run on new release.
+	WebHook               WebHooks               `json:"webhook,omitempty" yaml:"webhook,omitempty"`                 // Service-specific WebHook configuration.
+	DeployedVersionLookup *DeployedVersionLookup `json:"deployed_version,omitzero" yaml:"deployed_version,omitzero"` // Configuration to scrape the Service's current deployed version.
+	Dashboard             DashboardOptions       `json:"dashboard,omitzero" yaml:"dashboard,omitzero"`               // Dashboard options.
+	Status                *Status                `json:"status,omitempty" yaml:"status,omitempty"`                   // Track the Status of this source (version and regex misses).
 }
 
 // String implements fmt.Stringer and returns a JSON representation.
@@ -388,7 +376,7 @@ func (r *Service) String() string {
 
 // ServiceDefaults defines default values for a Service.
 type ServiceDefaults struct {
-	Comment               string                        `json:"comment,omitempty" yaml:"comment,omitempty"`                 // Comment on the Service.
+	Comment               string                        `json:"comment,omitzero" yaml:"comment,omitzero"`                   // Comment on the Service.
 	Options               ServiceOptions                `json:"options,omitzero" yaml:"options,omitzero"`                   // Options to give the Service.
 	LatestVersion         LatestVersionDefaults         `json:"latest_version,omitzero" yaml:"latest_version,omitzero"`     // Latest version lookup for the Service.
 	Notify                []string                      `json:"notify,omitempty" yaml:"notify,omitempty"`                   // Service-specific Notify configuration.
@@ -412,9 +400,9 @@ func (d ServiceDefaults) IsZero() bool {
 
 // ServiceOptions defines configuration options for a service.
 type ServiceOptions struct {
-	Active             *bool  `json:"active,omitempty" yaml:"active,omitempty"`                           // Active Service?.
-	Interval           string `json:"interval,omitempty" yaml:"interval,omitempty"`                       // AhBmCs = Sleep A hours, B minutes and C seconds between queries.
-	SemanticVersioning *bool  `json:"semantic_versioning,omitempty" yaml:"semantic_versioning,omitempty"` // Default - true = Version must exceed the previous version to trigger alerts/Commands/WebHooks.
+	Active             *bool  `json:"active,omitzero" yaml:"active,omitzero"`                           // Active Service?.
+	Interval           string `json:"interval,omitzero" yaml:"interval,omitzero"`                       // AhBmCs = Sleep A hours, B minutes and C seconds between queries.
+	SemanticVersioning *bool  `json:"semantic_versioning,omitzero" yaml:"semantic_versioning,omitzero"` // Default - true = Version must exceed the previous version to trigger alerts/Commands/WebHooks.
 }
 
 // IsZero implements the yaml.IsZeroer interface.
@@ -426,11 +414,11 @@ func (o ServiceOptions) IsZero() bool {
 
 // DashboardOptions defines configuration options for a service on the Web UI dashboard.
 type DashboardOptions struct {
-	AutoApprove *bool    `json:"auto_approve,omitempty" yaml:"auto_approve,omitempty"` // Default - true = Require approval before actioning new releases.
-	Icon        string   `json:"icon,omitempty" yaml:"icon,omitempty"`                 // Icon URL to use for messages/Web UI.
-	IconLinkTo  string   `json:"icon_link_to,omitempty" yaml:"icon_link_to,omitempty"` // URL to redirect Icon clicks to.
-	WebURL      string   `json:"web_url,omitempty" yaml:"web_url,omitempty"`           // URL to provide on the Web UI.
-	Tags        []string `json:"tags,omitempty" yaml:"tags,omitempty"`                 // Tags for the Service.
+	AutoApprove *bool    `json:"auto_approve,omitzero" yaml:"auto_approve,omitzero"` // Default - true = Require approval before actioning new releases.
+	Icon        string   `json:"icon,omitzero" yaml:"icon,omitzero"`                 // Icon URL to use for messages/Web UI.
+	IconLinkTo  string   `json:"icon_link_to,omitzero" yaml:"icon_link_to,omitzero"` // URL to redirect Icon clicks to.
+	WebURL      string   `json:"web_url,omitzero" yaml:"web_url,omitzero"`           // URL to provide on the Web UI.
+	Tags        []string `json:"tags,omitempty" yaml:"tags,omitempty"`               // Tags for the Service.
 }
 
 // IsZero implements the yaml.IsZeroer interface.
@@ -444,14 +432,14 @@ func (d DashboardOptions) IsZero() bool {
 
 // LatestVersion lookup of the service.
 type LatestVersion struct {
-	Type              string                `json:"type,omitempty" yaml:"type,omitempty"`                               // Service Type, github/url.
-	URL               string                `json:"url,omitempty" yaml:"url,omitempty"`                                 // URL to query.
-	AccessToken       string                `json:"access_token,omitempty" yaml:"access_token,omitempty"`               // GitHub access token to use.
-	AllowInvalidCerts *bool                 `json:"allow_invalid_certs,omitempty" yaml:"allow_invalid_certs,omitempty"` // Default - false = Disallows invalid HTTPS certificates.
-	UsePreRelease     *bool                 `json:"use_prerelease,omitempty" yaml:"use_prerelease,omitempty"`           // Whether to use GitHub prereleases.
-	URLCommands       URLCommands           `json:"url_commands,omitempty" yaml:"url_commands,omitempty"`               // Commands to filter the release from the URL request.
-	Headers           []Header              `json:"headers,omitempty" yaml:"headers,omitempty"`                         // Request Headers.
-	Require           *LatestVersionRequire `json:"require,omitempty" yaml:"require,omitempty"`                         // Requirements before treating a release as valid.
+	Type              string                `json:"type,omitzero" yaml:"type,omitzero"`                               // Service Type, github/url.
+	URL               string                `json:"url,omitzero" yaml:"url,omitzero"`                                 // URL to query.
+	AccessToken       string                `json:"access_token,omitzero" yaml:"access_token,omitzero"`               // GitHub access token to use.
+	AllowInvalidCerts *bool                 `json:"allow_invalid_certs,omitzero" yaml:"allow_invalid_certs,omitzero"` // Default - false = Disallows invalid HTTPS certificates.
+	UsePreRelease     *bool                 `json:"use_prerelease,omitzero" yaml:"use_prerelease,omitzero"`           // Whether to use GitHub prereleases.
+	URLCommands       URLCommands           `json:"url_commands,omitempty" yaml:"url_commands,omitempty"`             // Commands to filter the release from the URL request.
+	Headers           []Header              `json:"headers,omitempty" yaml:"headers,omitempty"`                       // Request Headers.
+	Require           *LatestVersionRequire `json:"require,omitzero" yaml:"require,omitzero"`                         // Requirements before treating a release as valid.
 }
 
 // String implements fmt.Stringer and returns a JSON representation.
@@ -466,7 +454,7 @@ func (r *LatestVersion) String() string {
 // every registered type live under 'common', and fields specific to a single type
 // live under that type's own key.
 type LatestVersionDefaults struct {
-	Type   string                      `json:"type,omitempty" yaml:"type,omitempty"` // "github" | "url".
+	Type   string                      `json:"type,omitzero" yaml:"type,omitzero"` // "github" | "url".
 	Common LatestVersionCommonDefaults `json:"common,omitzero" yaml:"common,omitzero"`
 	GitHub LatestVersionGitHubDefaults `json:"github,omitzero" yaml:"github,omitzero"`
 	URL    LatestVersionURLDefaults    `json:"url,omitzero" yaml:"url,omitzero"`
@@ -492,8 +480,8 @@ func (l LatestVersionCommonDefaults) IsZero() bool {
 
 // LatestVersionGitHubDefaults are GitHub-specific default values for a LatestVersion.
 type LatestVersionGitHubDefaults struct {
-	AccessToken   string `json:"access_token,omitempty" yaml:"access_token,omitempty"`     // GitHub access token to use.
-	UsePreRelease *bool  `json:"use_prerelease,omitempty" yaml:"use_prerelease,omitempty"` // Whether to use GitHub prereleases.
+	AccessToken   string `json:"access_token,omitzero" yaml:"access_token,omitzero"`     // GitHub access token to use.
+	UsePreRelease *bool  `json:"use_prerelease,omitzero" yaml:"use_prerelease,omitzero"` // Whether to use GitHub prereleases.
 }
 
 // IsZero implements the yaml.IsZeroer interface.
@@ -503,7 +491,7 @@ func (l LatestVersionGitHubDefaults) IsZero() bool {
 
 // LatestVersionURLDefaults are URL-specific default values for a LatestVersion.
 type LatestVersionURLDefaults struct {
-	AllowInvalidCerts *bool `json:"allow_invalid_certs,omitempty" yaml:"allow_invalid_certs,omitempty"` // Default - false = Disallows invalid HTTPS certificates.
+	AllowInvalidCerts *bool `json:"allow_invalid_certs,omitzero" yaml:"allow_invalid_certs,omitzero"` // Default - false = Disallows invalid HTTPS certificates.
 }
 
 // IsZero implements the yaml.IsZeroer interface.
@@ -513,10 +501,10 @@ func (l LatestVersionURLDefaults) IsZero() bool {
 
 // LatestVersionRequire contains commands, regex, etc. that must pass before considering a release valid.
 type LatestVersionRequire struct {
-	Command      []string       `json:"command,omitempty" yaml:"command,omitempty"`             // Require Command to pass.
-	Docker       *RequireDocker `json:"docker,omitempty" yaml:"docker,omitempty"`               // Docker image tag requirements.
-	RegexContent string         `json:"regex_content,omitempty" yaml:"regex_content,omitempty"` // "abc-[a-z]+-{{ version }}_amd64.deb" This regex must exist in the body of the URL to trigger new version actions.
-	RegexVersion string         `json:"regex_version,omitempty" yaml:"regex_version,omitempty"` // "v*[0-9.]+" The version found must match this release to trigger new version actions/.
+	Command      []string       `json:"command,omitempty" yaml:"command,omitempty"`           // Require Command to pass.
+	Docker       *RequireDocker `json:"docker,omitempty" yaml:"docker,omitempty"`             // Docker image tag requirements.
+	RegexContent string         `json:"regex_content,omitzero" yaml:"regex_content,omitzero"` // "abc-[a-z]+-{{ version }}_amd64.deb" This regex must exist in the body of the URL to trigger new version actions.
+	RegexVersion string         `json:"regex_version,omitzero" yaml:"regex_version,omitzero"` // "v*[0-9.]+" The version found must match this release to trigger new version actions/.
 }
 
 // String implements fmt.Stringer and returns a JSON representation.
@@ -566,7 +554,7 @@ type RequireDockerRegistryDefaults interface {
 
 // RequireDockerRegistryDefaultsAuth are the auth values for a RequireDocker that takes a Token.
 type RequireDockerRegistryDefaultsAuth struct {
-	Token string `json:"token,omitempty" yaml:"token,omitempty"` // Token to get the token for the queries.
+	Token string `json:"token,omitzero" yaml:"token,omitzero"` // Token to get the token for the queries.
 }
 
 // IsZero implements the yaml.IsZeroer interface.
@@ -576,7 +564,7 @@ func (r RequireDockerRegistryDefaultsAuth) IsZero() bool {
 
 // RequireDockerRegistryDefaultsAuthWithUsername are the auth values for a RequireDocker that takes a Username with Token.
 type RequireDockerRegistryDefaultsAuthWithUsername struct {
-	Username                          string `json:"username,omitempty" yaml:"username,omitempty"` // Username to get a new token.
+	Username                          string `json:"username,omitzero" yaml:"username,omitzero"` // Username to get a new token.
 	RequireDockerRegistryDefaultsAuth `json:",inline" yaml:",inline"`
 }
 
@@ -612,8 +600,8 @@ func (r *RequireDockerCheckRegistryDefaultsTokenWithUsername) GetToken() string 
 
 // RequireDockerDefaults are default values for a RequireDocker.
 type RequireDockerDefaults struct {
-	Type     string                          `json:"type,omitempty" yaml:"type,omitempty"`       // Default DockerCheck Type.
-	Tag      string                          `json:"tag,omitempty" yaml:"tag,omitempty"`         // Default Tag template.
+	Type     string                          `json:"type,omitzero" yaml:"type,omitzero"`         // Default DockerCheck Type.
+	Tag      string                          `json:"tag,omitzero" yaml:"tag,omitzero"`           // Default Tag template.
 	Registry RequireDockerRegistriesDefaults `json:"registry,omitzero" yaml:"registry,omitzero"` // GHCR | Hub | Quay.
 }
 
@@ -626,17 +614,17 @@ func (r RequireDockerDefaults) IsZero() bool {
 
 // RequireDocker points to a Docker repository for a release to qualify as valid.
 type RequireDocker struct {
-	Type     string `json:"type,omitempty" yaml:"type,omitempty"`         // Where to check, e.g. hub (Docker Hub), GHCR, Quay).
-	Image    string `json:"image,omitempty" yaml:"image,omitempty"`       // Image to check.
-	Tag      string `json:"tag,omitempty" yaml:"tag,omitempty"`           // Tag to check for.
-	Username string `json:"username,omitempty" yaml:"username,omitempty"` // Username to get a new token.
-	Token    string `json:"token,omitempty" yaml:"token,omitempty"`       // Token to get the token for the queries.
+	Type     string `json:"type,omitzero" yaml:"type,omitzero"`         // Where to check, e.g. hub (Docker Hub), GHCR, Quay).
+	Image    string `json:"image,omitzero" yaml:"image,omitzero"`       // Image to check.
+	Tag      string `json:"tag,omitzero" yaml:"tag,omitzero"`           // Tag to check for.
+	Username string `json:"username,omitzero" yaml:"username,omitzero"` // Username to get a new token.
+	Token    string `json:"token,omitzero" yaml:"token,omitzero"`       // Token to get the token for the queries.
 }
 
 type DeployedVersionLookupDefaults struct {
-	Type              string `json:"type,omitempty" yaml:"type,omitempty"`                               // "manual" | "url".
-	AllowInvalidCerts *bool  `json:"allow_invalid_certs,omitempty" yaml:"allow_invalid_certs,omitempty"` // Disallows invalid HTTPS certificates.
-	Method            string `json:"method,omitempty" yaml:"method,omitempty"`                           // HTTP method.
+	Type              string `json:"type,omitzero" yaml:"type,omitzero"`                               // "manual" | "url".
+	AllowInvalidCerts *bool  `json:"allow_invalid_certs,omitzero" yaml:"allow_invalid_certs,omitzero"` // Disallows invalid HTTPS certificates.
+	Method            string `json:"method,omitzero" yaml:"method,omitzero"`                           // HTTP method.
 }
 
 // IsZero implements the yaml.IsZeroer interface.
@@ -647,24 +635,24 @@ func (d DeployedVersionLookupDefaults) IsZero() bool {
 
 // DeployedVersionLookup of the service.
 type DeployedVersionLookup struct {
-	Type string `json:"type,omitempty" yaml:"type,omitempty"` // Service Type, url/manual.
+	Type string `json:"type,omitzero" yaml:"type,omitzero"` // Service Type, url/manual.
 
 	// manual
-	Version string `json:"version,omitempty" yaml:"version,omitempty"` // Deployed version.
+	Version string `json:"version,omitzero" yaml:"version,omitzero"` // Deployed version.
 
 	// url
-	Method            string                 `json:"method,omitempty" yaml:"method,omitempty"`                           // HTTP method.
-	URL               string                 `json:"url,omitempty" yaml:"url,omitempty"`                                 // URL to query.
-	AllowInvalidCerts *bool                  `json:"allow_invalid_certs,omitempty" yaml:"allow_invalid_certs,omitempty"` // Default - false = Disallows invalid HTTPS certificates.
-	TargetHeader      string                 `json:"target_header,omitempty" yaml:"target_header,omitempty"`             // Header to target for the version.
-	BasicAuth         *BasicAuth             `json:"basic_auth,omitempty" yaml:"basic_auth,omitempty"`                   // Basic Auth credentials.
-	Headers           []Header               `json:"headers,omitempty" yaml:"headers,omitempty"`                         // Request Headers.
-	Body              string                 `json:"body,omitempty" yaml:"body,omitempty"`                               // Request Body.
-	JSON              string                 `json:"json,omitempty" yaml:"json,omitempty"`                               // JSON key to use e.g. version_current.
-	Regex             string                 `json:"regex,omitempty" yaml:"regex,omitempty"`                             // Regex for the version.
-	RegexTemplate     string                 `json:"regex_template,omitempty" yaml:"regex_template,omitempty"`           // Template to apply to the RegEx match.
-	HardDefaults      *DeployedVersionLookup `json:"-" yaml:"-"`                                                         // Hardcoded default values.
-	Defaults          *DeployedVersionLookup `json:"-" yaml:"-"`                                                         // Default values.
+	Method            string                 `json:"method,omitzero" yaml:"method,omitzero"`                           // HTTP method.
+	URL               string                 `json:"url,omitzero" yaml:"url,omitzero"`                                 // URL to query.
+	AllowInvalidCerts *bool                  `json:"allow_invalid_certs,omitzero" yaml:"allow_invalid_certs,omitzero"` // Default - false = Disallows invalid HTTPS certificates.
+	TargetHeader      string                 `json:"target_header,omitzero" yaml:"target_header,omitzero"`             // Header to target for the version.
+	BasicAuth         *BasicAuth             `json:"basic_auth,omitzero" yaml:"basic_auth,omitzero"`                   // Basic Auth credentials.
+	Headers           []Header               `json:"headers,omitempty" yaml:"headers,omitempty"`                       // Request Headers.
+	Body              string                 `json:"body,omitzero" yaml:"body,omitzero"`                               // Request Body.
+	JSON              string                 `json:"json,omitzero" yaml:"json,omitzero"`                               // JSON key to use e.g. version_current.
+	Regex             string                 `json:"regex,omitzero" yaml:"regex,omitzero"`                             // Regex for the version.
+	RegexTemplate     string                 `json:"regex_template,omitzero" yaml:"regex_template,omitzero"`           // Template to apply to the RegEx match.
+	HardDefaults      *DeployedVersionLookup `json:"-" yaml:"-"`                                                       // Hardcoded default values.
+	Defaults          *DeployedVersionLookup `json:"-" yaml:"-"`                                                       // Default values.
 }
 
 // String implements fmt.Stringer and returns a JSON representation.
@@ -700,25 +688,25 @@ func (slice *URLCommands) String() string {
 
 // URLCommand is a command to run to filter versions from the URL body.
 type URLCommand struct {
-	Type     string `json:"type,omitempty" yaml:"type,omitempty"`         // regex/replace/split.
-	Regex    string `json:"regex,omitempty" yaml:"regex,omitempty"`       // regex: regexp.MustCompile(Regex).
-	Index    *int   `json:"index,omitempty" yaml:"index,omitempty"`       // regex/split: re.FindAllString(URL_content, -1)[Index]  /  strings.Split("text")[Index].
-	Template string `json:"template,omitempty" yaml:"template,omitempty"` // regex: template.
-	Text     string `json:"text,omitempty" yaml:"text,omitempty"`         // split:       strings.Split(tgtString, "Text").
-	New      string `json:"new,omitempty" yaml:"new,omitempty"`           // replace:     strings.ReplaceAll(tgtString, "Old", "New").
-	Old      string `json:"old,omitempty" yaml:"old,omitempty"`           // replace:     strings.ReplaceAll(tgtString, "Old", "New").
+	Type     string `json:"type,omitzero" yaml:"type,omitzero"`         // regex/replace/split.
+	Regex    string `json:"regex,omitzero" yaml:"regex,omitzero"`       // regex: regexp.MustCompile(Regex).
+	Index    *int   `json:"index,omitzero" yaml:"index,omitzero"`       // regex/split: re.FindAllString(URL_content, -1)[Index]  /  strings.Split("text")[Index].
+	Template string `json:"template,omitzero" yaml:"template,omitzero"` // regex: template.
+	Text     string `json:"text,omitzero" yaml:"text,omitzero"`         // split:       strings.Split(tgtString, "Text").
+	New      string `json:"new,omitzero" yaml:"new,omitzero"`           // replace:     strings.ReplaceAll(tgtString, "Old", "New").
+	Old      string `json:"old,omitzero" yaml:"old,omitzero"`           // replace:     strings.ReplaceAll(tgtString, "Old", "New").
 }
 
 // Status is the Status of a Service.
 type Status struct {
-	ApprovedVersion          string `json:"approved_version,omitempty" yaml:"approved_version,omitempty"`                     // The approved version.
-	DeployedVersion          string `json:"deployed_version,omitempty" yaml:"deployed_version,omitempty"`                     // Deployed version of the Service.
-	DeployedVersionTimestamp string `json:"deployed_version_timestamp,omitempty" yaml:"deployed_version_timestamp,omitempty"` // UTC timestamp that the deployed version changed.
-	LatestVersion            string `json:"latest_version,omitempty" yaml:"latest_version,omitempty"`                         // Latest version of the Service.
-	LatestVersionTimestamp   string `json:"latest_version_timestamp,omitempty" yaml:"latest_version_timestamp,omitempty"`     // UTC timestamp that the latest version last changed.
-	LastQueried              string `json:"last_queried,omitempty" yaml:"last_queried,omitempty"`                             // UTC timestamp of the last query.
-	RegexMissesContent       uint   `json:"regex_misses_content,omitzero" yaml:"regex_misses_content,omitzero"`               // Counter for the number of regular expression misses on URL content.
-	RegexMissesVersion       uint   `json:"regex_misses_version,omitzero" yaml:"regex_misses_version,omitzero"`               // Counter for the number of regular expression misses on version.
+	ApprovedVersion          string `json:"approved_version,omitzero" yaml:"approved_version,omitzero"`                     // The approved version.
+	DeployedVersion          string `json:"deployed_version,omitzero" yaml:"deployed_version,omitzero"`                     // Deployed version of the Service.
+	DeployedVersionTimestamp string `json:"deployed_version_timestamp,omitzero" yaml:"deployed_version_timestamp,omitzero"` // UTC timestamp that the deployed version changed.
+	LatestVersion            string `json:"latest_version,omitzero" yaml:"latest_version,omitzero"`                         // Latest version of the Service.
+	LatestVersionTimestamp   string `json:"latest_version_timestamp,omitzero" yaml:"latest_version_timestamp,omitzero"`     // UTC timestamp that the latest version last changed.
+	LastQueried              string `json:"last_queried,omitzero" yaml:"last_queried,omitzero"`                             // UTC timestamp of the last query.
+	RegexMissesContent       uint   `json:"regex_misses_content,omitzero" yaml:"regex_misses_content,omitzero"`             // Counter for the number of regular expression misses on URL content.
+	RegexMissesVersion       uint   `json:"regex_misses_version,omitzero" yaml:"regex_misses_version,omitzero"`             // Counter for the number of regular expression misses on version.
 }
 
 // String implements fmt.Stringer and returns a JSON representation.
@@ -766,17 +754,17 @@ func (w *WebHooks) Flatten() []WebHook {
 
 // WebHook is a WebHook to send.
 type WebHook struct {
-	ServiceID         string   `json:"-" yaml:"-"`                                                         // ID of the service this WebHook belongs to.
-	ID                string   `json:"name,omitempty" yaml:"name,omitempty"`                               // Name of this WebHook.
-	Type              string   `json:"type,omitempty" yaml:"type,omitempty"`                               // "github"/"url".
-	URL               string   `json:"url,omitempty" yaml:"url,omitempty"`                                 // "https://example.com".
-	AllowInvalidCerts *bool    `json:"allow_invalid_certs,omitempty" yaml:"allow_invalid_certs,omitempty"` // Default - false = Disallows invalid HTTPS certificates.
-	Secret            string   `json:"secret,omitempty" yaml:"secret,omitempty"`                           // "SECRET".
-	Headers           []Header `json:"headers,omitempty" yaml:"headers,omitempty"`                         // Custom Headers for the WebHook.
-	DesiredStatusCode *uint16  `json:"desired_status_code,omitempty" yaml:"desired_status_code,omitempty"` // e.g. 202.
-	Delay             string   `json:"delay,omitempty" yaml:"delay,omitempty"`                             // The delay before sending the WebHook.
-	MaxTries          *uint8   `json:"max_tries,omitempty" yaml:"max_tries,omitempty"`                     // Number of times to send the WebHook until we receive the desired status code.
-	SilentFails       *bool    `json:"silent_fails,omitempty" yaml:"silent_fails,omitempty"`               // Whether to notify if this WebHook fails MaxTries times.
+	ServiceID         string   `json:"-" yaml:"-"`                                                       // ID of the service this WebHook belongs to.
+	ID                string   `json:"name,omitzero" yaml:"name,omitzero"`                               // Name of this WebHook.
+	Type              string   `json:"type,omitzero" yaml:"type,omitzero"`                               // "github"/"url".
+	URL               string   `json:"url,omitzero" yaml:"url,omitzero"`                                 // "https://example.com".
+	AllowInvalidCerts *bool    `json:"allow_invalid_certs,omitzero" yaml:"allow_invalid_certs,omitzero"` // Default - false = Disallows invalid HTTPS certificates.
+	Secret            string   `json:"secret,omitzero" yaml:"secret,omitzero"`                           // "SECRET".
+	Headers           []Header `json:"headers,omitempty" yaml:"headers,omitempty"`                       // Custom Headers for the WebHook.
+	DesiredStatusCode *uint16  `json:"desired_status_code,omitzero" yaml:"desired_status_code,omitzero"` // e.g. 202.
+	Delay             string   `json:"delay,omitzero" yaml:"delay,omitzero"`                             // The delay before sending the WebHook.
+	MaxTries          *uint8   `json:"max_tries,omitzero" yaml:"max_tries,omitzero"`                     // Number of times to send the WebHook until we receive the desired status code.
+	SilentFails       *bool    `json:"silent_fails,omitzero" yaml:"silent_fails,omitzero"`               // Whether to notify if this WebHook fails MaxTries times.
 }
 
 // IsZero implements the yaml.IsZeroer interface.
@@ -823,7 +811,7 @@ func (w *WebHook) Censor() {
 
 // CommandSummary holds the summary of a Command.
 type CommandSummary struct {
-	Failed       *bool     `json:"failed,omitempty" yaml:"failed,omitempty"`               // Whether the last run failed.
+	Failed       *bool     `json:"failed,omitzero" yaml:"failed,omitzero"`                 // Whether the last run failed.
 	NextRunnable time.Time `json:"next_runnable,omitempty" yaml:"next_runnable,omitempty"` // Time at which the Command can next run (for staggering).
 }
 
@@ -839,21 +827,21 @@ type CommandStatusUpdate struct {
 
 // CommandEdit for JSON react-hook-form.
 type CommandEdit struct {
-	Arg string `json:"arg,omitempty" yaml:"arg,omitempty"` // Command argument.
+	Arg string `json:"arg,omitzero" yaml:"arg,omitzero"` // Command argument.
 }
 
 // ServiceEdit is a Service in API format.
 type ServiceEdit struct {
-	Name                  string                 `json:"name,omitempty" yaml:"name,omitempty"`                         // Name of the Service.
-	Comment               string                 `json:"comment,omitempty" yaml:"comment,omitempty"`                   // Comment on the Service.
-	Options               ServiceOptions         `json:"options,omitempty" yaml:"options,omitempty"`                   // Options to give the Service.
-	LatestVersion         *LatestVersion         `json:"latest_version,omitempty" yaml:"latest_version,omitempty"`     // Latest version lookup for the Service.
-	Notify                []Notify               `json:"notify,omitempty" yaml:"notify,omitempty"`                     // Service-specific Notify vars.
-	Command               Commands               `json:"command,omitempty" yaml:"command,omitempty"`                   // OS Commands to run on new release.
-	WebHook               []WebHook              `json:"webhook,omitempty" yaml:"webhook,omitempty"`                   // Service-specific WebHook vars.
-	DeployedVersionLookup *DeployedVersionLookup `json:"deployed_version,omitempty" yaml:"deployed_version,omitempty"` // Deployed version lookup for the Service.
-	Dashboard             DashboardOptions       `json:"dashboard,omitempty" yaml:"dashboard,omitempty"`               // Dashboard options.
-	Status                *Status                `json:"status,omitempty" yaml:"status,omitempty"`                     // Track the Status of this source (version and regex misses).
+	Name                  string                 `json:"name,omitzero" yaml:"name,omitzero"`                         // Name of the Service.
+	Comment               string                 `json:"comment,omitzero" yaml:"comment,omitzero"`                   // Comment on the Service.
+	Options               ServiceOptions         `json:"options,omitzero" yaml:"options,omitzero"`                   // Options to give the Service.
+	LatestVersion         *LatestVersion         `json:"latest_version,omitzero" yaml:"latest_version,omitzero"`     // Latest version lookup for the Service.
+	Notify                []Notify               `json:"notify,omitempty" yaml:"notify,omitempty"`                   // Service-specific Notify vars.
+	Command               Commands               `json:"command,omitempty" yaml:"command,omitempty"`                 // OS Commands to run on new release.
+	WebHook               []WebHook              `json:"webhook,omitempty" yaml:"webhook,omitempty"`                 // Service-specific WebHook vars.
+	DeployedVersionLookup *DeployedVersionLookup `json:"deployed_version,omitzero" yaml:"deployed_version,omitzero"` // Deployed version lookup for the Service.
+	Dashboard             DashboardOptions       `json:"dashboard,omitzero" yaml:"dashboard,omitzero"`               // Dashboard options.
+	Status                *Status                `json:"status,omitempty" yaml:"status,omitempty"`                   // Track the Status of this source (version and regex misses).
 }
 
 // nilIfUnchanged compares two pointers; returns nil if values are equal, newValue if different, or a zero value if removed.

--- a/web/api/types/argus_test.go
+++ b/web/api/types/argus_test.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/release-argus/Argus/config/decode"
 	"github.com/release-argus/Argus/internal/test"
@@ -32,6 +33,243 @@ const (
 	dvManualType = "manual"
 	dvURLType    = "url"
 )
+
+func TestServiceEdit_Marshal(t *testing.T) {
+	// GIVEN: a ServiceEdit.
+	tests := []struct {
+		name  string
+		input ServiceEdit
+		want  string
+	}{
+		{
+			name:  "empty",
+			input: ServiceEdit{},
+			want:  `{}`,
+		},
+		{
+			name:  "non-nil empty Status is omitted",
+			input: ServiceEdit{Name: "foo", Status: &Status{}},
+			want:  `{"name":"foo"}`,
+		},
+		{
+			name:  "non-nil empty Command is omitted",
+			input: ServiceEdit{Name: "foo", Command: Commands{}},
+			want:  `{"name":"foo"}`,
+		},
+		{
+			name: "filled",
+			input: ServiceEdit{
+				Name:    "foo",
+				Comment: "a comment",
+				Options: ServiceOptions{
+					Active:             test.Ptr(true),
+					Interval:           "10m",
+					SemanticVersioning: test.Ptr(true),
+				},
+				LatestVersion: &LatestVersion{
+					Type: "github",
+					URL:  "release-argus/argus",
+				},
+				Notify: []Notify{
+					{ID: "discord"},
+				},
+				Command: Commands{
+					{"echo", "hello"},
+				},
+				WebHook: []WebHook{
+					{
+						ID: "wh1",
+						Type: "github",
+						URL: "https://example.com",
+					},
+				},
+				DeployedVersionLookup: &DeployedVersionLookup{
+					Type: "url",
+					URL:  "https://example.com/version",
+				},
+				Dashboard: DashboardOptions{
+					AutoApprove: test.Ptr(false),
+					Icon:        "https://example.com/icon.png",
+				},
+				Status: &Status{
+					ApprovedVersion: "1.2.3",
+				},
+			},
+			want: test.TrimJSON(`{
+				"name": "foo",
+				"comment": "a comment",
+				"options": {
+					"active": true,
+					"interval": "10m",
+					"semantic_versioning": true
+				},
+				"latest_version": {
+					"type": "github",
+					"url": "release-argus/argus"
+				},
+				"notify": [
+					{
+						"name": "discord"
+					}
+				],
+				"command": [
+					["echo", "hello"]
+				],
+				"webhook": [
+					{
+						"name": "wh1",
+						"type": "github",
+						"url": "https://example.com"
+					}
+				],
+				"deployed_version": {
+					"type": "url",
+					"url": "https://example.com/version"
+				},
+				"dashboard": {
+					"auto_approve": false,
+					"icon":"https://example.com/icon.png"
+				},
+				"status": {
+					"approved_version": "1.2.3"
+				}
+			}`),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// WHEN: the ServiceEdit is marshaled to JSON.
+			got, err := decode.Marshal("json", tc.input)
+
+			// THEN: the result is as expected.
+			if err != nil {
+				t.Fatalf(
+					"%s\nServiceEdit marshal errored: %v",
+					packageName, err,
+				)
+			}
+
+			if string(got) != tc.want {
+				t.Errorf(
+					"%s\nServiceEdit marshal value mismatch\ngot:  %q\nwant: %q",
+					packageName, got, tc.want,
+				)
+			}
+		})
+	}
+}
+
+func TestWebHookSummary_Marshal(t *testing.T) {
+	// GIVEN: a WebHookSummary.
+	tests := []struct {
+		name  string
+		input *WebHookSummary
+		want  string
+	}{
+		{
+			name:  "nil",
+			input: nil,
+			want:  `null`,
+		},
+		{
+			name:  "empty",
+			input: &WebHookSummary{},
+			want:  `{"next_runnable":"0001-01-01T00:00:00Z"}`,
+		},
+		{
+			name: "filled",
+			input: &WebHookSummary{
+				Failed:       test.Ptr(true),
+				NextRunnable: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			},
+			want: test.TrimJSON(`{
+				"failed": true,
+				"next_runnable": "2025-01-01T00:00:00Z"
+			}`),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// WHEN: the WebHookSummary is marshaled to JSON.
+			got, err := decode.Marshal("json", tc.input)
+
+			// THEN: the result is as expected.
+			if err != nil {
+				t.Fatalf(
+					"%s\nWebHookSummary marshal errored: %v",
+					packageName, err,
+				)
+			}
+			if string(got) != tc.want {
+				t.Errorf(
+					"%s\nWebHookSummary marshal value mismatch\ngot:  %q\nwant: %q",
+					packageName, got, tc.want,
+				)
+			}
+		})
+	}
+}
+
+func TestCommandSummary_Marshal(t *testing.T) {
+	// GIVEN: a CommandSummary.
+	tests := []struct {
+		name  string
+		input *CommandSummary
+		want  string
+	}{
+		{
+			name:  "nil",
+			input: nil,
+			want:  `null`,
+		},
+		{
+			name:  "empty",
+			input: &CommandSummary{},
+			want:  `{"next_runnable":"0001-01-01T00:00:00Z"}`,
+		},
+		{
+			name: "filled",
+			input: &CommandSummary{
+				Failed:       test.Ptr(true),
+				NextRunnable: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			},
+			want: test.TrimJSON(`{
+				"failed": true,
+				"next_runnable": "2025-01-01T00:00:00Z"
+			}`),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// WHEN: the CommandSummary is marshaled to JSON.
+			got, err := decode.Marshal("json", tc.input)
+
+			// THEN: the result is as expected.
+			if err != nil {
+				t.Fatalf(
+					"%s\nCommandSummary marshal errored: %v",
+					packageName, err,
+				)
+			}
+
+			if string(got) != tc.want {
+				t.Errorf(
+					"%s\nCommandSummary marshal value mismatch\ngot:  %q\nwant: %q",
+					packageName, got, tc.want,
+				)
+			}
+		})
+	}
+}
 
 func TestServiceSummary_IsZero(t *testing.T) {
 	// GIVEN: a ServiceSummary struct.
@@ -248,6 +486,17 @@ func TestServiceSummary_String(t *testing.T) {
 					"status": {
 						"approved_version": "1.2.3"
 					}
+				}`,
+		},
+		{
+			name: "non-nil empty Status is omitted",
+			summary: &ServiceSummary{
+				ID:     "foo",
+				Status: &Status{},
+			},
+			want: `
+				{
+					"id": "foo"
 				}`,
 		},
 	}
@@ -1680,6 +1929,90 @@ func TestService_String(t *testing.T) {
 			name:  "empty",
 			input: &Service{},
 			want:  `{}`,
+		},
+		{
+			name:  "non-nil empty Status is omitted",
+			input: &Service{Name: "foo", Status: &Status{}},
+			want:  `{"name":"foo"}`,
+		},
+		{
+			name: "filled",
+			input: &Service{
+				Name:    "foo",
+				Comment: "a comment",
+				Options: ServiceOptions{
+					Active:             test.Ptr(true),
+					Interval:           "10m",
+					SemanticVersioning: test.Ptr(true),
+				},
+				LatestVersion: &LatestVersion{
+					Type: "github",
+					URL:  "release-argus/argus",
+				},
+				Notify: Notifiers{
+					"discord": {ID: "discord"},
+				},
+				Command: Commands{
+					{"echo", "hello"},
+				},
+				WebHook: WebHooks{
+					"wh1": {
+						ID: "wh1",
+						Type: "github",
+						URL: "https://example.com",
+					},
+				},
+				DeployedVersionLookup: &DeployedVersionLookup{
+					Type: "url",
+					URL:  "https://example.com/version",
+				},
+				Dashboard: DashboardOptions{
+					AutoApprove: test.Ptr(false),
+					Icon:        "https://example.com/icon.png",
+				},
+				Status: &Status{
+					ApprovedVersion: "1.2.3",
+				},
+			},
+			want: test.TrimJSON(`{
+				"name": "foo",
+				"comment": "a comment",
+				"options": {
+					"active": true,
+					"interval": "10m",
+					"semantic_versioning": true
+				},
+				"latest_version": {
+					"type": "github",
+					"url": "release-argus/argus"
+				},
+				"notify": {
+					"discord": {
+						"name": "discord"
+					}
+				},
+				"command": [
+					["echo", "hello"]
+				],
+				"webhook": {
+					"wh1": {
+						"name": "wh1",
+						"type": "github",
+						"url": "https://example.com"
+					}
+				},
+				"deployed_version": {
+					"type": "url",
+					"url": "https://example.com/version"
+				},
+				"dashboard": {
+					"auto_approve": false,
+					"icon": "https://example.com/icon.png"
+				},
+				"status": {
+					"approved_version": "1.2.3"
+				}
+			}`),
 		},
 	}
 

--- a/web/api/types/http.go
+++ b/web/api/types/http.go
@@ -37,6 +37,6 @@ type WebSocketTokenAPI struct {
 
 // Response is a generic API response body.
 type Response struct {
-	Error   string `json:"error,omitempty"`
-	Message string `json:"message,omitempty"`
+	Error   string `json:"error,omitzero"`
+	Message string `json:"message,omitzero"`
 }

--- a/web/api/types/websocket.go
+++ b/web/api/types/websocket.go
@@ -19,13 +19,13 @@ import "github.com/release-argus/Argus/config/decode"
 
 // WebSocketMessage is the message format to send/receive.
 type WebSocketMessage struct {
-	Version     *int                       `json:"version,omitempty"`
+	Version     *int                       `json:"version,omitzero"`
 	Page        string                     `json:"page"`
 	Type        string                     `json:"type"`
-	SubType     string                     `json:"sub_type,omitempty"`
-	Target      *string                    `json:"target,omitempty"`
+	SubType     string                     `json:"sub_type,omitzero"`
+	Target      *string                    `json:"target,omitzero"`
 	Order       *[]string                  `json:"order,omitempty"`
-	ServiceData *ServiceSummary            `json:"service_data,omitempty"`
+	ServiceData *ServiceSummary            `json:"service_data,omitzero"`
 	CommandData map[string]*CommandSummary `json:"command_data,omitempty"`
 	WebHookData map[string]*WebHookSummary `json:"webhook_data,omitempty"`
 }

--- a/web/api/v1/http-api-action.go
+++ b/web/api/v1/http-api-action.go
@@ -183,8 +183,8 @@ func (api *API) httpServiceRunActions(w http.ResponseWriter, r *http.Request) {
 	case ActionAll, ActionFailed:
 		go svc.HandleFailedActions()
 	default:
-		if strings.HasPrefix(payload.Target, "webhook_") {
-			go svc.HandleWebHook(strings.TrimPrefix(payload.Target, "webhook_"))
+		if after, ok := strings.CutPrefix(payload.Target, "webhook_"); ok {
+			go svc.HandleWebHook(after)
 		} else {
 			go svc.HandleCommand(strings.TrimPrefix(payload.Target, "command_"))
 		}

--- a/web/api/v1/http-api-edit_test.go
+++ b/web/api/v1/http-api-edit_test.go
@@ -25,6 +25,7 @@ import (
 	"net/url"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -2819,7 +2820,7 @@ func TestHTTP_ServiceDelete(t *testing.T) {
 					packageName, tc.serviceID,
 				)
 			}
-			if util.Contains(api.Config.Order, tc.serviceID) {
+			if slices.Contains(api.Config.Order, tc.serviceID) {
 				t.Errorf(
 					"%s\nservice %q not removed from Order",
 					packageName, tc.serviceID,

--- a/web/api/v1/http.go
+++ b/web/api/v1/http.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"io/fs"
 	"net/http"
+	"slices"
 	"strings"
 
 	"github.com/gorilla/mux"
@@ -118,7 +119,7 @@ func (api *API) DisableRoutes() {
 		webRoutePrefix + "/api/v1/service/actions":                    {name: "service_actions", method: http.MethodPost},
 	}
 	for _, r := range routes {
-		r.disabled = util.Contains(api.Config.Settings.Web.DisabledRoutes, r.name)
+		r.disabled = slices.Contains(api.Config.Settings.Web.DisabledRoutes, r.name)
 	}
 
 	_ = api.Router.Walk(func(route *mux.Route, _ *mux.Router, _ []*mux.Route) error {

--- a/web/api/v1/http_test.go
+++ b/web/api/v1/http_test.go
@@ -23,6 +23,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 
@@ -277,7 +278,7 @@ func TestHTTP_SetupRoutesAPI__disableRoutes(t *testing.T) {
 							<-(saveChannel)
 						}
 
-						if !strings.HasPrefix(name, "-") && util.Contains(disabledRoutes, name) {
+						if !strings.HasPrefix(name, "-") && slices.Contains(disabledRoutes, name) {
 							tc.wantStatus = http.StatusNotFound
 							tc.wantBody = "route disabled"
 						}

--- a/web/api/v1/util.go
+++ b/web/api/v1/util.go
@@ -101,7 +101,7 @@ func (api *API) announceOrder() {
 func ConstantTimeCompare(x, y [32]byte) bool {
 	var result byte
 
-	for i := 0; i < len(x); i++ {
+	for i := range len(x) {
 		result |= x[i] ^ y[i]
 	}
 

--- a/web/api/v1/websocket-client.go
+++ b/web/api/v1/websocket-client.go
@@ -106,8 +106,8 @@ func getIP(r *http.Request) (ip string) {
 
 	// Get IP from X-Forwarded-For header.
 	ips := r.Header.Get("X-Forwarded-For")
-	splitIps := strings.Split(ips, ",")
-	for _, ip = range splitIps {
+	splitIps := strings.SplitSeq(ips, ",")
+	for ip = range splitIps {
 		netIP := net.ParseIP(ip)
 		if netIP != nil {
 			return

--- a/web/ui/package-lock.json
+++ b/web/ui/package-lock.json
@@ -3908,9 +3908,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001802",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001802.tgz",
-			"integrity": "sha512-vmv8ub2xwTNmljSKf82mtCk5JH7hC+YgzLj3P5zotvA0tPQ9016tdNNOG8WRca1IxOnhSsivB+J0z5FeE5LOUw==",
+			"version": "1.0.30001803",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001803.tgz",
+			"integrity": "sha512-g/uHREV2ZpK9qMalCsWaxmA6ol+DX8GYhuf3T40RKoP+oL7vhRJh8LNt73PCjpnR6l14FzfPrB5Yux4PKm2meg==",
 			"dev": true,
 			"funding": [
 				{

--- a/webhook/types.go
+++ b/webhook/types.go
@@ -51,16 +51,16 @@ type Headers []Header
 
 // Base is the base struct for WebHook.
 type Base struct {
-	Type              string  `json:"type,omitempty" yaml:"type,omitempty"`                               // "github"/"url".
-	URL               string  `json:"url,omitempty" yaml:"url,omitempty"`                                 // "https://example.com".
-	AllowInvalidCerts *bool   `json:"allow_invalid_certs,omitempty" yaml:"allow_invalid_certs,omitempty"` // Default - false = Disallows invalid HTTPS certificates.
-	CustomHeaders     Headers `json:"custom_headers,omitempty" yaml:"custom_headers,omitempty"`           // Deprecated: Use Headers.
-	Headers           Headers `json:"headers,omitempty" yaml:"headers,omitempty"`                         // Custom Headers for the WebHook.
-	Secret            string  `json:"secret,omitempty" yaml:"secret,omitempty"`                           // 'SECRET'.
-	DesiredStatusCode *uint16 `json:"desired_status_code,omitempty" yaml:"desired_status_code,omitempty"` // e.g. 202.
-	Delay             string  `json:"delay,omitempty" yaml:"delay,omitempty"`                             // The delay before sending the WebHook.
-	MaxTries          *uint8  `json:"max_tries,omitempty" yaml:"max_tries,omitempty"`                     // Number of times to attempt sending the WebHook until we receive the desired status code.
-	SilentFails       *bool   `json:"silent_fails,omitempty" yaml:"silent_fails,omitempty"`               // Whether to notify if this WebHook fails MaxTries times.
+	Type              string  `json:"type,omitzero" yaml:"type,omitzero"`                               // "github"/"url".
+	URL               string  `json:"url,omitzero" yaml:"url,omitzero"`                                 // "https://example.com".
+	AllowInvalidCerts *bool   `json:"allow_invalid_certs,omitzero" yaml:"allow_invalid_certs,omitzero"` // Default - false = Disallows invalid HTTPS certificates.
+	CustomHeaders     Headers `json:"custom_headers,omitempty" yaml:"custom_headers,omitempty"`         // Deprecated: Use Headers.
+	Headers           Headers `json:"headers,omitempty" yaml:"headers,omitempty"`                       // Custom Headers for the WebHook.
+	Secret            string  `json:"secret,omitzero" yaml:"secret,omitzero"`                           // 'SECRET'.
+	DesiredStatusCode *uint16 `json:"desired_status_code,omitzero" yaml:"desired_status_code,omitzero"` // e.g. 202.
+	Delay             string  `json:"delay,omitzero" yaml:"delay,omitzero"`                             // The delay before sending the WebHook.
+	MaxTries          *uint8  `json:"max_tries,omitzero" yaml:"max_tries,omitzero"`                     // Number of times to attempt sending the WebHook until we receive the desired status code.
+	SilentFails       *bool   `json:"silent_fails,omitzero" yaml:"silent_fails,omitzero"`               // Whether to notify if this WebHook fails MaxTries times.
 }
 
 // WebHooksDefaults is a string map of Defaults.
@@ -75,7 +75,7 @@ type Defaults struct {
 type WebHook struct {
 	Base `json:",inline" yaml:",inline"`
 
-	ID string `json:"name,omitempty" yaml:"-"` // Unique across the WebHooks.
+	ID string `json:"name,omitzero" yaml:"-"` // Unique across the WebHooks.
 
 	mu     sync.RWMutex         // Mutex for concurrent access.
 	Failed *status.FailsWebHook `json:"-" yaml:"-"` // Whether the last send attempt failed.

--- a/webhook/verify.go
+++ b/webhook/verify.go
@@ -18,6 +18,7 @@ package webhook
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"strconv"
 	"time"
 
@@ -166,7 +167,7 @@ func (b *Base) CheckValues() (error, bool) {
 	errs := make([]error, 0, 2)
 	changed := false
 	// type
-	if b.Type != "" && !util.Contains(supportedTypes, b.Type) {
+	if b.Type != "" && !slices.Contains(supportedTypes, b.Type) {
 		errs = append(
 			errs,
 			polymorphic.InvalidTypeError{


### PR DESCRIPTION
- Bumps Go to 1.26.0.
- Applies gofix-style modernisations (`slices.Contains`, `maps.Copy`,
  range-over-int, `strings.CutPrefix`, `strings.SplitSeq`) and aligns
  json/yaml `omitempty`/`omitzero` tags with go1.26's `encoding/json/v2`
  semantics (`omitzero` for scalars/pointers, `omitempty` kept on
  slices/maps and on types without a complete `IsZero()`). Removes the
  unused `StatusFails`/`StatusFailsSummary` types.
- Fixes a bug the in the `common.require` restructuring:
  the deprecated `require` key was migrated in `CheckValues()`, which
  runs after `SetDefaults()` and service decode. Because of this, a
  service relying on the deprecated default would silently get the wrong
  registry type and lose the defaults/hardDefaults. Migration now happens
  in `Decode()`, before `SetDefaults()`/service decode.