### PR TITLE
fix(api): reject invalid service edit payloads and announce every edit

### DIFF
--- a/config/edit.go
+++ b/config/edit.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/release-argus/Argus/config/decode"
 	dbtype "github.com/release-argus/Argus/db/types"
 	"github.com/release-argus/Argus/internal/logx"
 	"github.com/release-argus/Argus/service"
@@ -27,9 +28,16 @@ import (
 
 // AddService adds or replaces a service and updates ordering, persistence, and tracking.
 func (c *Config) AddService(oldServiceID string, newService *service.Service) error {
+	logFrom := logx.LogFrom{Primary: "AddService"}
+
+	if newService.ID == "" {
+		err := &decode.FieldError{Key: "id"}
+		logx.Error(err, logFrom, true)
+		return err
+	}
+
 	c.OrderMu.Lock()
 	defer c.OrderMu.Unlock()
-	logFrom := logx.LogFrom{Primary: "AddService"}
 
 	// Check a service does not already exist with the new id/name (if the name is changing).
 	if oldServiceID != newService.ID &&
@@ -65,7 +73,7 @@ func (c *Config) AddService(oldServiceID string, newService *service.Service) er
 
 			// Old service being given a new ID.
 		} else {
-			c.RenameService(oldServiceID, newService)
+			c.renameService(oldServiceID, newService)
 		}
 	}
 
@@ -115,18 +123,22 @@ func (c *Config) ServiceWithNameExists(name, oldServiceID string) bool {
 	return false
 }
 
-// RenameService changes a service ID in config, order, and the database.
-func (c *Config) RenameService(oldService string, newService *service.Service) {
+// renameService changes a service ID in config, order, and the database.
+func (c *Config) renameService(oldService string, newService *service.Service) {
 	// Check whether the target service doesn't exist,
 	// or a rename is not required (name is the same),
+	// or the new name is empty,
 	// or a service with this new name already exists.
-	if c.Service[oldService] == nil || oldService == newService.ID || c.Service[newService.ID] != nil {
+	if c.Service[oldService] == nil ||
+		oldService == newService.ID ||
+		newService.ID == "" ||
+		c.Service[newService.ID] != nil {
 		return
 	}
 
 	logx.Info(
 		strconv.Quote(newService.ID),
-		logx.LogFrom{Primary: "RenameService", Secondary: oldService},
+		logx.LogFrom{Primary: "renameService", Secondary: oldService},
 		true,
 	)
 	// Replace the service in the order/config.

--- a/config/edit_test.go
+++ b/config/edit_test.go
@@ -65,6 +65,21 @@ func TestConfig_AddService(t *testing.T) {
 			dbMessages: 2, // 1 for change of ID, 1 for change of versions.
 		},
 		{
+			name:       "Rename to an empty ID",
+			oldService: "bravo",
+			newService: testServiceURL(t, ""),
+			wantOrder:  []string{"alpha", "bravo", "charlie"},
+			added:      false,
+			dbMessages: 0,
+		},
+		{
+			name:       "New service with an empty ID",
+			newService: testServiceURL(t, ""),
+			wantOrder:  []string{"alpha", "bravo", "charlie"},
+			added:      false,
+			dbMessages: 0,
+		},
+		{
 			name:       "ID already exists",
 			newService: testServiceURL(t, "alpha"),
 			wantOrder:  []string{"alpha", "bravo", "charlie"},
@@ -252,27 +267,33 @@ func TestConfig_RenameService(t *testing.T) {
 		noChange, fail bool
 	}{
 		{
-			name:  "Rename service",
+			name:  "new name",
 			oldID: "bravo", newID: "foo",
 			wantOrder: []string{"alpha", "foo", "charlie"},
 			fail:      false,
 		},
 		{
-			name:  "Rename service to same name",
+			name:  "same name",
 			oldID: "bravo", newID: "bravo",
 			wantOrder: []string{"alpha", "bravo", "charlie"},
 			noChange:  true,
 			fail:      false,
 		},
 		{
-			name:  "Rename service that doesn't exist",
+			name:  "service doesn't exist",
 			oldID: "test", newID: "foo",
 			wantOrder: []string{"alpha", "bravo", "charlie"},
 			fail:      true,
 		},
 		{
-			name:  "Rename service to existing name",
+			name:  "existing name",
 			oldID: "bravo", newID: "alpha",
+			wantOrder: []string{"alpha", "bravo", "charlie"},
+			fail:      true,
+		},
+		{
+			name:  "empty name",
+			oldID: "bravo", newID: "",
 			wantOrder: []string{"alpha", "bravo", "charlie"},
 			fail:      true,
 		},
@@ -291,12 +312,12 @@ func TestConfig_RenameService(t *testing.T) {
 			newSVC := testServiceURL(t, tc.newID)
 
 			// WHEN: the service is renamed.
-			cfg.RenameService(tc.oldID, newSVC)
+			cfg.renameService(tc.oldID, newSVC)
 			logMu.Unlock()
 			time.Sleep(time.Second)
 
 			prefix := fmt.Sprintf(
-				"%s\nConfig.RenameService(oldID=%q, newID=%q)",
+				"%s\nConfig.renameService(oldID=%q, newID=%q)",
 				packageName, tc.oldID, tc.newID,
 			)
 

--- a/notify/shoutrrr/types.go
+++ b/notify/shoutrrr/types.go
@@ -16,6 +16,8 @@
 package shoutrrr
 
 import (
+	"fmt"
+
 	"github.com/release-argus/Argus/config/decode"
 	"github.com/release-argus/Argus/service/status"
 	"github.com/release-argus/Argus/util"
@@ -113,7 +115,7 @@ func (s *Shoutrrrs) MarshalJSON() ([]byte, error) {
 	return decode.Marshal("json", arr) //nolint:wrapcheck
 }
 
-// UnmarshalJSON implements json.Unmarshaler for Shoutrrrs.
+// UnmarshalJSON implements the json.Unmarshaler interface.
 //
 // It supports a JSON array of Shoutrrr entries:
 //
@@ -123,16 +125,34 @@ func (s *Shoutrrrs) MarshalJSON() ([]byte, error) {
 //	]
 //
 // which is converted into a map keyed by each entry's ID field.
+// As that key must identify the entry, a name is required, and must be unique.
 func (s *Shoutrrrs) UnmarshalJSON(data []byte) error {
 	var arr []Shoutrrr
 	if err := decode.Unmarshal("json", data, &arr); err != nil {
 		return err //nolint:wrapcheck
 	}
-	*s = make(Shoutrrrs, len(arr))
 
+	shoutrrrs := make(Shoutrrrs, len(arr))
 	for i := range arr {
-		(*s)[arr[i].ID] = &arr[i]
+		id := arr[i].ID
+		if id == "" || shoutrrrs[id] != nil {
+			err := &decode.FieldError{
+				Key:   "name",
+				Value: id,
+			}
+			if id != "" {
+				err.Description = "must be unique"
+			}
+
+			return &decode.KeyFieldError{
+				Key: fmt.Sprintf("notify[%d]", i),
+				Err: err,
+			}
+		}
+		shoutrrrs[id] = &arr[i]
 	}
+
+	*s = shoutrrrs
 	return nil
 }
 

--- a/notify/shoutrrr/types_test.go
+++ b/notify/shoutrrr/types_test.go
@@ -142,15 +142,34 @@ func TestShoutrrrs_UnmarshalJSON(t *testing.T) {
 			wantKeys: map[string]string{},
 		},
 		{
-			name: "duplicate ids - last wins",
+			name: "duplicate names rejected",
 			data: test.TrimJSON(`[
 				{"name": "dupe", "type": "slack"},
 				{"name": "dupe", "type": "gotify"}
 			]`),
-			errRegex: `^$`,
-			wantKeys: map[string]string{
-				"dupe": "gotify",
-			},
+			errRegex: test.TrimYAML(`
+				^notify\[1\]:
+					name: "dupe" <invalid> \(must be unique\)$`,
+			),
+		},
+		{
+			name: "missing name rejected",
+			data: test.TrimJSON(`[
+				{"name": "a", "type": "slack"},
+				{"type": "gotify"}
+			]`),
+			errRegex: test.TrimYAML(`
+				^notify\[1\]:
+					name: <required>$`,
+			),
+		},
+		{
+			name: "empty name rejected",
+			data: `[{"name": "", "type": "slack"}]`,
+			errRegex: test.TrimYAML(`
+				^notify\[0\]:
+					name: <required>$`,
+			),
 		},
 		{
 			name:     "invalid JSON",

--- a/service/decode.go
+++ b/service/decode.go
@@ -18,6 +18,7 @@ import (
 	"strconv"
 
 	"github.com/release-argus/Argus/config/decode"
+	"github.com/release-argus/Argus/internal/logx"
 	"github.com/release-argus/Argus/notify/shoutrrr"
 	"github.com/release-argus/Argus/webhook"
 )
@@ -52,6 +53,14 @@ func DecodeServices(
 		if svcRaw == nil {
 			delete(field, id)
 			continue
+		}
+
+		if id == "" {
+			logx.Warn(
+				"Ignoring the service with an empty ID. Give it a name in the config to recover it",
+				logx.LogFrom{Primary: "DecodeServices"},
+				true,
+			)
 		}
 
 		// Create each Service.

--- a/service/decode_test.go
+++ b/service/decode_test.go
@@ -117,6 +117,35 @@ func TestDecodeServices(t *testing.T) {
 			errRegex: `^$`,
 		},
 		{
+			name:   "JSON/service with an empty ID is kept",
+			format: "json",
+			data: test.TrimJSON(`{
+				"": {
+					"latest_version": {
+						"type": "github",
+						"url": "owner/repo0"
+					}
+				},
+				"service1": {
+					"latest_version": {
+						"type": "github",
+						"url": "owner/repo"
+					}
+				}
+			}`),
+			want: test.TrimYAML(`
+				'':
+					latest_version:
+						type: github
+						url: owner/repo0
+				service1:
+					latest_version:
+						type: github
+						url: owner/repo
+			`),
+			errRegex: `^$`,
+		},
+		{
 			name:   "JSON/multiple services",
 			format: "json",
 			data: test.TrimJSON(`{

--- a/web/api/v1/http-api-edit.go
+++ b/web/api/v1/http-api-edit.go
@@ -590,6 +590,12 @@ func (api *API) httpTemplateParse(w http.ResponseWriter, r *http.Request) {
 
 // httpServiceEdit handles creating/editing a Service.
 //
+// The body is a full replacement, not a merge. The payload builds an entirely new
+// Service, so any field it omits is dropped rather than carried over from the
+// existing Service. The previous Service is consulted only to inherit masked
+// secrets (see [service.FromPayload]) and to keep versions where the lookup is
+// unchanged.
+//
 // Method: PUT
 //
 // Query Parameters:
@@ -659,6 +665,17 @@ func (api *API) httpServiceEdit(w http.ResponseWriter, r *http.Request) {
 		err = fmt.Errorf(
 			`%s %q failed: %w`,
 			reqType, serviceID, err,
+		)
+		logx.Error(err, logFrom, true)
+		failRequest(&w, err, http.StatusBadRequest)
+		return
+	}
+
+	if newService.ID == "" {
+		err := fmt.Errorf(
+			"%s %q failed: %w",
+			reqType, serviceID,
+			&decode.FieldError{Key: "id"},
 		)
 		logx.Error(err, logFrom, true)
 		failRequest(&w, err, http.StatusBadRequest)

--- a/web/api/v1/http-api-edit_test.go
+++ b/web/api/v1/http-api-edit_test.go
@@ -1462,6 +1462,37 @@ func TestHTTP_ServiceEdit__create(t *testing.T) {
 			},
 		},
 		{
+			name: "no id",
+			payload: test.TrimJSON(`{
+				"latest_version": {
+					"type": "github",
+					"url": "` + test.ArgusGitHubRepo + `"
+				}
+			}`),
+			wants: wants{
+				statusCode: http.StatusBadRequest,
+				bodyRegex: `` +
+					`^{"message":"create .* failed:\\n` +
+					`  id: <required>"}$`,
+			},
+		},
+		{
+			name: "empty id",
+			payload: test.TrimJSON(`{
+				"id": "",
+				"latest_version": {
+					"type": "github",
+					"url": "` + test.ArgusGitHubRepo + `"
+				}
+			}`),
+			wants: wants{
+				statusCode: http.StatusBadRequest,
+				bodyRegex: `` +
+					`^{"message":"create .* failed:\\n` +
+					`  id: <required>"}$`,
+			},
+		},
+		{
 			name: "lv-github",
 			payload: test.TrimJSON(`{
 				"id": "__name__-new",
@@ -2187,6 +2218,79 @@ func TestHTTP_ServiceEdit__edit(t *testing.T) {
 				)
 			}
 		})
+	}
+}
+
+func TestHTTP_ServiceEdit__edit__missingID(t *testing.T) {
+	// GIVEN: an API with a service to edit.
+	file := filepath.Join(t.TempDir(), "config.yml")
+	api := testAPI(t, file)
+
+	const editID = "TestHTTP_ServiceEdit__edit__missingID"
+	svc := testService(t, editID, "url", "url", true)
+	api.Config.Service[svc.ID] = svc
+	wantOrder := []string{"before", editID, "after"}
+	api.Config.Order = slices.Clone(wantOrder)
+
+	// WHEN: an edit is sent with a payload that omits `id`.
+	payload := bytes.NewReader([]byte(test.TrimJSON(`{
+		"options": {
+			"active": false
+		},
+		"latest_version": {
+			"type": "github",
+			"url": "` + test.ArgusGitHubRepo + `"
+		}
+	}`)))
+	params := url.Values{}
+	params.Set("service_id", editID)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/service/config", payload)
+	req.URL.RawQuery = params.Encode()
+	w := httptest.NewRecorder()
+	api.httpServiceEdit(w, req)
+	res := w.Result()
+	t.Cleanup(func() { _ = res.Body.Close() })
+
+	prefix := fmt.Sprintf("%s\nAPI.httpServiceEdit() (edit)", packageName)
+
+	// THEN: the edit fails with 400.
+	if got, want := res.StatusCode, http.StatusBadRequest; got != want {
+		t.Errorf(
+			"%s status code mismatch\ngot:  %d\nwant: %d",
+			prefix, got, want,
+		)
+	}
+	// AND: the body says the `id` is required.
+	body, _ := io.ReadAll(res.Body)
+	if got, want := string(body), `failed:\\n  id: <required>"}$`; !util.RegexCheck(want, got) {
+		t.Errorf(
+			"%s body mismatch\ngot:  %q\nwant: %q",
+			prefix, got, want,
+		)
+	}
+
+	// AND: the service being edited is left untouched.
+	if api.Config.Service[editID] != svc {
+		t.Errorf(
+			"%s service %q was modified/removed by a failed edit",
+			prefix, editID,
+		)
+	}
+
+	// AND: no service was created under the empty ID.
+	if got := api.Config.Service[""]; got != nil {
+		t.Errorf(
+			"%s a service was created with an empty ID:\n%s",
+			prefix, got.String(""),
+		)
+	}
+
+	// AND: the Order keeps its entries, with no empty slot.
+	if got := api.Config.Order; !slices.Equal(got, wantOrder) {
+		t.Errorf(
+			"%s Order mismatch\ngot:  %q\nwant: %q",
+			prefix, got, wantOrder,
+		)
 	}
 }
 

--- a/web/api/v1/util.go
+++ b/web/api/v1/util.go
@@ -49,18 +49,17 @@ func getParam(queryParams url.Values, key string) *string {
 	return &val
 }
 
-// announceEdit broadcasts an EDIT message to all WebSocket clients
-// if the displayed data has changed.
+// announceEdit broadcasts an EDIT message to all WebSocket clients.
+//
+// Only the fields the edit changed are sent; SubType carries the ID the service
+// had before the edit (empty when it was created). An edit that changes nothing
+// the dashboard displays still announces, with no ServiceData, so that clients
+// invalidate their cached config for the service.
 func (api *API) announceEdit(oldData *apitype.ServiceSummary, newData *apitype.ServiceSummary) {
 	serviceChanged := ""
 	if oldData != nil {
 		serviceChanged = oldData.ID
 		newData.RemoveUnchanged(oldData)
-	}
-
-	// Skip if ServiceData ended up empty
-	if newData.IsZero() {
-		return
 	}
 
 	api.sendAnnouncePayload(

--- a/web/api/v1/util_test.go
+++ b/web/api/v1/util_test.go
@@ -247,10 +247,7 @@ func TestAPI_AnnounceEdit(t *testing.T) {
 					)
 				}
 			default:
-				// Message not wanted.
-				if tc.wantedServiceData == nil {
-					return
-				}
+				// Every successful edit announces, even when nothing displayed changed.
 				t.Fatalf("%s Announce channel mismatch\ngot:  none\nwant: message", prefix)
 			}
 		})

--- a/web/ui/react-app/src/types/websocket.ts
+++ b/web/ui/react-app/src/types/websocket.ts
@@ -30,8 +30,11 @@ export type WebSocketResponse =
 	| {
 			page: 'APPROVALS';
 			type: 'EDIT';
+			/* The service ID prior to the edit ('' when the service was created). */
 			sub_type?: string;
-			service_data?: ServiceSummary;
+			/* Fields unchanged by the edit are omitted, so `id` is absent unless it
+			   changed - resolve the service from `sub_type` when it is. */
+			service_data?: Partial<ServiceSummary>;
 	  }
 	| {
 			page: 'APPROVALS';

--- a/web/ui/react-app/src/utils/api/query-cache.ts
+++ b/web/ui/react-app/src/utils/api/query-cache.ts
@@ -82,11 +82,10 @@ export const approvalsQueryCacheUpdater = ({
 
 		case 'EDIT': {
 			const newServiceData = msg.service_data;
-			if (!newServiceData) break;
 
 			// old ID when editing existing service.
 			const oldID = msg.sub_type;
-			const newID = newServiceData.id ?? oldID;
+			const newID = newServiceData?.id ?? oldID;
 			if (!newID) break;
 			const idHasChanged = oldID && oldID !== newID;
 
@@ -158,28 +157,30 @@ export const approvalsQueryCacheUpdater = ({
 			}
 
 			// Upsert summary for newID.
-			queryClient.setQueryData<ServiceSummary>(
-				QUERY_KEYS.SERVICE.SUMMARY_ITEM(newID),
-				(_oldData) => {
-					// Don't trust cached _oldData if we think `newID` is new.
-					const oldDataMerged: ServiceSummary = idHasChanged
-						? {
-								id: newID,
-								...oldData,
-							}
-						: {
-								...oldData,
-								..._oldData,
-								id: newID,
-								status: {
-									...oldData?.status,
-									..._oldData?.status,
-								},
-							};
+			if (newServiceData) {
+				queryClient.setQueryData<ServiceSummary>(
+					QUERY_KEYS.SERVICE.SUMMARY_ITEM(newID),
+					(_oldData) => {
+						// Don't trust cached _oldData if we think `newID` is new.
+						const oldDataMerged: ServiceSummary = idHasChanged
+							? {
+									...oldData,
+									id: newID,
+								}
+							: {
+									...oldData,
+									..._oldData,
+									id: newID,
+									status: {
+										...oldData?.status,
+										..._oldData?.status,
+									},
+								};
 
-					return serviceSummaryReducer(msg.service_data, oldDataMerged);
-				},
-			);
+						return serviceSummaryReducer(newServiceData, oldDataMerged);
+					},
+				);
+			}
 
 			// Ensure ID in order.
 			if (!newOrder.includes(newID)) {

--- a/web/ui/react-app/src/utils/api/types/requests/service-edit.ts
+++ b/web/ui/react-app/src/utils/api/types/requests/service-edit.ts
@@ -20,7 +20,7 @@ export type ServiceEditResponse = {
 };
 
 export const serviceSummaryReducer = (
-	service?: ServiceSummary,
+	service?: Partial<ServiceSummary>,
 	oldData?: ServiceSummary,
 ): ServiceSummary => {
 	const status = {

--- a/webhook/types.go
+++ b/webhook/types.go
@@ -16,6 +16,7 @@
 package webhook
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/release-argus/Argus/config/decode"
@@ -129,16 +130,43 @@ func (w *WebHooks) MarshalJSON() ([]byte, error) {
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface.
+//
+// It supports a JSON array of WebHook entries:
+//
+//	[
+//		{ id: "a", ... },
+//		{ id: "b", ... }
+//	]
+//
+// which is converted into a map keyed by each entry's ID field.
+// As that key must identify the entry, a name is required, and must be unique.
 func (w *WebHooks) UnmarshalJSON(data []byte) error {
 	var arr []WebHook
 	if err := decode.Unmarshal("json", data, &arr); err != nil {
 		return err //nolint:wrapcheck
 	}
-	*w = make(WebHooks, len(arr))
 
+	webhooks := make(WebHooks, len(arr))
 	for i := range arr {
-		(*w)[arr[i].ID] = &arr[i]
+		id := arr[i].ID
+		if id == "" || webhooks[id] != nil {
+			err := &decode.FieldError{
+				Key:   "name",
+				Value: id,
+			}
+			if id != "" {
+				err.Description = "must be unique"
+			}
+
+			return &decode.KeyFieldError{
+				Key: fmt.Sprintf("webhook[%d]", i),
+				Err: err,
+			}
+		}
+		webhooks[id] = &arr[i]
 	}
+
+	*w = webhooks
 	return nil
 }
 

--- a/webhook/types_test.go
+++ b/webhook/types_test.go
@@ -266,15 +266,34 @@ func TestWebHooks_UnmarshalJSON(t *testing.T) {
 			wantKeys: map[string]string{},
 		},
 		{
-			name: "duplicate ids - last wins",
+			name: "duplicate names rejected",
 			data: test.TrimJSON(`[
 				{"name": "dupe", "type": "github"},
 				{"name": "dupe", "type": "gitlab"}
 			]`),
-			errRegex: `^$`,
-			wantKeys: map[string]string{
-				"dupe": "gitlab",
-			},
+			errRegex: test.TrimYAML(`
+				^webhook\[1\]:
+					name: "dupe" <invalid> \(must be unique\)$`,
+			),
+		},
+		{
+			name: "missing name rejected",
+			data: test.TrimJSON(`[
+				{"name": "a", "type": "github"},
+				{"type": "gitlab"}
+			]`),
+			errRegex: test.TrimYAML(`
+				^webhook\[1\]:
+					name: <required>$`,
+			),
+		},
+		{
+			name: "empty name rejected",
+			data: `[{"name": "", "type": "github"}]`,
+			errRegex: test.TrimYAML(`
+				^webhook\[0\]:
+					name: <required>$`,
+			),
 		},
 		{
 			name:     "invalid JSON",


### PR DESCRIPTION
- **No `id` in the payload** - accepted with `200 OK`, replacing the service
  with an empty-ID one and corrupting the order. Now a `400`.
- **Notify/webhook entries with a missing or duplicate `name`** - stored under
  `""`, or silently collapsed into the last one. Now a `400`, naming the index.
- **Edits that change nothing the dashboard shows** - never broadcast, so other
  clients kept a stale config for the 5 minute `staleTime` and could silently
  revert the edit on their next save. Now always announced.

Fixes #940