### PR TITLE
feat(ui): add toolbar button to refresh all deployed versions

### DIFF
--- a/web/ui/react-app/playwright.config.ts
+++ b/web/ui/react-app/playwright.config.ts
@@ -18,6 +18,7 @@ import { defineConfig, devices } from '@playwright/test';
  */
 const SERIAL_SPECS = [
 	'create-service.spec.ts',
+	'refresh-deployed-versions.spec.ts',
 	'service-actions-dv-manual.spec.ts',
 	'service-ordering.spec.ts',
 	'service-secret-inheritance.spec.ts',

--- a/web/ui/react-app/src/components/approvals/toolbar/filter-dropdown.tsx
+++ b/web/ui/react-app/src/components/approvals/toolbar/filter-dropdown.tsx
@@ -7,6 +7,7 @@ import {
 import { useQueryClient } from '@tanstack/react-query';
 import { Eye } from 'lucide-react';
 import { type FC, useCallback } from 'react';
+import RefreshDeployedVersionsMenuItem from '@/components/approvals/toolbar/refresh-deployed-versions';
 import { useToolbar } from '@/components/approvals/toolbar/toolbar-context';
 import { Button } from '@/components/ui/button';
 import type { ExtraColumnMeta } from '@/components/ui/data-table';
@@ -242,6 +243,11 @@ const FilterDropdown: FC = () => {
 							{option.label}
 						</DropdownMenuCheckboxItem>
 					))}
+				</DropdownMenuGroup>
+				<DropdownMenuSeparator />
+				<DropdownMenuGroup>
+					<DropdownMenuLabel>Actions:</DropdownMenuLabel>
+					<RefreshDeployedVersionsMenuItem />
 				</DropdownMenuGroup>
 				{tableInstance && (
 					<>

--- a/web/ui/react-app/src/components/approvals/toolbar/refresh-deployed-versions.tsx
+++ b/web/ui/react-app/src/components/approvals/toolbar/refresh-deployed-versions.tsx
@@ -21,9 +21,7 @@ const REFRESH_TOAST_OPTS = {
 } as const;
 
 /**
- * Re-queries `deployed_version` (not the rate-limited `latest_version`) for
- * every configured service. Picking this from the dropdown is already a
- * deliberate two-step action, so it skips a separate confirmation step.
+ * Re-queries `deployed_version` for every configured service.
  */
 const RefreshDeployedVersionsMenuItem: FC = () => {
 	const queryClient = useQueryClient();

--- a/web/ui/react-app/src/components/approvals/toolbar/refresh-deployed-versions.tsx
+++ b/web/ui/react-app/src/components/approvals/toolbar/refresh-deployed-versions.tsx
@@ -1,0 +1,113 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { LoaderCircle } from 'lucide-react';
+import type { FC } from 'react';
+import { toast } from 'sonner';
+import { DropdownMenuItem } from '@/components/ui/dropdown-menu';
+import { getServiceSummaries } from '@/hooks/use-services';
+import { beautifyGoErrors } from '@/utils';
+import { mapRequest } from '@/utils/api/types/api-request-handler';
+
+/* Number of `deployed_version` refreshes to run concurrently. */
+const REFRESH_CONCURRENCY = 5;
+
+/*
+ * Shared id so the loading/success/error toasts update in place, pinned to
+ * its own position so a flood of per-service update notifications (default
+ * bottom-right) can't push the progress toast out of the visible stack.
+ */
+const REFRESH_TOAST_OPTS = {
+	id: 'refresh-deployed-versions',
+	position: 'top-center',
+} as const;
+
+/**
+ * Re-queries `deployed_version` (not the rate-limited `latest_version`) for
+ * every configured service. Picking this from the dropdown is already a
+ * deliberate two-step action, so it skips a separate confirmation step.
+ */
+const RefreshDeployedVersionsMenuItem: FC = () => {
+	const queryClient = useQueryClient();
+
+	const { mutate: refreshAll, isPending } = useMutation({
+		mutationFn: async () => {
+			const serviceIDs = getServiceSummaries(queryClient)
+				.filter((svc) => !svc.loading && svc.deployed_version_type)
+				.map((svc) => svc.id);
+
+			const total = serviceIDs.length;
+			if (total === 0) return { failed: 0, total };
+
+			let completed = 0;
+			let failed = 0;
+			toast.loading(
+				`Refreshing deployed versions: ${completed}/${total}`,
+				REFRESH_TOAST_OPTS,
+			);
+
+			const reportProgress = () => {
+				completed += 1;
+				toast.loading(
+					`Refreshing deployed versions: ${completed}/${total}`,
+					REFRESH_TOAST_OPTS,
+				);
+			};
+
+			for (let i = 0; i < serviceIDs.length; i += REFRESH_CONCURRENCY) {
+				const batch = serviceIDs.slice(i, i + REFRESH_CONCURRENCY);
+				const results = await Promise.allSettled(
+					batch.map((serviceID) =>
+						mapRequest('VERSION_REFRESH', {
+							dataSemanticVersioning: null,
+							dataTarget: 'deployed_version',
+							original: null,
+							originalSemanticVersioning: null,
+							serviceID,
+						}).finally(reportProgress),
+					),
+				);
+				failed += results.filter((r) => r.status === 'rejected').length;
+			}
+
+			return { failed, total };
+		},
+		onError: (error) => {
+			toast.error('Failed to refresh deployed versions', {
+				...REFRESH_TOAST_OPTS,
+				description: beautifyGoErrors(error.message),
+			});
+		},
+		onSuccess: ({ failed, total }) => {
+			if (total === 0) {
+				toast.info(
+					'No services with a deployed version to refresh',
+					REFRESH_TOAST_OPTS,
+				);
+				return;
+			}
+			if (failed > 0) {
+				toast.error(
+					`Refreshed deployed versions: ${failed}/${total} failed`,
+					REFRESH_TOAST_OPTS,
+				);
+			} else {
+				toast.success(
+					`Refreshed deployed version for ${total} service${total === 1 ? '' : 's'}`,
+					REFRESH_TOAST_OPTS,
+				);
+			}
+		},
+	});
+
+	return (
+		<DropdownMenuItem
+			className="cursor-pointer"
+			disabled={isPending}
+			onClick={() => refreshAll()}
+		>
+			Refresh all deployed versions
+			{isPending && <LoaderCircle className="ml-2 animate-spin" />}
+		</DropdownMenuItem>
+	);
+};
+
+export default RefreshDeployedVersionsMenuItem;

--- a/web/ui/react-app/tests/refresh-deployed-versions.spec.ts
+++ b/web/ui/react-app/tests/refresh-deployed-versions.spec.ts
@@ -1,0 +1,91 @@
+import { expect, test } from '@playwright/test';
+import {
+	cleanupServices,
+	createService,
+	LOOKUP_LATEST_VERSION_JSON,
+	screenshotsUnder,
+	withProject,
+} from './fixtures/service';
+
+// createService makes a real network call to verify the lookups before the
+// modal closes, so allow extra time.
+test.beforeEach(() => {
+	test.slow();
+});
+
+test.describe('refresh all deployed versions', () => {
+	let createdID: string | undefined;
+	test.afterEach(async ({ page }) => {
+		if (createdID) await cleanupServices(page, [createdID]);
+		createdID = undefined;
+	});
+
+	test('filter dropdown item re-queries the deployed_version of a service', async ({
+		page,
+	}, testInfo) => {
+		const shot = screenshotsUnder(
+			page,
+			testInfo.project.name,
+			'refresh-deployed-versions',
+		);
+		const baseID = 'REFRESH-ALL, DV';
+		const id = withProject(baseID, testInfo.project.name);
+		createdID = id;
+
+		await page.goto('/');
+		await page.getByRole('button', { name: /toggle edit mode/i }).click();
+
+		// GIVEN: a service with a manual deployed_version (no network lookup
+		// needed for the refresh itself).
+		await createService(page, id, {
+			deployedVersion: { type: 'manual', version: '0.0.1' },
+			latestVersion: LOOKUP_LATEST_VERSION_JSON,
+		});
+		await expect(page.getByRole('heading', { name: id })).toBeVisible();
+		await shot('01-before-refresh');
+
+		// WHEN: "Refresh all deployed versions" is picked from the filter
+		// dropdown. The backend is shared across specs, so other services may
+		// also be refreshed - only assert on the response for the service this
+		// test created, matched by its `service_id` query param (not string
+		// containment, since URLSearchParams encodes differently to
+		// encodeURIComponent for values like this ID's spaces/commas).
+		await page.getByRole('button', { name: 'Filter shown services' }).click();
+		const refreshMenuItem = page.getByRole('menuitem', {
+			name: 'Refresh all deployed versions',
+		});
+		await expect(refreshMenuItem).toBeVisible();
+		const [response] = await Promise.all([
+			page.waitForResponse((res) => {
+				if (!res.url().includes('/api/v1/deployed_version/refresh'))
+					return false;
+				if (res.request().method() !== 'GET') return false;
+				return new URL(res.url()).searchParams.get('service_id') === id;
+			}),
+			refreshMenuItem.click(),
+		]);
+
+		// THEN: the refresh succeeds and a completion toast is shown.
+		expect(response.ok()).toBeTruthy();
+		await expect(
+			page.getByText(/Refreshed deployed version/i).first(),
+		).toBeVisible();
+		await shot('02-after-refresh');
+	});
+
+	test('is reachable the same way regardless of viewport width', async ({
+		page,
+	}) => {
+		await page.setViewportSize({ width: 390, height: 844 });
+		await page.goto('/');
+
+		await expect(
+			page.getByRole('button', { name: 'Refresh all deployed versions' }),
+		).toHaveCount(0);
+
+		await page.getByRole('button', { name: 'Filter shown services' }).click();
+		await expect(
+			page.getByRole('menuitem', { name: 'Refresh all deployed versions' }),
+		).toBeVisible();
+	});
+});

--- a/web/ui/react-app/tests/refresh-deployed-versions.spec.ts
+++ b/web/ui/react-app/tests/refresh-deployed-versions.spec.ts
@@ -14,13 +14,13 @@ test.beforeEach(() => {
 });
 
 test.describe('refresh all deployed versions', () => {
-	let createdID: string | undefined;
+	let createdIDs: string[] = [];
 	test.afterEach(async ({ page }) => {
-		if (createdID) await cleanupServices(page, [createdID]);
-		createdID = undefined;
+		if (createdIDs.length) await cleanupServices(page, createdIDs);
+		createdIDs = [];
 	});
 
-	test('filter dropdown item re-queries the deployed_version of a service', async ({
+	test('filter dropdown item re-queries the deployed_version of 2+ services', async ({
 		page,
 	}, testInfo) => {
 		const shot = screenshotsUnder(
@@ -28,45 +28,54 @@ test.describe('refresh all deployed versions', () => {
 			testInfo.project.name,
 			'refresh-deployed-versions',
 		);
-		const baseID = 'REFRESH-ALL, DV';
-		const id = withProject(baseID, testInfo.project.name);
-		createdID = id;
+		const ids = ['REFRESH-ALL, DV, 1', 'REFRESH-ALL, DV, 2'].map((baseID) =>
+			withProject(baseID, testInfo.project.name),
+		);
+		createdIDs = ids;
 
 		await page.goto('/');
 		await page.getByRole('button', { name: /toggle edit mode/i }).click();
 
-		// GIVEN: a service with a manual deployed_version (no network lookup
+		// GIVEN: two services with a manual deployed_version (no network lookup
 		// needed for the refresh itself).
-		await createService(page, id, {
-			deployedVersion: { type: 'manual', version: '0.0.1' },
-			latestVersion: LOOKUP_LATEST_VERSION_JSON,
-		});
-		await expect(page.getByRole('heading', { name: id })).toBeVisible();
+		for (const id of ids) {
+			await createService(page, id, {
+				deployedVersion: { type: 'manual', version: '0.0.1' },
+				latestVersion: LOOKUP_LATEST_VERSION_JSON,
+			});
+			await expect(page.getByRole('heading', { name: id })).toBeVisible();
+		}
 		await shot('01-before-refresh');
 
 		// WHEN: "Refresh all deployed versions" is picked from the filter
 		// dropdown. The backend is shared across specs, so other services may
-		// also be refreshed - only assert on the response for the service this
-		// test created, matched by its `service_id` query param (not string
+		// also be refreshed - only assert on the responses for the services this
+		// test created, matched by their `service_id` query param (not string
 		// containment, since URLSearchParams encodes differently to
-		// encodeURIComponent for values like this ID's spaces/commas).
+		// encodeURIComponent for values like these IDs' spaces/commas).
 		await page.getByRole('button', { name: 'Filter shown services' }).click();
 		const refreshMenuItem = page.getByRole('menuitem', {
 			name: 'Refresh all deployed versions',
 		});
 		await expect(refreshMenuItem).toBeVisible();
-		const [response] = await Promise.all([
-			page.waitForResponse((res) => {
-				if (!res.url().includes('/api/v1/deployed_version/refresh'))
-					return false;
-				if (res.request().method() !== 'GET') return false;
-				return new URL(res.url()).searchParams.get('service_id') === id;
-			}),
+		const [responses] = await Promise.all([
+			Promise.all(
+				ids.map((id) =>
+					page.waitForResponse((res) => {
+						if (!res.url().includes('/api/v1/deployed_version/refresh'))
+							return false;
+						if (res.request().method() !== 'GET') return false;
+						return new URL(res.url()).searchParams.get('service_id') === id;
+					}),
+				),
+			),
 			refreshMenuItem.click(),
 		]);
 
-		// THEN: the refresh succeeds and a completion toast is shown.
-		expect(response.ok()).toBeTruthy();
+		// THEN: both refreshes succeed and a completion toast is shown.
+		for (const response of responses) {
+			expect(response.ok()).toBeTruthy();
+		}
 		await expect(
 			page.getByText(/Refreshed deployed version/i).first(),
 		).toBeVisible();


### PR DESCRIPTION
Adds a button that refreshes deployed_version for every service at once (closes #858). Only deployed_version gets re-queried, not latest_version, since that's what actually hits GitHub/Docker Hub rate limits.

Covered by a new e2e test and the full Playwright suite, plus manual testing against a running instance.

Desktop:
<img width="1776" height="284" alt="image" src="https://github.com/user-attachments/assets/34caeeda-b65f-4821-8282-d75e82d84ba4" />

iPhone 14 Pro:
<img width="224" height="406" alt="IMG_3607" src="https://github.com/user-attachments/assets/01afb0f0-a8b9-4a15-8231-d697fd3849f4" />
