### PR TITLE
feat(ui): clickable ID and an Icon column in table view 

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -5,5 +5,5 @@ service:
       url: release-argus/Argus
     dashboard:
       icon: https://raw.githubusercontent.com/release-argus/Argus/master/web/ui/react-app/public/favicon.svg
-      icon_link-to: https://release-argus.io
+      icon_link_to: https://release-argus.io
       web_url: https://github.com/release-argus/Argus/blob/master/CHANGELOG.md

--- a/web/ui/react-app/src/components/approvals/service-image.tsx
+++ b/web/ui/react-app/src/components/approvals/service-image.tsx
@@ -2,11 +2,14 @@ import { SiGithub } from '@icons-pack/react-simple-icons';
 import { AppWindow, LoaderCircle } from 'lucide-react';
 import { type FC, useMemo } from 'react';
 import { useDelayedRender } from '@/hooks/use-delayed-render';
+import { cn } from '@/lib/utils';
 import { LATEST_VERSION_LOOKUP_TYPE } from '@/utils/api/types/config/service/latest-version';
 import type { ServiceSummary } from '@/utils/api/types/config/summary';
 
 type ServiceImageProps = {
 	service?: ServiceSummary;
+	/* Class names for the image container. */
+	className?: string;
 };
 
 /**
@@ -14,9 +17,10 @@ type ServiceImageProps = {
  * If the service has no icon, the service type icon (github/url) is displayed.
  *
  * @param service - The service.
+ * @param className - Class names for the image container.
  * @returns The image tied to the service.
  */
-const ServiceImage: FC<ServiceImageProps> = ({ service }) => {
+const ServiceImage: FC<ServiceImageProps> = ({ service, className }) => {
 	const delayedRender = useDelayedRender(500);
 	const {
 		type: serviceType,
@@ -50,8 +54,16 @@ const ServiceImage: FC<ServiceImageProps> = ({ service }) => {
 	}, [serviceType, icon, loading]);
 
 	return (
-		<div className="relative my-auto flex aspect-3/2 size-22 items-center justify-center">
+		<div
+			className={cn(
+				'relative my-auto flex aspect-3/2 size-22 items-center justify-center',
+				className,
+			)}
+		>
 			<a
+				aria-label={
+					iconLinkTo ? `${service?.name ?? service?.id} icon link` : undefined
+				}
 				className="flex size-full items-center justify-center"
 				href={iconLinkTo || undefined}
 				rel="noreferrer noopener"

--- a/web/ui/react-app/src/components/approvals/service-image.tsx
+++ b/web/ui/react-app/src/components/approvals/service-image.tsx
@@ -42,9 +42,10 @@ const ServiceImage: FC<ServiceImageProps> = ({ service }) => {
 			);
 
 		// Default icon.
-		const ServiceIcon = LATEST_VERSION_LOOKUP_TYPE.GITHUB.value
-			? SiGithub
-			: AppWindow;
+		const ServiceIcon =
+			serviceType === LATEST_VERSION_LOOKUP_TYPE.GITHUB.value
+				? SiGithub
+				: AppWindow;
 		return <ServiceIcon className="size-full! object-contain" />;
 	}, [serviceType, icon, loading]);
 

--- a/web/ui/react-app/src/components/approvals/table/service-id.tsx
+++ b/web/ui/react-app/src/components/approvals/table/service-id.tsx
@@ -1,0 +1,32 @@
+import type { Row } from '@tanstack/react-table';
+import type { FC } from 'react';
+import { Link } from 'react-router';
+import { Button } from '@/components/ui/button';
+import type { ServiceSummary } from '@/utils/api/types/config/summary';
+
+type ServiceIDProps = {
+	/* The row in the table */
+	row: Row<ServiceSummary>;
+};
+
+/**
+ * A functional component displaying the ID of a service, linking to the service's
+ * web URL when it has one (as the title does in the grid layout).
+ *
+ * @param row - The ServiceSummary data of the service.
+ *
+ * @returns The service ID, as a link when the service has a web URL.
+ */
+export const ServiceID: FC<ServiceIDProps> = ({ row }) => {
+	const { id, url } = row.original;
+
+	if (!url) return id;
+
+	return (
+		<Button asChild className="p-0 text-foreground" size="fit" variant="link">
+			<Link rel="noreferrer noopener" target="_blank" to={url}>
+				{id}
+			</Link>
+		</Button>
+	);
+};

--- a/web/ui/react-app/src/components/approvals/toolbar/filter-dropdown.tsx
+++ b/web/ui/react-app/src/components/approvals/toolbar/filter-dropdown.tsx
@@ -31,12 +31,14 @@ import {
 	HideValue,
 	type HideValueType,
 	TABLE_COLUMNS_ORDER_STORAGE_KEY,
-	TABLE_COLUMNS_VISIBLE_STORAGE_KEY,
 	toolbarHideOptions,
 } from '@/constants/toolbar';
 import { getServiceSummaries } from '@/hooks/use-services';
-import { resetColumnVisibility } from '@/pages/approvals/layouts/table/column-visibility';
-import { columns } from '@/pages/approvals/layouts/table/columns.tsx';
+import {
+	persistColumnVisibility,
+	resetColumnVisibility,
+} from '@/pages/approvals/layouts/table/column-visibility';
+import { COLUMN_IDS } from '@/pages/approvals/layouts/table/columns.tsx';
 
 type HideOptionKey = (typeof toolbarHideOptions)[number]['key'];
 
@@ -162,25 +164,13 @@ const FilterDropdown: FC = () => {
 		setTableColumnVisibility(visibility);
 
 		// Persist column visibility.
-		localStorage.setItem(
-			TABLE_COLUMNS_VISIBLE_STORAGE_KEY,
-			Object.entries(visibility)
-				.filter(([_, isVisible]) => isVisible)
-				.map(([columnID]) => columnID)
-				.join(','),
-		);
+		persistColumnVisibility(visibility);
 
 		// Reset order.
-		const fallbackOrder = columns
-			.map((c) => c.id)
-			.filter((id): id is string => typeof id === 'string');
-		setTableColumnOrder(fallbackOrder);
+		setTableColumnOrder([...COLUMN_IDS]);
 
 		// Persist column order.
-		localStorage.setItem(
-			TABLE_COLUMNS_ORDER_STORAGE_KEY,
-			fallbackOrder.join(','),
-		);
+		localStorage.setItem(TABLE_COLUMNS_ORDER_STORAGE_KEY, COLUMN_IDS.join(','));
 	}, []);
 
 	const filterButtonTooltip = 'Filter shown services';

--- a/web/ui/react-app/src/constants/toolbar.ts
+++ b/web/ui/react-app/src/constants/toolbar.ts
@@ -67,7 +67,13 @@ export const URL_PARAMS = {
 	VIEW: 'view',
 } as const;
 
-/* Storage key for the visible table columns. */
-export const TABLE_COLUMNS_VISIBLE_STORAGE_KEY = 'tableColumnsVisible';
+/* Storage key for the hidden table columns. */
+export const TABLE_COLUMNS_HIDDEN_STORAGE_KEY = 'tableColumnsHidden';
+/**
+ * Storage key of the superseded 'visible table columns' format.
+ * Hidden columns are stored rather than visible ones so that columns added in a later
+ * release start visible instead of hidden. Removed on load.
+ */
+export const TABLE_COLUMNS_VISIBLE_STORAGE_KEY_LEGACY = 'tableColumnsVisible';
 /* Storage key for the order of table columns. */
 export const TABLE_COLUMNS_ORDER_STORAGE_KEY = 'tableColumnsOrder';

--- a/web/ui/react-app/src/pages/approvals/layouts/table/column-order.ts
+++ b/web/ui/react-app/src/pages/approvals/layouts/table/column-order.ts
@@ -1,0 +1,31 @@
+import { COLUMN_IDS } from '@/pages/approvals/layouts/table/columns';
+
+/**
+ * Merges a persisted column order with the known columns.
+ *
+ * Unknown (and duplicate) IDs are dropped, and any column missing from `storedOrder`
+ * (i.e. one added in a later release) is inserted at its position in the column
+ * definitions rather than appended to the end.
+ *
+ * @param storedOrder - The persisted order of column IDs.
+ * @returns The order of every known column ID.
+ */
+export const mergeColumnOrder = (storedOrder: string[]): string[] => {
+	const known = new Set(COLUMN_IDS);
+	const order = [...new Set(storedOrder.filter((id) => known.has(id)))];
+
+	// Insert missing columns after the column they follow in the definitions.
+	let insertAt = 0;
+	for (const id of COLUMN_IDS) {
+		const index = order.indexOf(id);
+		if (index !== -1) {
+			insertAt = index + 1;
+			continue;
+		}
+
+		order.splice(insertAt, 0, id);
+		insertAt++;
+	}
+
+	return order;
+};

--- a/web/ui/react-app/src/pages/approvals/layouts/table/column-visibility.ts
+++ b/web/ui/react-app/src/pages/approvals/layouts/table/column-visibility.ts
@@ -1,5 +1,9 @@
 import type { VisibilityState } from '@tanstack/react-table';
-import { columns } from '@/pages/approvals/layouts/table/columns';
+import {
+	TABLE_COLUMNS_HIDDEN_STORAGE_KEY,
+	TABLE_COLUMNS_VISIBLE_STORAGE_KEY_LEGACY,
+} from '@/constants/toolbar';
+import { COLUMN_IDS, columns } from '@/pages/approvals/layouts/table/columns';
 import { isEmptyOrNull } from '@/utils';
 import type { ServiceSummary } from '@/utils/api/types/config/summary';
 
@@ -61,9 +65,49 @@ export const resetColumnVisibility = ({
 	if (trueCount > 0) return;
 
 	// Enable all columns when no columns are visible.
-	for (const col of columns) {
-		const id = col.id ?? ('accessorKey' in col ? col.accessorKey : '');
+	for (const id of COLUMN_IDS) {
 		visibility[id] = true;
 	}
 	setAutoHideColumnVisibility({ data, visibility });
+};
+
+/**
+ * Reads the persisted column visibility.
+ *
+ * Hidden columns are what get persisted, so a column that the user has never seen
+ * (i.e. one added in a later release) starts visible rather than hidden.
+ * The superseded 'visible columns' value is discarded on the first read.
+ *
+ * @returns The visibility state of every known column.
+ */
+export const loadColumnVisibility = (): VisibilityState => {
+	localStorage.removeItem(TABLE_COLUMNS_VISIBLE_STORAGE_KEY_LEGACY);
+
+	const hidden = new Set(
+		(localStorage.getItem(TABLE_COLUMNS_HIDDEN_STORAGE_KEY) ?? '')
+			.split(',')
+			.filter(Boolean),
+	);
+	// Ignore a state that would leave nothing to show.
+	const hideNone = COLUMN_IDS.every((id) => hidden.has(id));
+
+	return COLUMN_IDS.reduce<VisibilityState>((acc, id) => {
+		acc[id] = hideNone || !hidden.has(id);
+		return acc;
+	}, {});
+};
+
+/**
+ * Persists the hidden columns of the given visibility state.
+ *
+ * @param visibility - A map of column IDs to their visibility state.
+ */
+export const persistColumnVisibility = (visibility: VisibilityState) => {
+	localStorage.setItem(
+		TABLE_COLUMNS_HIDDEN_STORAGE_KEY,
+		Object.entries(visibility)
+			.filter(([_, isVisible]) => !isVisible)
+			.map(([columnID]) => columnID)
+			.join(','),
+	);
 };

--- a/web/ui/react-app/src/pages/approvals/layouts/table/columns.tsx
+++ b/web/ui/react-app/src/pages/approvals/layouts/table/columns.tsx
@@ -1,6 +1,8 @@
 import type { HeaderContext } from '@tanstack/react-table';
 import { formatISO9075 } from 'date-fns';
+import ServiceImage from '@/components/approvals/service-image';
 import { ServiceActionRelease } from '@/components/approvals/table/service-action-release';
+import { ServiceID } from '@/components/approvals/table/service-id';
 import { ServiceStatus } from '@/components/approvals/table/service-status';
 import type { ColumnDefWithMeta } from '@/components/ui/data-table';
 import { DataTableColumnHeader } from '@/components/ui/data-table-column-header';
@@ -13,7 +15,24 @@ type HeaderContextWithReset<TData, TValue> = HeaderContext<TData, TValue> & {
 
 export const columns: ColumnDefWithMeta<ServiceSummary>[] = [
 	{
+		accessorKey: 'icon',
+		cell: ({ row }) => (
+			<ServiceImage className="aspect-square size-8" service={row.original} />
+		),
+		enableSorting: false,
+		header: (context: HeaderContextWithReset<ServiceSummary, unknown>) => (
+			<DataTableColumnHeader
+				column={context.column}
+				resetSorting={context.resetSorting}
+				title="Icon"
+			/>
+		),
+		id: 'icon',
+		meta: { hideWhenAllValuesEmpty: true, label: 'Icon' },
+	},
+	{
 		accessorKey: 'id',
+		cell: ({ row }) => <ServiceID row={row} />,
 		enableSorting: true,
 		header: (context: HeaderContextWithReset<ServiceSummary, unknown>) => (
 			<DataTableColumnHeader
@@ -164,3 +183,8 @@ export const columns: ColumnDefWithMeta<ServiceSummary>[] = [
 		meta: { label: 'Actions' },
 	},
 ];
+
+/* The IDs of every known column, in the order they are defined above. */
+export const COLUMN_IDS: string[] = columns
+	.map((col) => col.id ?? ('accessorKey' in col ? String(col.accessorKey) : ''))
+	.filter(Boolean);

--- a/web/ui/react-app/src/pages/approvals/layouts/table/table.tsx
+++ b/web/ui/react-app/src/pages/approvals/layouts/table/table.tsx
@@ -1,19 +1,19 @@
+import type { DragEndEvent, SensorOptions } from '@dnd-kit/core';
+import type { SensorDescriptor } from '@dnd-kit/core/dist/sensors/types';
+import type { VisibilityState } from '@tanstack/react-table';
+import { type FC, useCallback, useEffect } from 'react';
 import { useToolbar } from '@/components/approvals/toolbar/toolbar-context';
 import { DataTable } from '@/components/ui/data-table';
+import { TABLE_COLUMNS_ORDER_STORAGE_KEY } from '@/constants/toolbar';
+import { mergeColumnOrder } from '@/pages/approvals/layouts/table/column-order';
 import {
-	TABLE_COLUMNS_ORDER_STORAGE_KEY,
-	TABLE_COLUMNS_VISIBLE_STORAGE_KEY,
-} from '@/constants/toolbar';
-import {
+	loadColumnVisibility,
+	persistColumnVisibility,
 	resetColumnVisibility,
 	setAutoHideColumnVisibility,
 } from '@/pages/approvals/layouts/table/column-visibility';
 import { columns } from '@/pages/approvals/layouts/table/columns';
 import type { ServiceSummary } from '@/utils/api/types/config/summary';
-import type { DragEndEvent, SensorOptions } from '@dnd-kit/core';
-import type { SensorDescriptor } from '@dnd-kit/core/dist/sensors/types';
-import type { VisibilityState } from '@tanstack/react-table';
-import { type FC, useCallback, useEffect } from 'react';
 
 type TableLayoutProps = {
 	/* The list of service summaries for the table. */
@@ -111,14 +111,8 @@ export const TableLayout: FC<TableLayoutProps> = ({
 				if (typeof updater !== 'function')
 					setAutoHideColumnVisibility({ data: services, visibility: newValue });
 
-				// persist visible columns.
-				localStorage.setItem(
-					TABLE_COLUMNS_VISIBLE_STORAGE_KEY,
-					Object.entries(newValue)
-						.filter(([_, isVisible]) => isVisible)
-						.map(([columnID]) => columnID)
-						.join(','),
-				);
+				// Persist hidden columns.
+				persistColumnVisibility(newValue);
 
 				resetColumnVisibility({ data: services, visibility: newValue });
 
@@ -133,31 +127,12 @@ export const TableLayout: FC<TableLayoutProps> = ({
 	// biome-ignore lint/correctness/useExhaustiveDependencies: Startup dependency.
 	useEffect(() => {
 		// Column visibility.
-		const storedVisibility = new Set(
-			(localStorage.getItem(TABLE_COLUMNS_VISIBLE_STORAGE_KEY) ?? '')
-				.split(',')
-				.filter(Boolean),
-		);
+		setTableColumnVisibility(loadColumnVisibility());
 
-		// Convert string[] to VisibilityState (full visibility if empty).
-		const visibility = columns.reduce<VisibilityState>((acc, col) => {
-			const id = col.id ?? ('accessorKey' in col ? col.accessorKey : '');
-			if (id) acc[id] = storedVisibility.size ? storedVisibility.has(id) : true;
-			return acc;
-		}, {});
-
-		setTableColumnVisibility(visibility);
-
-		// Column order.
-		const storedOrder = localStorage
-			.getItem(TABLE_COLUMNS_ORDER_STORAGE_KEY)
-			?.split(',')
-			.filter(Boolean);
-		const fallbackOrder = columns
-			.map((c) => c.id)
-			.filter((id): id is string => typeof id === 'string');
-
-		setTableColumnOrder(storedOrder ?? fallbackOrder);
+		// Column order (columns absent from the stored order keep their defined position).
+		const storedOrder =
+			localStorage.getItem(TABLE_COLUMNS_ORDER_STORAGE_KEY)?.split(',') ?? [];
+		setTableColumnOrder(mergeColumnOrder(storedOrder));
 
 		return () => setTableInstance(undefined);
 	}, []);

--- a/web/ui/react-app/tests/dashboard-table.spec.ts
+++ b/web/ui/react-app/tests/dashboard-table.spec.ts
@@ -1,0 +1,71 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * The service seeded from config.yml.example.
+ * It has an icon, an icon link, and a web URL.
+ */
+const EXAMPLE_SERVICE = {
+	/* The service ID. */
+	id: 'release-argus/Argus',
+	/* `dashboard.icon`. */
+	icon:
+		'https://raw.githubusercontent.com/release-argus/Argus/master/web/ui/' +
+		'react-app/public/favicon.svg',
+	/* `dashboard.icon_link_to`. */
+	iconLinkTo: 'https://release-argus.io',
+	/* `dashboard.web_url`. */
+	webURL: 'https://github.com/release-argus/Argus/blob/master/CHANGELOG.md',
+} as const;
+
+test.describe('Dashboard table view', () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/approvals?view=table');
+	});
+
+	test('the ID links to the service web URL', async ({ page }) => {
+		const link = page.getByRole('link', {
+			exact: true,
+			name: EXAMPLE_SERVICE.id,
+		});
+		await expect(link).toHaveAttribute('href', EXAMPLE_SERVICE.webURL);
+		await expect(link).toHaveAttribute('target', '_blank');
+	});
+
+	test('the icon column shows the service icon, linking to icon_link_to', async ({
+		page,
+	}) => {
+		await expect(
+			page.getByRole('columnheader', { name: 'Icon' }),
+		).toBeVisible();
+
+		// The icon is presentational (empty alt), so it has no accessible role.
+		const row = page
+			.getByRole('row')
+			.filter({ hasText: EXAMPLE_SERVICE.id })
+			.first();
+		await expect(row.locator('img').first()).toHaveAttribute(
+			'src',
+			EXAMPLE_SERVICE.icon,
+		);
+
+		const iconLink = row.getByRole('link', {
+			name: `${EXAMPLE_SERVICE.id} icon link`,
+		});
+		await expect(iconLink).toHaveAttribute('href', EXAMPLE_SERVICE.iconLinkTo);
+		await expect(iconLink).toHaveAttribute('target', '_blank');
+	});
+
+	test('the icon column can be hidden, and stays hidden', async ({ page }) => {
+		const iconHeader = page.getByRole('columnheader', { name: 'Icon' });
+		await expect(iconHeader).toBeVisible();
+
+		await page.getByRole('button', { name: 'Filter shown services' }).click();
+		await page.getByRole('menuitemcheckbox', { name: 'Icon' }).click();
+		await page.keyboard.press('Escape');
+		await expect(iconHeader).toBeHidden();
+
+		await page.reload();
+		await expect(page.getByRole('table')).toBeVisible();
+		await expect(iconHeader).toBeHidden();
+	});
+});


### PR DESCRIPTION
Added the Icon column to the table view and copied the clickable-nature from the grid view
Also fixed:
- the fallback service-type icon functionality so that it uses the service-type once again rather than always GitHub for service's without an icon.
- the icon_link_to field in the config.yml.example accidentally included a - `icon_link-to`, so was never visible

Icon                     |  ID
-------------------------|-------------------------
![](https://github.com/user-attachments/assets/5c462e64-ca76-44e1-9c59-15935f6a0c1b) | ![](https://github.com/user-attachments/assets/22bc625c-7608-4a13-854f-1c62f6ba283f)
