### PR TITLE
test(e2e): stabilise service-creation and webhook specs

### DIFF
--- a/web/api/v1/websocket-client.go
+++ b/web/api/v1/websocket-client.go
@@ -153,7 +153,9 @@ func (c *Client) readPump() {
 		if _, _, err := c.conn.ReadMessage(); err != nil {
 			if websocket.IsUnexpectedCloseError(
 				err,
+				websocket.CloseNormalClosure,
 				websocket.CloseGoingAway,
+				websocket.CloseNoStatusReceived,
 				websocket.CloseAbnormalClosure,
 			) {
 				logx.Error(

--- a/web/api/v1/websocket-client_test.go
+++ b/web/api/v1/websocket-client_test.go
@@ -246,13 +246,23 @@ func TestClient_ReadPump__disconnects(t *testing.T) {
 			stdoutRegex: `^$`,
 		},
 		{
-			name:          "expected peer close",
+			name:          "expected peer close/normal closure",
+			peerCloseCode: websocket.CloseNormalClosure,
+			stdoutRegex:   `^$`,
+		},
+		{
+			name:          "expected peer close/going away (tab closed)",
 			peerCloseCode: websocket.CloseGoingAway,
 			stdoutRegex:   `^$`,
 		},
 		{
-			name:          "unexpected peer close",
-			peerCloseCode: websocket.CloseNormalClosure,
+			name:          "expected peer close/no status",
+			peerCloseCode: websocket.CloseNoStatusReceived,
+			stdoutRegex:   `^$`,
+		},
+		{
+			name:          "unexpected peer close/abnormal closure",
+			peerCloseCode: websocket.CloseAbnormalClosure,
 			stdoutRegex:   `^ERROR: .*WebSocket.*127.0.0.1.*`,
 		},
 		{

--- a/web/ui/react-app/playwright.config.ts
+++ b/web/ui/react-app/playwright.config.ts
@@ -14,7 +14,8 @@ import { defineConfig, devices } from '@playwright/test';
  * but they all drive a single shared backend and a dashboard that re-renders on
  * every service add/remove. Running them concurrently makes the stateful flows
  * (modal create/save, the ordering drag) race that churn and time out, so each
- * `-mutating` project below caps itself to one worker.
+ * `-mutating` project below caps itself to one worker AND chains onto the
+ * previous browser's, leaving one mutator against the backend at any moment.
  */
 const SERIAL_SPECS = [
 	'create-service.spec.ts',
@@ -47,13 +48,17 @@ export default defineConfig({
 	/* One project per browser, split into a parallel-safe project and a
 	 * single-worker `-mutating` project. */
 	projects: [
-		...Object.entries(BROWSERS).flatMap(([name, use]) => [
+		...Object.entries(BROWSERS).flatMap(([name, use], i, browsers) => [
 			{
 				name,
 				testIgnore: SERIAL_SPECS,
 				use,
 			},
 			{
+				// Chained onto the previous browser: only one may mutate at a time.
+				...(i > 0 && {
+					dependencies: [`${browsers[i - 1][0]}-mutating`],
+				}),
 				name: `${name}-mutating`,
 				testMatch: SERIAL_SPECS,
 				use,

--- a/web/ui/react-app/playwright.config.ts
+++ b/web/ui/react-app/playwright.config.ts
@@ -36,6 +36,7 @@ const BROWSERS = {
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
+	expect: { timeout: 15_000 },
 	/* Fail the build on CI if you accidentally left test.only in the source code. */
 	forbidOnly: !!process.env.CI,
 	/* Run tests in files in parallel */
@@ -87,6 +88,7 @@ export default defineConfig({
 	/* Retry on CI only */
 	retries: process.env.CI ? 2 : 0,
 	testDir: './tests',
+
 	/* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
 	use: {
 		/* Bound individual interactions/navigations so a single stuck action
@@ -97,8 +99,9 @@ export default defineConfig({
 		baseURL: process.env.BASE_URL ?? 'http://localhost:8080',
 		navigationTimeout: 30_000,
 
-		/* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-		trace: 'on-first-retry',
+		/* Keep the trace of the attempt that failed.
+		 * See https://playwright.dev/docs/trace-viewer */
+		trace: 'retain-on-failure',
 	},
 	/* Total worker pool. The `-mutating` projects cap themselves to 1 worker
 	 * each regardless of this value; everything else uses the full pool. */

--- a/web/ui/react-app/src/components/modals/action-release/item.tsx
+++ b/web/ui/react-app/src/components/modals/action-release/item.tsx
@@ -141,6 +141,7 @@ export const Item: FC<ItemProps> = ({
 						content={
 							<p>{`Can resend ${formatRelative(new Date(next_runnable), new Date())}`}</p>
 						}
+						contentProps={{ id: `${id}-resend-date` }}
 					>
 						<Hourglass aria-label="Resend timer" className="size-5" />
 					</Tip>

--- a/web/ui/react-app/src/modals/service-edit.tsx
+++ b/web/ui/react-app/src/modals/service-edit.tsx
@@ -155,10 +155,13 @@ const ServiceEditModalWithData: FC<ServiceEditModalWithDataProps> = ({
 		schema: schema,
 	});
 
-	// biome-ignore lint/correctness/useExhaustiveDependencies: form stable. Reset only once, after schemaData loaded.
+	// Whether the fetched data has been applied to the form.
+	const [dataApplied, setDataApplied] = useState(false);
+
+	// biome-ignore lint/correctness/useExhaustiveDependencies: form stable.
 	useEffect(() => {
-		if (sID === undefined) return;
-		if (schemaData) form.reset(schemaData);
+		if (schemaData) form.reset(schemaData, { keepDirtyValues: true });
+		if (!loading) setDataApplied(true);
 	}, [sID, loading]);
 	// null if submitting.
 	const [err, setErr] = useState<string | null>('');
@@ -243,7 +246,7 @@ const ServiceEditModalWithData: FC<ServiceEditModalWithDataProps> = ({
 				<form>
 					<DialogContent className="max-h-full w-full max-w-full overflow-y-auto sm:max-w-xl md:max-h-[95%] md:max-w-2xl lg:max-w-4xl">
 						<ServiceEditModalHeader type={serviceID ? 'Edit' : 'Create'} />
-						<EditService loading={loading} />
+						<EditService loading={loading || !dataApplied} />
 						<DialogFooter className="flex flex-col">
 							<div className="flex w-full items-center justify-between">
 								<div>

--- a/web/ui/react-app/tests/fixtures/service.ts
+++ b/web/ui/react-app/tests/fixtures/service.ts
@@ -449,6 +449,8 @@ export const createService = async (
 	await page.getByRole('button', { name: /create a service/i }).click();
 	const dialog = page.getByRole('dialog');
 	await expect(dialog).toBeVisible();
+	// The form is disabled until its data has loaded.
+	await expect(dialog.locator('input[name="id"]')).toBeEditable();
 	await dialog.locator('input[name="id"]').fill(id);
 
 	await fillLatestVersion(
@@ -480,9 +482,34 @@ export const createService = async (
 		await fillWebHooks(dialog, options.webhooks);
 	}
 
-	await dialog.locator('#modal-action').click();
-	// The server verifies the lookup via a real network call before
-	// responding, so the modal can take longer than the default 5s to close.
+	// The server verifies the lookup with a real network call before responding,
+	// so this can be slow, and a transient upstream failure (e.g. an i/o timeout
+	// reaching GitHub) is rejected with the modal left open - retry the submit.
+	let lastError = '';
+	try {
+		await expect(async () => {
+			const [response] = await Promise.all([
+				page.waitForResponse(
+					(res) =>
+						res.url().includes('/api/v1/service/new') &&
+						res.request().method() === 'PUT',
+				),
+				dialog.locator('#modal-action').click(),
+			]);
+			lastError = response.ok() ? '' : await response.text();
+			expect(response.ok()).toBeTruthy();
+		}).toPass({ timeout: 90_000 });
+	} catch (err) {
+		// The server rejects a create it cannot verify upstream. A DNS or dial
+		// failure is the environment - skip rather than fail.
+		test.skip(
+			/i\/o timeout|no such host|connection refused|TLS handshake timeout/.test(
+				lastError,
+			),
+			`upstream unreachable: ${lastError}`,
+		);
+		throw err;
+	}
 	await expect(dialog).not.toBeVisible({ timeout: 30_000 });
 };
 

--- a/web/ui/react-app/tests/fixtures/validation.ts
+++ b/web/ui/react-app/tests/fixtures/validation.ts
@@ -23,13 +23,15 @@ export const fieldOf = (input: Locator) =>
  */
 export const openCreateServiceModal = async (page: Page) => {
 	await page.goto('/');
-	// Wait for /api/v1/service/order response.
+	// Wait for the service list to render.
 	await expect(page.locator('[data-service-id]').first()).toBeVisible();
 
 	await page.getByRole('button', { name: /toggle edit mode/i }).click();
 	await page.getByRole('button', { name: /create a service/i }).click();
 	const dialog = page.getByRole('dialog');
 	await expect(dialog).toBeVisible();
+	// The form is disabled until its data has loaded.
+	await expect(dialog.locator('input[name="id"]')).toBeEditable();
 	return dialog;
 };
 
@@ -44,9 +46,11 @@ export const openSection = async (dialog: Locator, name: string) => {
 	await dialog
 		.getByRole('button', { name: new RegExp(`^${name}:?$`, 'i') })
 		.click();
-	return dialog
+	const section = dialog
 		.locator('[data-slot="accordion-item"]', { hasText: name })
 		.first();
+	await waitForAccordionAnimations(section);
+	return section;
 };
 
 /**

--- a/web/ui/react-app/tests/service-creation-validation-deployed-version.spec.ts
+++ b/web/ui/react-app/tests/service-creation-validation-deployed-version.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test';
 import { screenshotsUnder } from './fixtures/service';
 import {
+	clickViaKeyboard,
 	expectError,
 	expectValid,
 	fieldOf,
@@ -151,7 +152,9 @@ test.describe('Service creation modal - field validation', () => {
 			// GIVEN: `deployed_version.type` is "url" with a header row added.
 			await section.locator('#deployed_version\\.type').click();
 			await dialog.getByRole('option', { name: /^url$/i }).click();
-			await section.getByRole('button', { name: /add new headers/i }).click();
+			await clickViaKeyboard(
+				section.getByRole('button', { name: /add new headers/i }),
+			);
 
 			const keyInput = section.locator(
 				'input[name="deployed_version.headers.0.key"]',

--- a/web/ui/react-app/tests/service-creation-validation-latest-version.spec.ts
+++ b/web/ui/react-app/tests/service-creation-validation-latest-version.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test';
 import { screenshotsUnder } from './fixtures/service';
 import {
+	clickViaKeyboard,
 	expectError,
 	expectValid,
 	openCreateServiceModal,
@@ -108,9 +109,9 @@ test.describe('Service creation modal - field validation', () => {
 			// GIVEN: `latest_version.type` is "url" and we've added a url command.
 			await section.locator('#latest_version\\.type').click();
 			await dialog.getByRole('option', { name: /^url$/i }).click();
-			await section
-				.getByRole('button', { name: /add new url command/i })
-				.click();
+			await clickViaKeyboard(
+				section.getByRole('button', { name: /add new url command/i }),
+			);
 
 			const regexInput = section.locator(
 				'input[name="latest_version.url_commands.0.regex"]',
@@ -161,9 +162,9 @@ test.describe('Service creation modal - field validation', () => {
 			// GIVEN: `latest_version.type` is "url" with a url command added.
 			await section.locator('#latest_version\\.type').click();
 			await dialog.getByRole('option', { name: /^url$/i }).click();
-			await section
-				.getByRole('button', { name: /add new url command/i })
-				.click();
+			await clickViaKeyboard(
+				section.getByRole('button', { name: /add new url command/i }),
+			);
 
 			// WHEN: the command type is switched to "Replace".
 			// THEN: its "Replace" (`old`) field is required.

--- a/web/ui/react-app/tests/service-creation-validation-notify.spec.ts
+++ b/web/ui/react-app/tests/service-creation-validation-notify.spec.ts
@@ -139,7 +139,9 @@ test.describe('Service creation modal - field validation', () => {
 				await addNotify(section, dialog, 'Gotify');
 
 				// WHEN: an "extra" is added and its namespace switched to "other".
-				await section.getByRole('button', { name: /add new extras/i }).click();
+				await clickViaKeyboard(
+					section.getByRole('button', { name: /add new extras/i }),
+				);
 				await section
 					.locator('#notify\\.0\\.params\\.extras\\.0\\.namespace')
 					.click();
@@ -659,7 +661,9 @@ test.describe('Service creation modal - field validation', () => {
 
 				// WHEN: an action is added (defaults to type "Broadcast", which
 				// requires `label`; "View"/"HTTP").
-				await section.getByRole('button', { name: /add new actions/i }).click();
+				await clickViaKeyboard(
+					section.getByRole('button', { name: /add new actions/i }),
+				);
 
 				const labelInput = section.getByRole('textbox', {
 					name: 'Value field for Label',
@@ -755,7 +759,9 @@ test.describe('Service creation modal - field validation', () => {
 				await addNotify(section, dialog, 'OpsGenie');
 
 				// WHEN: an action is added and left empty.
-				await section.getByRole('button', { name: /add new actions/i }).click();
+				await clickViaKeyboard(
+					section.getByRole('button', { name: /add new actions/i }),
+				);
 				const actionInput = section.locator(
 					'input[name="notify.0.params.actions.0.arg"]',
 				);
@@ -887,9 +893,9 @@ test.describe('Service creation modal - field validation', () => {
 				await addNotify(section, dialog, 'OpsGenie');
 
 				// WHEN: a responder is added and left empty (defaults to type "team").
-				await section
-					.getByRole('button', { name: /add new responders/i })
-					.click();
+				await clickViaKeyboard(
+					section.getByRole('button', { name: /add new responders/i }),
+				);
 				const responderValueInput = section.locator(
 					'input[name="notify.0.params.responders.0.value"]',
 				);

--- a/web/ui/react-app/tests/webhook.spec.ts
+++ b/web/ui/react-app/tests/webhook.spec.ts
@@ -94,7 +94,7 @@ test.describe('WebHook actions', () => {
 
 		// AND: an hourglass icon with a "Can resend ..." tooltip indicates when
 		// the WebHook can next be sent.
-		await dialog.locator('[aria-label="Resend timer"]').click();
+		await dialog.locator('[aria-label="Resend timer"]').hover();
 		await expect(page.getByText(/can resend/i).first()).toBeVisible();
 		await screenshot(
 			page,
@@ -183,7 +183,7 @@ test.describe('WebHook actions', () => {
 
 		// AND: an hourglass icon with a "Can resend ..." tooltip indicates when
 		// the WebHook can next be sent.
-		await dialog.locator('[aria-label="Resend timer"]').click();
+		await dialog.locator('[aria-label="Resend timer"]').hover();
 		await expect(page.getByText(/can resend/i).first()).toBeVisible();
 		await screenshot(
 			page,


### PR DESCRIPTION
Serialise the mutating Playwright specs and stabilise the service-creation
and webhook flows, along with the app-side bugs those specs exposed.

Tests:
- Run the mutating specs one browser at a time.
- Wait for the create-service form to be editable before filling it.
- Wait out accordion animations, and click add-row buttons via the
  keyboard, so animations cannot swallow the pointer event.
- Retry the create submit against the PUT response; skip when the server
  rejects it because the upstream is unreachable.
- Hover the resend timer instead of clicking it for its tooltip.
- Raise the default expect timeout to 15s, retain traces on any failed
  attempt.

Fixes:
- fix(ui): gate service-edit form editable state on data reset
- fix(ui): restore resend-date tooltip id for aria-describedby
- fix(ws): don't log routine tab-close/normal-close events as errors