### PR TITLE
feat(ui): refresh deployed versions for visible services only

### DIFF
--- a/web/ui/react-app/playwright.config.ts
+++ b/web/ui/react-app/playwright.config.ts
@@ -26,6 +26,10 @@ const SERIAL_SPECS = [
 	'webhook.spec.ts',
 ];
 
+/* Every serial spec creates services, and each create blocks on the server
+ * verifying the lookup upstream. */
+const MUTATING_TEST_TIMEOUT = 90_000;
+
 const BROWSERS = {
 	chromium: devices['Desktop Chrome'],
 	firefox: devices['Desktop Firefox'],
@@ -62,6 +66,7 @@ export default defineConfig({
 				}),
 				name: `${name}-mutating`,
 				testMatch: SERIAL_SPECS,
+				timeout: MUTATING_TEST_TIMEOUT,
 				use,
 				/* Mutating specs run one-at-a-time per browser. */
 				workers: 1,
@@ -92,8 +97,7 @@ export default defineConfig({
 	/* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
 	use: {
 		/* Bound individual interactions/navigations so a single stuck action
-		 * fails fast rather than riding out the (tripled, via `test.slow()`)
-		 * test timeout. */
+		 * fails fast rather than riding out the whole test timeout. */
 		actionTimeout: 15_000,
 		/* Base URL to use in actions like `await page.goto('')`. */
 		baseURL: process.env.BASE_URL ?? 'http://localhost:8080',

--- a/web/ui/react-app/src/components/approvals/service-info--deployed-version.tsx
+++ b/web/ui/react-app/src/components/approvals/service-info--deployed-version.tsx
@@ -29,13 +29,13 @@ const ServiceInfoDeployedVersion: FC<ServiceInfoVersionProps> = ({
 	return (
 		<ServiceInfoVersionItem
 			Icon={hasDeployedVersion ? AtSign : undefined}
-			liKey="deployed_v"
 			timestamp={deployedVersionTimestamp ?? undefined}
 			tipClassName={cn(
 				updateAvailable ? 'text-muted-foreground' : 'text-foreground',
 			)}
 			tooltipLabel="Deployed"
 			value={deployedVersion ?? undefined}
+			versionType="deployed"
 		/>
 	);
 };

--- a/web/ui/react-app/src/components/approvals/service-info--latest-version.tsx
+++ b/web/ui/react-app/src/components/approvals/service-info--latest-version.tsx
@@ -29,11 +29,11 @@ const ServiceInfoLatestVersion: FC<ServiceInfoVersionProps> = ({
 		<ServiceInfoVersionItem
 			contentProps={{ side: 'bottom' }}
 			Icon={updateAvailable ? CornerDownRight : undefined}
-			liKey="latest_v"
 			timestamp={latestVersionTimestamp ?? undefined}
 			tipClassName="text-foreground"
 			tooltipLabel="Latest version found"
 			value={latestVersion ?? undefined}
+			versionType="latest"
 		/>
 	);
 };

--- a/web/ui/react-app/src/components/approvals/service-info--version-item.tsx
+++ b/web/ui/react-app/src/components/approvals/service-info--version-item.tsx
@@ -15,8 +15,8 @@ export type ServiceInfoVersionProps = {
 };
 
 export type ServiceInfoVersionItemProps = {
-	/* Unique key for the list item. */
-	liKey?: string;
+	/* Which of the service's versions this item shows. */
+	versionType: 'deployed' | 'latest';
 
 	/* Icon to display before the version value. */
 	Icon?: LucideIcon;
@@ -36,7 +36,7 @@ export type ServiceInfoVersionItemProps = {
 /**
  * Service version item with an associated icon, value, timestamp and tooltip label.
  *
- * @property liKey - Unique key required for the `<li>` element in the rendered list.
+ * @property versionType - Which of the service's versions this item shows.
  * @property Icon - An optional icon to display alongside the item details.
  * @property value - The version value to be displayed.
  * @property timestamp - Timestamp information for the version.
@@ -45,7 +45,7 @@ export type ServiceInfoVersionItemProps = {
  * @property contentProps - Additional properties to pass to the tooltip content configuration.
  */
 const ServiceInfoVersionItem: FC<ServiceInfoVersionItemProps> = ({
-	liKey,
+	versionType,
 	Icon,
 	value,
 	timestamp,
@@ -56,7 +56,7 @@ const ServiceInfoVersionItem: FC<ServiceInfoVersionItemProps> = ({
 	const tooltipContent = `${tooltipLabel} ${timestamp ? relativeDate(new Date(timestamp)) : 'Unknown'}`;
 
 	return (
-		<li key={liKey}>
+		<li data-version-type={versionType} key={versionType}>
 			<Tip
 				className={cn('flex flex-wrap items-center gap-x-1 p-0', tipClassName)}
 				content={tooltipContent}

--- a/web/ui/react-app/src/components/approvals/service.tsx
+++ b/web/ui/react-app/src/components/approvals/service.tsx
@@ -66,32 +66,21 @@ const Service: FC<ServiceProps> = ({ id, editable = false }) => {
 	const updateStatus = useMemo(() => {
 		const updateAvailable = data?.status?.state === 'AVAILABLE';
 		const updateSkipped = data?.status?.state === 'SKIPPED';
-		const updateWarning = updateAvailable && !updateSkipped;
 
 		return {
-			// Update available when both 'latest' and 'deployed' versions defined, and differ.
 			available: updateAvailable,
-			// className for possible warning state
 			className: cn(
-				updateWarning && [
+				updateAvailable && [
 					'text-foreground',
 					data?.active !== false && 'bg-accent',
 				],
 			),
-			hasActions:
-				(data?.command ?? 0) > 0 ||
-				(data?.webhook ?? 0) > 0 ||
-				updateAvailable ||
-				updateSkipped,
 			// Version not found.
 			not_found:
 				isEmptyOrNull(data?.status?.deployed_version) ||
 				isEmptyOrNull(data?.status?.latest_version) ||
 				isEmptyOrNull(data?.status?.last_queried),
-			// Update available, and 'approved' version is a skip of the 'latest'.
 			skipped: updateSkipped,
-			// 'New' version found (and not skipped).
-			warning: updateWarning,
 		};
 	}, [data]);
 
@@ -110,7 +99,7 @@ const Service: FC<ServiceProps> = ({ id, editable = false }) => {
 					: updateStatus.className,
 			)}
 			data-service-id={id}
-			data-update-available={updateStatus.warning && data?.active !== false}
+			data-update-state={data?.status?.state}
 			key={data?.id}
 			ref={setNodeRef}
 			style={dragStyle}

--- a/web/ui/react-app/src/components/approvals/toolbar/filter-dropdown.tsx
+++ b/web/ui/react-app/src/components/approvals/toolbar/filter-dropdown.tsx
@@ -6,8 +6,10 @@ import {
 } from '@dnd-kit/sortable';
 import { useQueryClient } from '@tanstack/react-query';
 import { Eye } from 'lucide-react';
-import { type FC, useCallback } from 'react';
-import RefreshDeployedVersionsMenuItem from '@/components/approvals/toolbar/refresh-deployed-versions';
+import { type FC, useCallback, useMemo } from 'react';
+import RefreshDeployedVersionsMenuItem, {
+	canRefreshDeployedVersion,
+} from '@/components/approvals/toolbar/refresh-deployed-versions';
 import { useToolbar } from '@/components/approvals/toolbar/toolbar-context';
 import { Button } from '@/components/ui/button';
 import type { ExtraColumnMeta } from '@/components/ui/data-table';
@@ -60,8 +62,14 @@ const FilterDropdown: FC = () => {
 		setTableColumnVisibility,
 		tableColumnOrder,
 		setTableColumnOrder,
+		visibleServices,
 	} = useToolbar();
 	const currentHideValues = values.hide;
+	const refreshableServiceIDs = useMemo(
+		() =>
+			visibleServices.filter(canRefreshDeployedVersion).map((svc) => svc.id),
+		[visibleServices],
+	);
 
 	const onDragEnd = (event: DragEndEvent) => {
 		const { active, over } = event;
@@ -234,11 +242,17 @@ const FilterDropdown: FC = () => {
 						</DropdownMenuCheckboxItem>
 					))}
 				</DropdownMenuGroup>
-				<DropdownMenuSeparator />
-				<DropdownMenuGroup>
-					<DropdownMenuLabel>Actions:</DropdownMenuLabel>
-					<RefreshDeployedVersionsMenuItem />
-				</DropdownMenuGroup>
+				{refreshableServiceIDs.length > 0 && (
+					<>
+						<DropdownMenuSeparator />
+						<DropdownMenuGroup>
+							<DropdownMenuLabel>Actions:</DropdownMenuLabel>
+							<RefreshDeployedVersionsMenuItem
+								serviceIDs={refreshableServiceIDs}
+							/>
+						</DropdownMenuGroup>
+					</>
+				)}
 				{tableInstance && (
 					<>
 						<DropdownMenuSeparator />

--- a/web/ui/react-app/src/components/approvals/toolbar/refresh-deployed-versions.tsx
+++ b/web/ui/react-app/src/components/approvals/toolbar/refresh-deployed-versions.tsx
@@ -1,11 +1,12 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import { LoaderCircle } from 'lucide-react';
 import type { FC } from 'react';
 import { toast } from 'sonner';
 import { DropdownMenuItem } from '@/components/ui/dropdown-menu';
-import { getServiceSummaries } from '@/hooks/use-services';
 import { beautifyGoErrors } from '@/utils';
 import { mapRequest } from '@/utils/api/types/api-request-handler';
+import { DEPLOYED_VERSION_LOOKUP_TYPE } from '@/utils/api/types/config/service/deployed-version';
+import type { ServiceSummary } from '@/utils/api/types/config/summary';
 
 /* Number of `deployed_version` refreshes to run concurrently. */
 const REFRESH_CONCURRENCY = 5;
@@ -21,20 +22,32 @@ const REFRESH_TOAST_OPTS = {
 } as const;
 
 /**
- * Re-queries `deployed_version` for every configured service.
+ * Whether a service's deployed_version has an external source to re-query.
+ *
+ * @param svc - The service summary to check.
+ * @returns True if the service's deployed_version can be re-queried.
  */
-const RefreshDeployedVersionsMenuItem: FC = () => {
-	const queryClient = useQueryClient();
+export const canRefreshDeployedVersion = (svc: ServiceSummary): boolean =>
+	Boolean(svc.deployed_version_type) &&
+	svc.deployed_version_type !== DEPLOYED_VERSION_LOOKUP_TYPE.MANUAL.value;
 
-	const { mutate: refreshAll, isPending } = useMutation({
+type RefreshDeployedVersionsMenuItemProps = {
+	/* IDs of the services to re-query. */
+	serviceIDs: string[];
+};
+
+/**
+ * Re-queries the `deployed_version` of each of `serviceIDs`.
+ *
+ * @param serviceIDs - IDs of the services to re-query.
+ */
+const RefreshDeployedVersionsMenuItem: FC<
+	RefreshDeployedVersionsMenuItemProps
+> = ({ serviceIDs }) => {
+	const total = serviceIDs.length;
+
+	const { mutate: refreshVisible, isPending } = useMutation({
 		mutationFn: async () => {
-			const serviceIDs = getServiceSummaries(queryClient)
-				.filter((svc) => !svc.loading && svc.deployed_version_type)
-				.map((svc) => svc.id);
-
-			const total = serviceIDs.length;
-			if (total === 0) return { failed: 0, total };
-
 			let completed = 0;
 			let failed = 0;
 			toast.loading(
@@ -50,21 +63,31 @@ const RefreshDeployedVersionsMenuItem: FC = () => {
 				);
 			};
 
-			for (let i = 0; i < serviceIDs.length; i += REFRESH_CONCURRENCY) {
-				const batch = serviceIDs.slice(i, i + REFRESH_CONCURRENCY);
-				const results = await Promise.allSettled(
-					batch.map((serviceID) =>
-						mapRequest('VERSION_REFRESH', {
+			let next = 0;
+			const worker = async () => {
+				while (next < serviceIDs.length) {
+					const serviceID = serviceIDs[next++];
+					try {
+						await mapRequest('VERSION_REFRESH', {
 							dataSemanticVersioning: null,
 							dataTarget: 'deployed_version',
 							original: null,
 							originalSemanticVersioning: null,
-							serviceID,
-						}).finally(reportProgress),
-					),
-				);
-				failed += results.filter((r) => r.status === 'rejected').length;
-			}
+							serviceID: serviceID,
+						});
+					} catch {
+						failed += 1;
+					} finally {
+						reportProgress();
+					}
+				}
+			};
+			await Promise.all(
+				Array.from(
+					{ length: Math.min(REFRESH_CONCURRENCY, serviceIDs.length) },
+					worker,
+				),
+			);
 
 			return { failed, total };
 		},
@@ -75,23 +98,21 @@ const RefreshDeployedVersionsMenuItem: FC = () => {
 			});
 		},
 		onSuccess: ({ failed, total }) => {
-			if (total === 0) {
-				toast.info(
-					'No services with a deployed version to refresh',
-					REFRESH_TOAST_OPTS,
-				);
-				return;
-			}
 			if (failed > 0) {
-				toast.error(
-					`Refreshed deployed versions: ${failed}/${total} failed`,
-					REFRESH_TOAST_OPTS,
-				);
+				toast.error(`Refreshed deployed versions`, {
+					description: (
+						<div className="flex flex-col gap-1">
+							<span>Succeeded: {total - failed}</span>
+							<span>Failed: {failed}</span>
+						</div>
+					),
+					...REFRESH_TOAST_OPTS,
+				});
 			} else {
-				toast.success(
-					`Refreshed deployed version for ${total} service${total === 1 ? '' : 's'}`,
-					REFRESH_TOAST_OPTS,
-				);
+				toast.success(`Refreshed deployed versions`, {
+					description: `Succeeded: ${total}`,
+					...REFRESH_TOAST_OPTS,
+				});
 			}
 		},
 	});
@@ -100,9 +121,9 @@ const RefreshDeployedVersionsMenuItem: FC = () => {
 		<DropdownMenuItem
 			className="cursor-pointer"
 			disabled={isPending}
-			onClick={() => refreshAll()}
+			onClick={() => refreshVisible()}
 		>
-			Refresh all deployed versions
+			Refresh visible deployed versions
 			{isPending && <LoaderCircle className="ml-2 animate-spin" />}
 		</DropdownMenuItem>
 	);

--- a/web/ui/react-app/src/components/approvals/toolbar/toolbar-context.tsx
+++ b/web/ui/react-app/src/components/approvals/toolbar/toolbar-context.tsx
@@ -44,6 +44,10 @@ export type ToolbarContextValue = {
 	onSaveOrder: () => Promise<void>;
 	/* Whether the order of the service list has changed */
 	hasOrderChanged: boolean;
+
+	/* Services currently visible under the toolbar filters, in dashboard order.
+	   Includes still-loading placeholders. */
+	visibleServices: ServiceSummary[];
 };
 
 const ToolbarContext = createContext<ToolbarContextValue | null>(null);

--- a/web/ui/react-app/src/contexts/service-edit-zod-type.tsx
+++ b/web/ui/react-app/src/contexts/service-edit-zod-type.tsx
@@ -62,7 +62,7 @@ export const SchemaProvider: FC<SchemaProviderProps> = ({
 }) => {
 	const { data: orderData } = useServiceOrder();
 	const order = orderData?.order ?? [];
-	const { services } = useServices();
+	const { services } = useServices(order);
 
 	// Stable key for service IDs.
 	// biome-ignore lint/correctness/useExhaustiveDependencies: orderData covers order.
@@ -106,7 +106,7 @@ export const SchemaProvider: FC<SchemaProviderProps> = ({
 			typeDataDefaults,
 			typeDataDefaultsHollow,
 		};
-	}, [data, otherOptionsData, serviceIDs]);
+	}, [data, otherOptionsData, serviceIDs, services]);
 
 	return <SchemaContext value={contextValue}>{children}</SchemaContext>;
 };

--- a/web/ui/react-app/src/contexts/service-edit-zod-type.tsx
+++ b/web/ui/react-app/src/contexts/service-edit-zod-type.tsx
@@ -62,7 +62,7 @@ export const SchemaProvider: FC<SchemaProviderProps> = ({
 }) => {
 	const { data: orderData } = useServiceOrder();
 	const order = orderData?.order ?? [];
-	const services = useServices();
+	const { services } = useServices();
 
 	// Stable key for service IDs.
 	// biome-ignore lint/correctness/useExhaustiveDependencies: orderData covers order.
@@ -75,7 +75,7 @@ export const SchemaProvider: FC<SchemaProviderProps> = ({
 	// biome-ignore lint/correctness/useExhaustiveDependencies: serviceIDs covers orderData.order.
 	const contextValue = useMemo(() => {
 		const serviceNamesSet = new Set(
-			services.map((svc) => svc.data?.name).filter(Boolean) as string[],
+			services.map((svc) => svc.name).filter(Boolean) as string[],
 		);
 
 		const {

--- a/web/ui/react-app/src/hooks/use-services.ts
+++ b/web/ui/react-app/src/hooks/use-services.ts
@@ -1,4 +1,8 @@
-import { type QueryClient, useQueries } from '@tanstack/react-query';
+import {
+	type QueryClient,
+	type UseQueryResult,
+	useQueries,
+} from '@tanstack/react-query';
 import { QUERY_KEYS } from '@/lib/query-keys';
 import { mapRequest } from '@/utils/api/types/api-request-handler';
 import type {
@@ -6,14 +10,34 @@ import type {
 	ServiceSummary,
 } from '@/utils/api/types/config/summary';
 
+export type UseServicesResult = {
+	/* Service summaries, in dashboard order. */
+	services: ServiceSummary[];
+	/* Whether any service summary is currently fetching. */
+	isFetching: boolean;
+};
+
+/*
+ * Combine the results of multiple service summary queries.
+ */
+const combineServices = (
+	results: UseQueryResult<ServiceSummary>[],
+): UseServicesResult => ({
+	isFetching: results.some((result) => result.isFetching),
+	services: results.flatMap((result) => (result.data ? [result.data] : [])),
+});
+
 /**
  * Fetch service summaries for a list of service IDs.
  *
  * @param order - The list of services to fetch.
- * @returns A React Query response object from `useQueries`.
+ * @returns The summaries, and whether any is still fetching.
  */
-export const useServices = (order?: OrderAPIResponse['order']) =>
+export const useServices = (
+	order?: OrderAPIResponse['order'],
+): UseServicesResult =>
 	useQueries({
+		combine: combineServices,
 		queries: (order ?? []).map((id) => ({
 			placeholderData: { id: id, loading: true },
 			queryFn: () => mapRequest('SERVICE_SUMMARY', { serviceID: id }),

--- a/web/ui/react-app/src/hooks/use-tags.ts
+++ b/web/ui/react-app/src/hooks/use-tags.ts
@@ -24,7 +24,9 @@ export type UseTagsResult = {
 export const useTags = (excludeServiceID?: string | null): UseTagsResult => {
 	const { data: orderData, isFetching: isFetchingOrderData } =
 		useServiceOrder();
-	const services = useServices(orderData?.order);
+	const { services, isFetching: isFetchingServices } = useServices(
+		orderData?.order,
+	);
 
 	return useMemo(() => {
 		const tagCounts: Record<string, number> = {};
@@ -32,8 +34,8 @@ export const useTags = (excludeServiceID?: string | null): UseTagsResult => {
 
 		// Retrieve all tags, and a count of usage for each tag.
 		for (const svc of services) {
-			const svcID = svc.data?.id;
-			const svcTags = svc.data?.tags ?? [];
+			const svcID = svc.id;
+			const svcTags = svc.tags ?? [];
 
 			for (const t of svcTags) allTags.add(t);
 
@@ -48,9 +50,8 @@ export const useTags = (excludeServiceID?: string | null): UseTagsResult => {
 		);
 
 		// Loading state if fetching order, or any service still loading.
-		const anyLoading =
-			isFetchingOrderData || services.some((s) => s.isFetching);
+		const anyLoading = isFetchingOrderData || isFetchingServices;
 
 		return { counts: tagCounts, isLoading: anyLoading, tags: sortedTags };
-	}, [excludeServiceID, isFetchingOrderData, services]);
+	}, [excludeServiceID, isFetchingOrderData, isFetchingServices, services]);
 };

--- a/web/ui/react-app/src/pages/approvals/index.tsx
+++ b/web/ui/react-app/src/pages/approvals/index.tsx
@@ -1,4 +1,3 @@
-import { useQueryClient } from '@tanstack/react-query';
 import type { Table, VisibilityState } from '@tanstack/react-table';
 import { type ReactElement, useCallback, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router';
@@ -22,6 +21,7 @@ import { GridLayout } from '@/pages/approvals/layouts/grid';
 import { TableLayout } from '@/pages/approvals/layouts/table/table';
 import type { TagsTriType } from '@/types/util';
 import type { ServiceSummary } from '@/utils/api/types/config/summary';
+import { visibleServices as getVisibleServices } from '@/utils/visible-services';
 
 const toolbarDefaults: ApprovalsToolbarOptions = {
 	editMode: false,
@@ -35,7 +35,6 @@ const toolbarDefaults: ApprovalsToolbarOptions = {
  * @returns The 'approvals' page, including a toolbar, and a list of services.
  */
 export const Approvals = (): ReactElement => {
-	const queryClient = useQueryClient();
 	const [searchParams, setSearchParams] = useSearchParams();
 	// Signal for resetting table sorting when order is reset.
 	const [resetSortingSignal, setResetSortingSignal] = useState(0);
@@ -109,64 +108,12 @@ export const Approvals = (): ReactElement => {
 		applyOrder,
 	} = useSortableServices();
 
-	const services = useServices(order);
+	const { services } = useServices(order);
 
-	// Filter the services based on the toolbar options.
-	// biome-ignore lint/correctness/useExhaustiveDependencies: queryClient stable.
-	const filteredServices = useMemo(() => {
-		const {
-			search = '',
-			tags = toolbarDefaults.tags,
-			hide,
-		} = {
-			...toolbarOptions,
-			search: toolbarOptions.search.toLowerCase(),
-		};
-		const filterOnTags = tags.include.length > 0 || tags.exclude.length > 0;
-		const excludeOnly = filterOnTags && tags.include.length === 0;
-
-		return services
-			.filter((svc) => {
-				const service = svc.data;
-				if (!service || service.loading) return true;
-
-				const serviceID = service.id;
-
-				// Filter on 'tags'.
-				//     Have no tags to filter on,
-				//   OR
-				//     The service doesn't have any EXCLUDE tags
-				//       AND
-				//     We are only excluding tags, OR the service has all INCLUDE tags.
-				const hasTags =
-					!filterOnTags ||
-					(!tags.exclude.some((tag) => service.tags?.includes(tag)) &&
-						(excludeOnly ||
-							tags.include.some((tag) => service.tags?.includes(tag))));
-				if (!hasTags) return false;
-
-				// Filter on 'name'.
-				const name = (service.name ?? serviceID).toLowerCase();
-				if (!name.includes(search)) return false;
-
-				// Filter on 'hide' options.
-				const skipped = service.status?.state === 'SKIPPED';
-				const upToDate = service.status?.state === 'UP_TO_DATE';
-				const hideInactiveServices = hide.includes(HideValue.Inactive);
-				return (
-					// hideUpToDate: deployed_version NOT latest_version.
-					(!hide.includes(HideValue.UpToDate) || !upToDate) &&
-					// hideUpdatable: deployed_version IS latest_version AND approved_version NOT a skip of latest_version.
-					(!hide.includes(HideValue.Updatable) || upToDate || skipped) &&
-					// hideSkipped: approved_version NOT a skip of latest_version OR NO approved_version.
-					(!hide.includes(HideValue.Skipped) || !skipped) &&
-					// hideInactive: active NOT false.
-					(!hideInactiveServices || service.active !== false)
-				);
-			})
-			.map((svc) => svc.data)
-			.filter(Boolean) as ServiceSummary[];
-	}, [toolbarOptions, queryClient, services]);
+	const visibleServices = useMemo(
+		() => getVisibleServices(services, toolbarOptions),
+		[services, toolbarOptions],
+	);
 
 	// URL param helpers and context value
 	type URLParam = boolean | number[] | readonly number[] | string | string[];
@@ -297,6 +244,7 @@ export const Approvals = (): ReactElement => {
 				toggleEditMode,
 
 				values: toolbarOptions,
+				visibleServices,
 			}}
 		>
 			<ApprovalsToolbar />
@@ -306,7 +254,7 @@ export const Approvals = (): ReactElement => {
 					handleDragEnd={handleDragEnd}
 					order={order}
 					sensors={sensors}
-					services={filteredServices}
+					services={visibleServices}
 				/>
 			)}
 			{toolbarOptions.view === APPROVALS_TOOLBAR_VIEW.TABLE.value && (
@@ -318,7 +266,7 @@ export const Approvals = (): ReactElement => {
 					resetSorting={resetSorting}
 					resetSortingSignal={resetSortingSignal}
 					sensors={sensors}
-					services={filteredServices}
+					services={visibleServices}
 				/>
 			)}
 		</ToolbarProvider>

--- a/web/ui/react-app/src/types/websocket.ts
+++ b/web/ui/react-app/src/types/websocket.ts
@@ -39,9 +39,8 @@ export type WebSocketResponse =
 	| {
 			page: 'APPROVALS';
 			type: 'SERVICE';
-			sub_type: 'INIT' | 'ORDER';
+			sub_type: 'ORDER';
 			order?: string[];
-			service_data?: ServiceSummary;
 	  }
 	| {
 			page: 'APPROVALS';

--- a/web/ui/react-app/src/utils/api/query-cache.ts
+++ b/web/ui/react-app/src/utils/api/query-cache.ts
@@ -29,20 +29,9 @@ export const approvalsQueryCacheUpdater = ({
 	if (msg.page !== 'APPROVALS') return;
 
 	switch (msg.type) {
-		// INIT
 		// ORDER
 		case 'SERVICE': {
 			switch (msg.sub_type) {
-				case 'INIT': {
-					const id = msg?.service_data?.id;
-					if (!id) return;
-
-					queryClient.setQueryData(QUERY_KEYS.SERVICE.SUMMARY_ITEM(id), () => ({
-						...msg.service_data,
-						loading: false,
-					}));
-					break;
-				}
 				case 'ORDER': {
 					if (msg.order === undefined) return;
 

--- a/web/ui/react-app/src/utils/api/types/requests/service-edit.ts
+++ b/web/ui/react-app/src/utils/api/types/requests/service-edit.ts
@@ -103,10 +103,10 @@ export const applyDeployedVersionUpdate = (
 };
 
 export const getServiceUpdateState = (
-	status?: StatusSummaryType,
+	status: StatusSummaryType,
 ): ServiceUpdateState => {
 	// Loading 'status' still.
-	if (status === undefined) return null;
+	if (!status.latest_version && !status.deployed_version) return null;
 
 	// Latest version is deployed.
 	if (status.latest_version === status.deployed_version) return 'UP_TO_DATE';

--- a/web/ui/react-app/src/utils/visible-services.ts
+++ b/web/ui/react-app/src/utils/visible-services.ts
@@ -1,0 +1,89 @@
+import {
+	type ApprovalsToolbarOptions,
+	HideValue,
+	type HideValueType,
+} from '@/constants/toolbar';
+import type { TagsTriType } from '@/types/util';
+import type {
+	ServiceSummary,
+	ServiceUpdateState,
+} from '@/utils/api/types/config/summary';
+
+/* The 'hide' toggle that removes each update state from view. */
+const HIDE_VALUE_FOR_STATE: Record<
+	NonNullable<ServiceUpdateState>,
+	HideValueType
+> = {
+	AVAILABLE: HideValue.Updatable,
+	SKIPPED: HideValue.Skipped,
+	UP_TO_DATE: HideValue.UpToDate,
+};
+
+/**
+ * Whether a service's tags match the toolbar filters.
+ *
+ * @param svc - The service summary to check.
+ * @param tags - The toolbar tag filters.
+ *
+ * @returns True if the service matches the tag filters, false otherwise.
+ */
+const matchesTags = (svc: ServiceSummary, tags: TagsTriType): boolean =>
+	!tags.exclude.some((tag) => svc.tags?.includes(tag)) &&
+	(tags.include.length === 0 ||
+		tags.include.some((tag) => svc.tags?.includes(tag)));
+
+/**
+ * Whether a service's name or ID matches the toolbar search.
+ *
+ * @param svc - The service summary to check.
+ * @param search - The lower-cased search string.
+ *
+ * @returns True if the service matches the search, false otherwise.
+ */
+const matchesSearch = (svc: ServiceSummary, search: string): boolean =>
+	(svc.name ?? svc.id).toLowerCase().includes(search);
+
+/**
+ * Whether a service's status matches the toolbar hide filters.
+ *
+ * @param svc  - The service summary to check.
+ * @param hide - The toolbar hide filters.
+ *
+ * @returns True if the service matches the hide filters, false otherwise.
+ */
+const matchesHide = (svc: ServiceSummary, hide: HideValueType[]): boolean => {
+	if (svc.active === false && hide.includes(HideValue.Inactive)) return false;
+
+	const state = svc.status?.state;
+	return !state || !hide.includes(HIDE_VALUE_FOR_STATE[state]);
+};
+
+export type ToolbarFilters = Pick<
+	ApprovalsToolbarOptions,
+	'hide' | 'search' | 'tags'
+>;
+
+/**
+ * The services the dashboard renders under the given toolbar filters, in the
+ * order given. Still-loading services always render - their filterable fields
+ * haven't arrived yet.
+ *
+ * @param services - Service summaries, in dashboard order.
+ * @param filters - The current toolbar filter values.
+ *
+ * @returns The services to render.
+ */
+export const visibleServices = (
+	services: ServiceSummary[],
+	filters: ToolbarFilters,
+): ServiceSummary[] => {
+	const search = filters.search.toLowerCase();
+
+	return services.filter(
+		(svc) =>
+			svc.loading ||
+			(matchesTags(svc, filters.tags) &&
+				matchesSearch(svc, search) &&
+				matchesHide(svc, filters.hide)),
+	);
+};

--- a/web/ui/react-app/tests/create-service.spec.ts
+++ b/web/ui/react-app/tests/create-service.spec.ts
@@ -1,11 +1,17 @@
 import { expect, type Page, test } from '@playwright/test';
 import {
+	expectUpdateState,
+	expectVersions,
+	openDashboardInEditMode,
+	serviceCard,
+} from './fixtures/dashboard';
+import {
 	type CreateServiceOptions,
-	cleanupServices,
 	createService,
 	deleteService,
 	LOOKUP_LATEST_VERSION_JSON,
 	screenshot,
+	trackCreatedServices,
 	withProject,
 } from './fixtures/service';
 import {
@@ -13,12 +19,6 @@ import {
 	LOOKUP_BASIC_AUTH,
 	LOOKUP_WITH_HEADER_AUTH,
 } from './fixtures/test-endpoints';
-
-// Creating a service makes a real server-side network call that can exceed the
-// default timeout under load - so triple it.
-test.beforeEach(() => {
-	test.slow();
-});
 
 /**
  * Runs a create -> verify -> refresh -> delete cycle, screenshotting each stage.
@@ -36,8 +36,7 @@ const runCreateServiceTest = async (
 	projectName: string,
 	options?: CreateServiceOptions,
 ) => {
-	await page.goto('/');
-	await page.getByRole('button', { name: /toggle edit mode/i }).click();
+	await openDashboardInEditMode(page);
 	await screenshot(
 		page,
 		`service-create/${baseID}/01-before-create`,
@@ -76,17 +75,12 @@ const runCreateServiceTest = async (
 };
 
 test.describe('Service creation', () => {
-	// Safety net for a test that fails before its own `deleteService` step.
-	let createdID: string | undefined;
-	test.afterEach(async ({ page }) => {
-		if (createdID) await cleanupServices(page, [createdID]);
-		createdID = undefined;
-	});
+	const createdIDs = trackCreatedServices();
 
 	test('latest-version=github', async ({ page }, testInfo) => {
 		const baseID = 'LATEST_VERSION=GITHUB';
 		const id = withProject(baseID, testInfo.project.name);
-		createdID = id;
+		createdIDs.push(id);
 		await runCreateServiceTest(page, id, baseID, testInfo.project.name, {
 			latestVersion: {
 				type: 'github',
@@ -98,7 +92,7 @@ test.describe('Service creation', () => {
 	test('latest-version=url', async ({ page }, testInfo) => {
 		const baseID = 'LATEST_VERSION=URL';
 		const id = withProject(baseID, testInfo.project.name);
-		createdID = id;
+		createdIDs.push(id);
 		await runCreateServiceTest(page, id, baseID, testInfo.project.name, {
 			latestVersion: {
 				type: 'url',
@@ -110,7 +104,7 @@ test.describe('Service creation', () => {
 	test('deployed-version=manual', async ({ page }, testInfo) => {
 		const baseID = 'DEPLOYED_VERSION=MANUAL';
 		const id = withProject(baseID, testInfo.project.name);
-		createdID = id;
+		createdIDs.push(id);
 		await runCreateServiceTest(page, id, baseID, testInfo.project.name, {
 			deployedVersion: {
 				type: 'manual',
@@ -122,7 +116,7 @@ test.describe('Service creation', () => {
 	test('deployed-version=url (JSON)', async ({ page }, testInfo) => {
 		const baseID = 'DEPLOYED_VERSION=URL';
 		const id = withProject(baseID, testInfo.project.name);
-		createdID = id;
+		createdIDs.push(id);
 		await runCreateServiceTest(page, id, baseID, testInfo.project.name, {
 			deployedVersion: {
 				json: 'version',
@@ -135,7 +129,7 @@ test.describe('Service creation', () => {
 	test('deployed-version=url (basic auth)', async ({ page }, testInfo) => {
 		const baseID = 'DEPLOYED_VERSION=URL BASIC-AUTH';
 		const id = withProject(baseID, testInfo.project.name);
-		createdID = id;
+		createdIDs.push(id);
 		await runCreateServiceTest(page, id, baseID, testInfo.project.name, {
 			deployedVersion: {
 				basicAuth: {
@@ -153,7 +147,7 @@ test.describe('Service creation', () => {
 	test('deployed-version=url (header auth)', async ({ page }, testInfo) => {
 		const baseID = 'DEPLOYED_VERSION=URL HEADER-AUTH';
 		const id = withProject(baseID, testInfo.project.name);
-		createdID = id;
+		createdIDs.push(id);
 		await runCreateServiceTest(page, id, baseID, testInfo.project.name, {
 			deployedVersion: {
 				headers: [
@@ -170,22 +164,16 @@ test.describe('Service creation', () => {
 });
 
 test.describe('Service update status', () => {
-	// Safety net for a test that fails before its own `deleteService` step.
-	let createdID: string | undefined;
-	test.afterEach(async ({ page }) => {
-		if (createdID) await cleanupServices(page, [createdID]);
-		createdID = undefined;
-	});
+	const createdIDs = trackCreatedServices();
 
 	test('latest_version === deployed_version (up to date)', async ({
 		page,
 	}, testInfo) => {
 		const baseID = 'UPDATE_STATUS=UP_TO_DATE';
 		const id = withProject(baseID, testInfo.project.name);
-		createdID = id;
+		createdIDs.push(id);
 
-		await page.goto('/');
-		await page.getByRole('button', { name: /toggle edit mode/i }).click();
+		await openDashboardInEditMode(page);
 
 		// GIVEN: a service whose `latest_version` and `deployed_version` lookups
 		// both resolve to the same version (1.2.3).
@@ -193,23 +181,20 @@ test.describe('Service update status', () => {
 			deployedVersion: { type: 'manual', version: '1.2.3' },
 			latestVersion: LOOKUP_LATEST_VERSION_JSON,
 		});
-		await expect(page.getByRole('heading', { name: id })).toBeVisible();
 
-		const serviceCard = page.locator(`[data-service-id="${id}"]`);
+		const card = serviceCard(page, id);
 
-		// THEN: the "Deployed" version is shown as 1.2.3.
-		await expect(serviceCard.getByText('1.2.3')).toBeVisible();
+		// THEN: the "Deployed" version is shown as 1.2.3, with no separate
+		// "latest version" indicator - it collapses into the deployed item
+		// when the two match.
+		await expectVersions(page, id, { deployed: '1.2.3', latest: null });
 
-		// AND: there is no separate "latest version" indicator for a different
-		// version - only the single (deployed) version value is rendered.
-		await expect(serviceCard.getByText(/^\d+\.\d+\.\d+$/)).toHaveCount(1);
-
-		// AND: the card is not flagged as having an update available.
-		await expect(serviceCard).toHaveAttribute('data-update-available', 'false');
+		// AND: the card reports itself as up to date.
+		await expectUpdateState(page, id, 'UP_TO_DATE');
 
 		// AND: there is no "Skip" button (no update to skip).
 		await expect(
-			serviceCard.getByRole('button', { name: /reject release/i }),
+			card.getByRole('button', { name: /reject release/i }),
 		).not.toBeVisible();
 
 		await screenshot(
@@ -219,15 +204,38 @@ test.describe('Service update status', () => {
 		);
 	});
 
+	test('no deployed_version lookup shows only the latest version', async ({
+		page,
+	}, testInfo) => {
+		const baseID = 'UPDATE_STATUS=NO_DEPLOYED_VERSION';
+		const id = withProject(baseID, testInfo.project.name);
+		createdIDs.push(id);
+
+		await openDashboardInEditMode(page);
+
+		// GIVEN: a service with a `latest_version` lookup, and no
+		// `deployed_version` lookup to track what is actually running.
+		await createService(page, id, {
+			latestVersion: LOOKUP_LATEST_VERSION_JSON,
+		});
+
+		// THEN: only the latest version is shown - with nothing tracking a
+		// deployed version, there is no deployed version item to render.
+		await expectVersions(page, id, { deployed: null, latest: '1.2.3' });
+
+		// AND: the card still reports itself as up to date, as an untracked
+		// deployed_version is taken to be the latest.
+		await expectUpdateState(page, id, 'UP_TO_DATE');
+	});
+
 	test('latest_version !== deployed_version (update available)', async ({
 		page,
 	}, testInfo) => {
 		const baseID = 'UPDATE_STATUS=AVAILABLE';
 		const id = withProject(baseID, testInfo.project.name);
-		createdID = id;
+		createdIDs.push(id);
 
-		await page.goto('/');
-		await page.getByRole('button', { name: /toggle edit mode/i }).click();
+		await openDashboardInEditMode(page);
 
 		// GIVEN: a service whose `latest_version` (1.2.3) and `deployed_version`
 		// (0.0.1) lookups resolve to different versions.
@@ -235,20 +243,18 @@ test.describe('Service update status', () => {
 			deployedVersion: { type: 'manual', version: '0.0.1' },
 			latestVersion: LOOKUP_LATEST_VERSION_JSON,
 		});
-		await expect(page.getByRole('heading', { name: id })).toBeVisible();
 
-		const serviceCard = page.locator(`[data-service-id="${id}"]`);
-		const skipButton = serviceCard.getByRole('button', {
+		const card = serviceCard(page, id);
+		const skipButton = card.getByRole('button', {
 			name: /reject release/i,
 		});
 
 		// THEN: both the "Latest" (1.2.3) and "Deployed" (0.0.1) versions are
-		// displayed.
-		await expect(serviceCard.getByText('1.2.3')).toBeVisible();
-		await expect(serviceCard.getByText('0.0.1')).toBeVisible();
+		// displayed, each in its own item.
+		await expectVersions(page, id, { deployed: '0.0.1', latest: '1.2.3' });
 
 		// AND: the card is flagged as having an update available.
-		await expect(serviceCard).toHaveAttribute('data-update-available', 'true');
+		await expectUpdateState(page, id, 'AVAILABLE');
 
 		// AND: a "Skip" button is visible.
 		await expect(skipButton).toBeVisible();
@@ -275,8 +281,9 @@ test.describe('Service update status', () => {
 		// THEN: the modal closes.
 		await expect(dialog).not.toBeVisible();
 
-		// AND: the card is no longer flagged as having an update available.
-		await expect(serviceCard).toHaveAttribute('data-update-available', 'false');
+		// AND: the card now reports the release as skipped, rather than merely
+		// 'no update available'.
+		await expectUpdateState(page, id, 'SKIPPED');
 
 		// AND: the "Skip" button is no longer shown.
 		await expect(skipButton).not.toBeVisible();

--- a/web/ui/react-app/tests/create-service.spec.ts
+++ b/web/ui/react-app/tests/create-service.spec.ts
@@ -11,6 +11,7 @@ import {
 	deleteService,
 	LOOKUP_LATEST_VERSION_JSON,
 	screenshot,
+	screenshotsUnder,
 	trackCreatedServices,
 	withProject,
 } from './fixtures/service';
@@ -19,6 +20,11 @@ import {
 	LOOKUP_BASIC_AUTH,
 	LOOKUP_WITH_HEADER_AUTH,
 } from './fixtures/test-endpoints';
+import {
+	expectError,
+	expectValid,
+	MUST_BE_UNIQUE,
+} from './fixtures/validation';
 
 /**
  * Runs a create -> verify -> refresh -> delete cycle, screenshotting each stage.
@@ -292,5 +298,56 @@ test.describe('Service update status', () => {
 			`service-update-status/${baseID}/03-after-skip`,
 			testInfo.project.name,
 		);
+	});
+});
+
+test.describe('Service name uniqueness', () => {
+	const createdIDs = trackCreatedServices();
+
+	test('a Name already used by another service is flagged as not unique', async ({
+		page,
+	}, testInfo) => {
+		const shot = screenshotsUnder(
+			page,
+			testInfo.project.name,
+			'service-name-uniqueness',
+		);
+		const baseID = 'NAME_UNIQUE=EXISTING';
+		const id = withProject(baseID, testInfo.project.name);
+		const name = withProject(`${baseID}-display`, testInfo.project.name);
+		createdIDs.push(id);
+
+		await openDashboardInEditMode(page);
+
+		// GIVEN: a service whose Name differs from its ID.
+		await createService(page, id, { name });
+
+		// WHEN: a second service is given a unique ID, but that existing Name.
+		await page.getByRole('button', { name: /create a service/i }).click();
+		const dialog = page.getByRole('dialog');
+		await expect(dialog).toBeVisible();
+		const idInput = dialog.locator('input[name="id"]');
+		await expect(idInput).toBeEditable();
+		await idInput.fill(`${id}-second`);
+		await dialog
+			.getByRole('button', { name: /toggle to separate id/i })
+			.click();
+		const nameInput = dialog.locator('input[name="name"]');
+
+		// THEN: the Name is flagged.
+		await expectError(
+			nameInput,
+			name,
+			MUST_BE_UNIQUE,
+			shot,
+			'01-name-duplicate',
+		);
+
+		// WHEN: a Name no other service uses is entered.
+		// THEN: the error clears.
+		await expectValid(nameInput, `${name}-second`, shot, '02-name-unique');
+
+		await dialog.locator('#modal-cancel').click();
+		await expect(dialog).not.toBeVisible();
 	});
 });

--- a/web/ui/react-app/tests/dashboard-table.spec.ts
+++ b/web/ui/react-app/tests/dashboard-table.spec.ts
@@ -5,15 +5,15 @@ import { expect, test } from '@playwright/test';
  * It has an icon, an icon link, and a web URL.
  */
 const EXAMPLE_SERVICE = {
-	/* The service ID. */
-	id: 'release-argus/Argus',
-	/* `dashboard.icon`. */
+	/** `dashboard.icon`. */
 	icon:
 		'https://raw.githubusercontent.com/release-argus/Argus/master/web/ui/' +
 		'react-app/public/favicon.svg',
-	/* `dashboard.icon_link_to`. */
+	/** `dashboard.icon_link_to`. */
 	iconLinkTo: 'https://release-argus.io',
-	/* `dashboard.web_url`. */
+	/** The service ID. */
+	id: 'release-argus/Argus',
+	/** `dashboard.web_url`. */
 	webURL: 'https://github.com/release-argus/Argus/blob/master/CHANGELOG.md',
 } as const;
 

--- a/web/ui/react-app/tests/fixtures/dashboard.ts
+++ b/web/ui/react-app/tests/fixtures/dashboard.ts
@@ -1,0 +1,147 @@
+import { expect, type Page, type Response } from '@playwright/test';
+
+const DEPLOYED_VERSION_REFRESH_PATH = '/api/v1/deployed_version/refresh';
+
+/**
+ * Loads the dashboard and turns edit mode on.
+ *
+ * @param page - The dashboard page.
+ */
+export const openDashboardInEditMode = async (page: Page) => {
+	await page.goto('/');
+	await page.getByRole('button', { name: /toggle edit mode/i }).click();
+	await expect(
+		page.getByRole('button', { name: 'Create a service' }),
+	).toBeVisible();
+};
+
+/**
+ * Locates a service's card/row on the dashboard.
+ *
+ * @param page - The dashboard page.
+ * @param serviceID - The service ID.
+ * @returns The service's `[data-service-id]` container.
+ */
+export const serviceCard = (page: Page, serviceID: string) =>
+	page.locator(`[data-service-id="${serviceID}"]`);
+
+/* The update states a loaded card reports via `data-update-state`. */
+export type ServiceUpdateStateName = 'AVAILABLE' | 'SKIPPED' | 'UP_TO_DATE';
+
+/**
+ * Locates one of a service's two version items.
+ *
+ * @param page - The dashboard page.
+ * @param serviceID - The service ID.
+ * @param versionType - Which version to locate.
+ */
+const versionItem = (
+	page: Page,
+	serviceID: string,
+	versionType: 'deployed' | 'latest',
+) =>
+	serviceCard(page, serviceID).locator(`[data-version-type="${versionType}"]`);
+
+export type ExpectedVersions = {
+	/* Expected deployed version, or null if that item must not render. */
+	deployed: string | null;
+	/* Expected latest version, or null if that item must not render. */
+	latest: string | null;
+};
+
+/**
+ * Asserts both of a service's version items.
+ *
+ * - `{deployed: X, latest: null}`  - a deployed_version lookup, already up to date.
+ * - `{deployed: X, latest: Y}`     - a deployed_version lookup, behind the latest.
+ * - `{deployed: null, latest: Y}`  - no deployed_version lookup.
+ *
+ * @param page - The dashboard page.
+ * @param serviceID - The service ID.
+ * @param versions - The expected version items.
+ */
+export const expectVersions = async (
+	page: Page,
+	serviceID: string,
+	versions: ExpectedVersions,
+) => {
+	for (const versionType of ['deployed', 'latest'] as const) {
+		const item = versionItem(page, serviceID, versionType);
+		const expected = versions[versionType];
+		await (expected === null
+			? expect(item).toHaveCount(0)
+			: expect(item).toHaveText(expected));
+	}
+};
+
+/**
+ * Waits for a service's summary to arrive.
+ *
+ * @param page - The dashboard page.
+ * @param serviceID - The service ID.
+ */
+export const expectServiceLoaded = (page: Page, serviceID: string) =>
+	expect(serviceCard(page, serviceID)).toHaveAttribute(
+		'data-update-state',
+		/AVAILABLE|SKIPPED|UP_TO_DATE/,
+	);
+
+/**
+ * Asserts a service's update state.
+ *
+ * @param page - The dashboard page.
+ * @param serviceID - The service ID.
+ * @param state - The expected `data-update-state`.
+ */
+export const expectUpdateState = (
+	page: Page,
+	serviceID: string,
+	state: ServiceUpdateStateName,
+) =>
+	expect(serviceCard(page, serviceID)).toHaveAttribute(
+		'data-update-state',
+		state,
+	);
+
+/**
+ * The `service_id` a `deployed_version/refresh` response was for, or null for
+ * any other response.
+ *
+ * @param response - The response to inspect.
+ */
+const refreshedServiceID = (response: Response) => {
+	if (!response.url().includes(DEPLOYED_VERSION_REFRESH_PATH)) return null;
+	if (response.request().method() !== 'GET') return null;
+	return new URL(response.url()).searchParams.get('service_id');
+};
+
+/**
+ * Waits for a `deployed_version/refresh` response.
+ *
+ * @param page - The dashboard page.
+ * @param serviceID - Restrict to the refresh of this service; omit to match the
+ *   next refresh of any service.
+ */
+export const waitForDeployedVersionRefresh = (page: Page, serviceID?: string) =>
+	page.waitForResponse((response) => {
+		const refreshedID = refreshedServiceID(response);
+		if (refreshedID === null) return false;
+		return serviceID === undefined || refreshedID === serviceID;
+	});
+
+/**
+ * Starts recording the service IDs of every `deployed_version/refresh` response,
+ * so a test can assert which services were (and weren't) targeted. Reset between
+ * phases with `.length = 0`.
+ *
+ * @param page - The dashboard page.
+ * @returns The recorded IDs, appended to as responses arrive.
+ */
+export const recordDeployedVersionRefreshes = (page: Page) => {
+	const serviceIDs: string[] = [];
+	page.on('response', (response) => {
+		const serviceID = refreshedServiceID(response);
+		if (serviceID) serviceIDs.push(serviceID);
+	});
+	return serviceIDs;
+};

--- a/web/ui/react-app/tests/fixtures/dashboard.ts
+++ b/web/ui/react-app/tests/fixtures/dashboard.ts
@@ -3,16 +3,23 @@ import { expect, type Page, type Response } from '@playwright/test';
 const DEPLOYED_VERSION_REFRESH_PATH = '/api/v1/deployed_version/refresh';
 
 /**
+ * Dashboard URL with every 'hide' filter off.
+ */
+export const DASHBOARD_SHOW_ALL = '/approvals?hide=';
+
+/**
  * Loads the dashboard and turns edit mode on.
  *
  * @param page - The dashboard page.
+ * @param url - Dashboard URL to load (Default='/').
  */
-export const openDashboardInEditMode = async (page: Page) => {
-	await page.goto('/');
+export const openDashboardInEditMode = async (page: Page, url = '/') => {
+	await page.goto(url);
 	await page.getByRole('button', { name: /toggle edit mode/i }).click();
 	await expect(
 		page.getByRole('button', { name: 'Create a service' }),
 	).toBeVisible();
+	await expect(page.locator('[data-service-id]').first()).toBeVisible();
 };
 
 /**
@@ -25,7 +32,7 @@ export const openDashboardInEditMode = async (page: Page) => {
 export const serviceCard = (page: Page, serviceID: string) =>
 	page.locator(`[data-service-id="${serviceID}"]`);
 
-/* The update states a loaded card reports via `data-update-state`. */
+/** The update states a loaded card reports via `data-update-state`. */
 export type ServiceUpdateStateName = 'AVAILABLE' | 'SKIPPED' | 'UP_TO_DATE';
 
 /**
@@ -43,9 +50,9 @@ const versionItem = (
 	serviceCard(page, serviceID).locator(`[data-version-type="${versionType}"]`);
 
 export type ExpectedVersions = {
-	/* Expected deployed version, or null if that item must not render. */
+	/** Expected deployed version, or null if that item must not render. */
 	deployed: string | null;
-	/* Expected latest version, or null if that item must not render. */
+	/** Expected latest version, or null if that item must not render. */
 	latest: string | null;
 };
 
@@ -65,6 +72,8 @@ export const expectVersions = async (
 	serviceID: string,
 	versions: ExpectedVersions,
 ) => {
+	await expectServiceLoaded(page, serviceID);
+
 	for (const versionType of ['deployed', 'latest'] as const) {
 		const item = versionItem(page, serviceID, versionType);
 		const expected = versions[versionType];

--- a/web/ui/react-app/tests/fixtures/service.ts
+++ b/web/ui/react-app/tests/fixtures/service.ts
@@ -1,4 +1,9 @@
 import { expect, type Locator, type Page, test } from '@playwright/test';
+import {
+	openDashboardInEditMode,
+	serviceCard,
+	waitForDeployedVersionRefresh,
+} from './dashboard';
 import { bareEndpoint } from './test-endpoints';
 import { openSection } from './validation';
 
@@ -433,9 +438,10 @@ const fillNotify = async (dialog: Locator, notifiers: NotifyOptions[]) => {
 };
 
 /**
- * Creates a service. Defaults to a `url` 'latest version' lookup against the
- * test server's `/bare/1.2.3` endpoint; pass `latestVersion`/`deployedVersion`
- * to exercise other lookup types.
+ * Creates a service and waits for it to appear on the dashboard. Defaults to a
+ * `url` 'latest version' lookup against the test server's `/bare/1.2.3`
+ * endpoint; pass `latestVersion`/`deployedVersion` to exercise other lookup
+ * types.
  *
  * @param page - The dashboard page (edit mode must already be on).
  * @param id - The service ID.
@@ -511,6 +517,9 @@ export const createService = async (
 		throw err;
 	}
 	await expect(dialog).not.toBeVisible({ timeout: 30_000 });
+	await expect(
+		page.getByRole('heading', { exact: true, name: id }),
+	).toBeVisible();
 };
 
 /**
@@ -528,8 +537,9 @@ export const saveDeployedVersionManual = async (
 	serviceID: string,
 	version: string,
 ) => {
-	const serviceCard = page.locator(`[data-service-id="${serviceID}"]`);
-	await serviceCard.getByRole('button', { name: /edit/i }).click();
+	await serviceCard(page, serviceID)
+		.getByRole('button', { name: /edit/i })
+		.click();
 
 	const dialog = page.getByRole('dialog');
 	await expect(dialog).toBeVisible();
@@ -542,11 +552,7 @@ export const saveDeployedVersionManual = async (
 	// - retry the click until it lands outside that window.
 	await expect(async () => {
 		const [response] = await Promise.all([
-			page.waitForResponse(
-				(res) =>
-					res.url().includes('/api/v1/deployed_version/refresh') &&
-					res.request().method() === 'GET',
-			),
+			waitForDeployedVersionRefresh(page),
 			saveButton.click(),
 		]);
 		expect(response.ok()).toBeTruthy();
@@ -564,8 +570,9 @@ export const saveDeployedVersionManual = async (
  * @param serviceID - The ID of the service to delete.
  */
 export const deleteService = async (page: Page, serviceID: string) => {
-	const serviceCard = page.locator(`[data-service-id="${serviceID}"]`);
-	await serviceCard.getByRole('button', { name: /edit/i }).click();
+	await serviceCard(page, serviceID)
+		.getByRole('button', { name: /edit/i })
+		.click();
 
 	const dialog = page.getByRole('dialog');
 	await expect(dialog).toBeVisible();
@@ -579,9 +586,25 @@ export const deleteService = async (page: Page, serviceID: string) => {
 
 	// The card disappears once the delete is broadcast over the WebSocket -
 	// allow extra time under parallel load.
-	await expect(
-		page.locator(`[data-service-id="${serviceID}"]`),
-	).not.toBeVisible({ timeout: 30_000 });
+	await expect(serviceCard(page, serviceID)).not.toBeVisible({
+		timeout: 30_000,
+	});
+};
+
+/**
+ * Registers an `afterEach` deleting every service ID pushed onto the returned
+ * array, so each test only has to record what it creates. Call from inside the
+ * `describe` whose tests share the cleanup.
+ *
+ * @returns The IDs to delete after the current test.
+ */
+export const trackCreatedServices = () => {
+	const serviceIDs: string[] = [];
+	test.afterEach(async ({ page }) => {
+		if (serviceIDs.length) await cleanupServices(page, serviceIDs);
+		serviceIDs.length = 0;
+	});
+	return serviceIDs;
 };
 
 /**
@@ -591,10 +614,9 @@ export const deleteService = async (page: Page, serviceID: string) => {
  * @param serviceIDs - The IDs to remove if present.
  */
 export const cleanupServices = async (page: Page, serviceIDs: string[]) => {
-	await page.goto('/');
-	await page.getByRole('button', { name: /toggle edit mode/i }).click();
+	await openDashboardInEditMode(page);
 	for (const id of serviceIDs) {
-		if (await page.locator(`[data-service-id="${id}"]`).isVisible()) {
+		if (await serviceCard(page, id).isVisible()) {
 			await deleteService(page, id);
 		}
 	}

--- a/web/ui/react-app/tests/fixtures/service.ts
+++ b/web/ui/react-app/tests/fixtures/service.ts
@@ -1,5 +1,6 @@
 import { expect, type Locator, type Page, test } from '@playwright/test';
 import {
+	DASHBOARD_SHOW_ALL,
 	openDashboardInEditMode,
 	serviceCard,
 	waitForDeployedVersionRefresh,
@@ -21,15 +22,15 @@ export const withProject = (id: string, projectName: string) =>
 	`${id}-${projectName}`;
 
 export type LatestVersionOptions = {
-	/* `latest_version.type` - defaults to 'github'. */
+	/** `latest_version.type` - defaults to 'github'. */
 	type?: 'github' | 'url';
-	/* `latest_version.url` (the GitHub "Repository" or generic "URL" field). */
+	/** `latest_version.url` (the GitHub "Repository" or generic "URL" field). */
 	url: string;
-	/* `latest_version.allow_invalid_certs` - only applicable to type 'url'. */
+	/** `latest_version.allow_invalid_certs` - only applicable to type 'url'. */
 	allowInvalidCerts?: boolean;
-	/* `latest_version.headers` - only applicable to type 'url'. */
+	/** `latest_version.headers` - only applicable to type 'url'. */
 	headers?: KeyVal[];
-	/* `latest_version.url_commands` (only the first command, type 'regex') -
+	/** `latest_version.url_commands` (only the first command, type 'regex') -
 	 * only applicable to type 'url'. Used to extract a version from a
 	 * response body that isn't a bare semver string. */
 	urlCommandRegex?: { regex: string; index?: string };
@@ -37,67 +38,70 @@ export type LatestVersionOptions = {
 
 export type DeployedVersionOptions =
 	| {
-			/* `deployed_version.type` = 'manual'. */
+			/** `deployed_version.type` = 'manual'. */
 			type: 'manual';
-			/* `deployed_version.version`. */
+			/** `deployed_version.version`. */
 			version: string;
 	  }
 	| {
-			/* `deployed_version.type` = 'url'. */
+			/** `deployed_version.type` = 'url'. */
 			type: 'url';
-			/* `deployed_version.url`. */
+			/** `deployed_version.url`. */
 			url: string;
-			/* `deployed_version.method` - defaults to 'GET'. */
+			/** `deployed_version.method` - defaults to 'GET'. */
 			method?: 'GET' | 'POST';
-			/* `deployed_version.allow_invalid_certs`. */
+			/** `deployed_version.allow_invalid_certs`. */
 			allowInvalidCerts?: boolean;
-			/* `deployed_version.basic_auth`. */
+			/** `deployed_version.basic_auth`. */
 			basicAuth?: { username: string; password: string };
-			/* `deployed_version.headers`. */
+			/** `deployed_version.headers`. */
 			headers?: KeyVal[];
-			/* `deployed_version.body` - only sent when `method` is 'POST'. */
+			/** `deployed_version.body` - only sent when `method` is 'POST'. */
 			body?: string;
-			/* `deployed_version.target_header`. */
+			/** `deployed_version.target_header`. */
 			targetHeader?: string;
-			/* `deployed_version.json`. */
+			/** `deployed_version.json`. */
 			json?: string;
-			/* `deployed_version.regex`. */
+			/** `deployed_version.regex`. */
 			regex?: string;
 	  };
 
 export type WebHookOptions = {
-	/* `webhook.X.name`. */
+	/** `webhook.X.name`. */
 	name: string;
-	/* `webhook.X.url`. */
+	/** `webhook.X.url`. */
 	url: string;
-	/* `webhook.X.secret`. */
+	/** `webhook.X.secret`. */
 	secret: string;
-	/* `webhook.X.max_tries`. */
+	/** `webhook.X.max_tries`. */
 	maxTries?: string;
 };
 
-/* A `gotify` notifier. */
+/** A `gotify` notifier. */
 export type NotifyOptions = {
-	/* `notify.X.type` - only 'gotify' is supported here. */
+	/** `notify.X.type` - only 'gotify' is supported here. */
 	type: 'gotify';
-	/* `notify.X.name`. */
+	/** `notify.X.name`. */
 	name: string;
-	/* `notify.X.url_fields.host`. */
+	/** `notify.X.url_fields.host`. */
 	host: string;
-	/* `notify.X.url_fields.path`. */
+	/** `notify.X.url_fields.path`. */
 	path?: string;
-	/* `notify.X.url_fields.token` (the masked secret). */
+	/** `notify.X.url_fields.token` (the masked secret). */
 	token: string;
-	/* `notify.X.params.title`. */
+	/** `notify.X.params.title`. */
 	title?: string;
 };
 
 export type CreateServiceOptions = {
+	/** `name` - a display name distinct from the service ID. */
+	name?: string;
 	latestVersion?: LatestVersionOptions;
 	deployedVersion?: DeployedVersionOptions;
-	/* `options.semantic_versioning` - set to `false` for lookups whose raw
+	/** `options.semantic_versioning` - set to `false` for lookups whose raw
 	 * response isn't a parseable MAJOR.MINOR.PATCH version. */
 	semanticVersioning?: boolean;
+	active?: boolean;
 	notifiers?: NotifyOptions[];
 	webhooks?: WebHookOptions[];
 };
@@ -459,6 +463,13 @@ export const createService = async (
 	await expect(dialog.locator('input[name="id"]')).toBeEditable();
 	await dialog.locator('input[name="id"]').fill(id);
 
+	if (options?.name !== undefined) {
+		await dialog
+			.getByRole('button', { name: /toggle to separate id/i })
+			.click();
+		await dialog.locator('input[name="name"]').fill(options.name);
+	}
+
 	await fillLatestVersion(
 		dialog,
 		options?.latestVersion ?? LOOKUP_LATEST_VERSION_JSON,
@@ -468,16 +479,23 @@ export const createService = async (
 		await fillDeployedVersion(dialog, options.deployedVersion);
 	}
 
-	if (options?.semanticVersioning !== undefined) {
+	if (options?.semanticVersioning !== undefined || options?.active === false) {
 		await dialog.getByRole('button', { name: /^Options:?$/i }).click();
 		const optionsSection = dialog
 			.locator('[data-slot="accordion-item"]', { hasText: 'Options' })
 			.first();
-		await setBooleanWithDefault(
-			optionsSection,
-			'options.semantic_versioning',
-			options.semanticVersioning,
-		);
+
+		if (options.active === false) {
+			await optionsSection.locator('[id="options.active"]').uncheck();
+		}
+
+		if (options.semanticVersioning !== undefined) {
+			await setBooleanWithDefault(
+				optionsSection,
+				'options.semantic_versioning',
+				options.semanticVersioning,
+			);
+		}
 	}
 
 	if (options?.notifiers?.length) {
@@ -517,9 +535,8 @@ export const createService = async (
 		throw err;
 	}
 	await expect(dialog).not.toBeVisible({ timeout: 30_000 });
-	await expect(
-		page.getByRole('heading', { exact: true, name: id }),
-	).toBeVisible();
+	// The card, not the heading - only the grid layout renders a heading.
+	await expect(serviceCard(page, id)).toBeVisible();
 };
 
 /**
@@ -601,8 +618,11 @@ export const deleteService = async (page: Page, serviceID: string) => {
 export const trackCreatedServices = () => {
 	const serviceIDs: string[] = [];
 	test.afterEach(async ({ page }) => {
-		if (serviceIDs.length) await cleanupServices(page, serviceIDs);
-		serviceIDs.length = 0;
+		try {
+			if (serviceIDs.length) await cleanupServices(page, serviceIDs);
+		} finally {
+			serviceIDs.length = 0;
+		}
 	});
 	return serviceIDs;
 };
@@ -614,7 +634,7 @@ export const trackCreatedServices = () => {
  * @param serviceIDs - The IDs to remove if present.
  */
 export const cleanupServices = async (page: Page, serviceIDs: string[]) => {
-	await openDashboardInEditMode(page);
+	await openDashboardInEditMode(page, DASHBOARD_SHOW_ALL);
 	for (const id of serviceIDs) {
 		if (await serviceCard(page, id).isVisible()) {
 			await deleteService(page, id);

--- a/web/ui/react-app/tests/fixtures/validation.ts
+++ b/web/ui/react-app/tests/fixtures/validation.ts
@@ -1,4 +1,5 @@
 import { expect, type Locator, type Page } from '@playwright/test';
+import { openDashboardInEditMode } from './dashboard';
 
 // Validation messages for the modal forms.
 export const REQUIRED = 'Required.';
@@ -22,11 +23,8 @@ export const fieldOf = (input: Locator) =>
  * @returns The open modal dialog.
  */
 export const openCreateServiceModal = async (page: Page) => {
-	await page.goto('/');
-	// Wait for the service list to render.
-	await expect(page.locator('[data-service-id]').first()).toBeVisible();
+	await openDashboardInEditMode(page);
 
-	await page.getByRole('button', { name: /toggle edit mode/i }).click();
 	await page.getByRole('button', { name: /create a service/i }).click();
 	const dialog = page.getByRole('dialog');
 	await expect(dialog).toBeVisible();

--- a/web/ui/react-app/tests/refresh-deployed-versions.spec.ts
+++ b/web/ui/react-app/tests/refresh-deployed-versions.spec.ts
@@ -1,26 +1,122 @@
-import { expect, test } from '@playwright/test';
+import { expect, type Page, test } from '@playwright/test';
 import {
-	cleanupServices,
+	expectServiceLoaded,
+	expectUpdateState,
+	openDashboardInEditMode,
+	recordDeployedVersionRefreshes,
+	serviceCard,
+	waitForDeployedVersionRefresh,
+} from './fixtures/dashboard';
+import {
 	createService,
 	LOOKUP_LATEST_VERSION_JSON,
 	screenshotsUnder,
+	trackCreatedServices,
 	withProject,
 } from './fixtures/service';
+import { bareEndpoint } from './fixtures/test-endpoints';
 
-// createService makes a real network call to verify the lookups before the
-// modal closes, so allow extra time.
-test.beforeEach(() => {
-	test.slow();
-});
+const SEARCH_INPUT_NAME = 'Search and filter services by name';
+const FILTER_BUTTON_NAME = 'Filter shown services';
+const REFRESH_MENU_ITEM_NAME = 'Refresh visible deployed versions';
 
-test.describe('refresh all deployed versions', () => {
-	let createdIDs: string[] = [];
-	test.afterEach(async ({ page }) => {
-		if (createdIDs.length) await cleanupServices(page, createdIDs);
-		createdIDs = [];
+// The version LOOKUP_LATEST_VERSION_JSON resolves to.
+const LATEST_VERSION = '1.2.3';
+
+/**
+ * Creates a service whose deployed_version is a url lookup, so the refresh
+ * action can re-query it.
+ *
+ * @param page - The dashboard page (edit mode must already be on).
+ * @param id - The service ID.
+ * @param version - The version the lookup resolves to (Default='0.0.1').
+ */
+const createTrackedService = (page: Page, id: string, version = '0.0.1') =>
+	createService(page, id, {
+		deployedVersion: {
+			json: 'version',
+			type: 'url',
+			url: bareEndpoint(`{"version":"${version}"}`),
+		},
+		latestVersion: LOOKUP_LATEST_VERSION_JSON,
 	});
 
-	test('filter dropdown item re-queries the deployed_version of 2+ services', async ({
+const refreshMenuItem = (page: Page) =>
+	page.getByRole('menuitem', { exact: true, name: REFRESH_MENU_ITEM_NAME });
+
+/**
+ * Opens the filter dropdown and picks the refresh action.
+ *
+ * @param page - The dashboard page.
+ */
+const pickRefreshFromFilterDropdown = async (page: Page) => {
+	await page.getByRole('button', { name: FILTER_BUTTON_NAME }).click();
+	const menuItem = refreshMenuItem(page);
+	await expect(menuItem).toBeVisible();
+	await menuItem.click();
+};
+
+/**
+ * Picks the refresh action and waits for each of `serviceIDs` to be re-queried.
+ *
+ * @param page - The dashboard page.
+ * @param serviceIDs - The IDs expected to be refreshed.
+ */
+const refreshAndAwait = async (page: Page, serviceIDs: string[]) => {
+	const [responses] = await Promise.all([
+		Promise.all(
+			serviceIDs.map((id) => waitForDeployedVersionRefresh(page, id)),
+		),
+		pickRefreshFromFilterDropdown(page),
+	]);
+	for (const response of responses) {
+		expect(response.ok()).toBeTruthy();
+	}
+	// Success completion toast.
+	const toast = page
+		.locator('[data-sonner-toast][data-type="success"]')
+		.filter({ hasText: 'Refreshed deployed versions' })
+		.first();
+	await expect(toast).toBeVisible();
+	await expect(toast).toContainText(`Succeeded: ${serviceIDs.length}`);
+};
+
+/**
+ * Asserts the refresh action isn't offered for the currently visible services.
+ *
+ * @param page - The dashboard page.
+ */
+const expectRefreshActionHidden = async (page: Page) => {
+	await page.getByRole('button', { name: FILTER_BUTTON_NAME }).click();
+	// Wait for the menu to render, so the absence below isn't just "not yet".
+	await expect(page.getByRole('menu')).toBeVisible();
+	await expect(refreshMenuItem(page)).toHaveCount(0);
+};
+
+/**
+ * Narrows the dashboard to the services matching `term`.
+ *
+ * @param page - The dashboard page.
+ * @param term - The search term to filter by.
+ */
+const filterServices = (page: Page, term: string) =>
+	page.getByRole('textbox', { name: SEARCH_INPUT_NAME }).fill(term);
+
+/**
+ * Flips one of the filter dropdown's 'hide' toggles.
+ *
+ * @param page - The dashboard page.
+ * @param label - The toggle's label, e.g. 'Hide inactive'.
+ */
+const toggleHideOption = async (page: Page, label: string) => {
+	await page.getByRole('button', { name: FILTER_BUTTON_NAME }).click();
+	await page.getByRole('menuitemcheckbox', { name: label }).click();
+};
+
+test.describe('refresh visible deployed versions', () => {
+	const createdIDs = trackCreatedServices();
+
+	test('filter dropdown item re-queries the deployed_version of 2+ visible services', async ({
 		page,
 	}, testInfo) => {
 		const shot = screenshotsUnder(
@@ -31,70 +127,400 @@ test.describe('refresh all deployed versions', () => {
 		const ids = ['REFRESH-ALL, DV, 1', 'REFRESH-ALL, DV, 2'].map((baseID) =>
 			withProject(baseID, testInfo.project.name),
 		);
-		createdIDs = ids;
+		createdIDs.push(...ids);
 
-		await page.goto('/');
-		await page.getByRole('button', { name: /toggle edit mode/i }).click();
+		await openDashboardInEditMode(page);
 
-		// GIVEN: two services with a manual deployed_version (no network lookup
-		// needed for the refresh itself).
+		// GIVEN: two services with a url deployed_version.
 		for (const id of ids) {
-			await createService(page, id, {
-				deployedVersion: { type: 'manual', version: '0.0.1' },
-				latestVersion: LOOKUP_LATEST_VERSION_JSON,
-			});
-			await expect(page.getByRole('heading', { name: id })).toBeVisible();
+			await createTrackedService(page, id);
 		}
+
+		// AND: the search filter narrows the dashboard down to just these two,
+		// so the refresh can't reach services owned by other specs.
+		await filterServices(page, 'REFRESH-ALL');
 		await shot('01-before-refresh');
 
-		// WHEN: "Refresh all deployed versions" is picked from the filter
-		// dropdown. The backend is shared across specs, so other services may
-		// also be refreshed - only assert on the responses for the services this
-		// test created, matched by their `service_id` query param (not string
-		// containment, since URLSearchParams encodes differently to
-		// encodeURIComponent for values like these IDs' spaces/commas).
-		await page.getByRole('button', { name: 'Filter shown services' }).click();
-		const refreshMenuItem = page.getByRole('menuitem', {
-			name: 'Refresh all deployed versions',
-		});
-		await expect(refreshMenuItem).toBeVisible();
-		const [responses] = await Promise.all([
-			Promise.all(
-				ids.map((id) =>
-					page.waitForResponse((res) => {
-						if (!res.url().includes('/api/v1/deployed_version/refresh'))
-							return false;
-						if (res.request().method() !== 'GET') return false;
-						return new URL(res.url()).searchParams.get('service_id') === id;
-					}),
-				),
-			),
-			refreshMenuItem.click(),
-		]);
-
-		// THEN: both refreshes succeed and a completion toast is shown.
-		for (const response of responses) {
-			expect(response.ok()).toBeTruthy();
-		}
-		await expect(
-			page.getByText(/Refreshed deployed version/i).first(),
-		).toBeVisible();
+		// WHEN: the refresh action is picked from the filter dropdown.
+		// THEN: both services are re-queried, and a completion toast is shown.
+		await refreshAndAwait(page, ids);
 		await shot('02-after-refresh');
+	});
+
+	test('only re-queries deployed_version for services visible under the current search filter', async ({
+		page,
+	}, testInfo) => {
+		const shot = screenshotsUnder(
+			page,
+			testInfo.project.name,
+			'refresh-deployed-versions',
+		);
+		const visibleIDs = ['REFRESH-VISIBLE, DV, 1', 'REFRESH-VISIBLE, DV, 2'].map(
+			(baseID) => withProject(baseID, testInfo.project.name),
+		);
+		const hiddenID = withProject(
+			'REFRESH-HIDDEN, DV, 1',
+			testInfo.project.name,
+		);
+		const ids = [...visibleIDs, hiddenID];
+		createdIDs.push(...ids);
+
+		await openDashboardInEditMode(page);
+
+		// GIVEN: three services with a url deployed_version.
+		for (const id of ids) {
+			await createTrackedService(page, id);
+		}
+		await shot('01-before-filter');
+
+		// WHEN: the search filter narrows the visible services down to 2 of the 3.
+		await filterServices(page, 'REFRESH-VISIBLE');
+		await expect(page.getByRole('heading', { name: hiddenID })).toHaveCount(0);
+		for (const id of visibleIDs) {
+			await expect(page.getByRole('heading', { name: id })).toBeVisible();
+		}
+		await shot('02-filtered');
+
+		// Record every deployed_version refresh fired while the filter is
+		// applied, so we can assert the hidden service's id never appears.
+		const refreshedServiceIDs = recordDeployedVersionRefreshes(page);
+
+		// AND: the refresh action is picked from the filter dropdown.
+		await refreshAndAwait(page, visibleIDs);
+		await shot('03-after-refresh');
+
+		// THEN: clearing the filter reveals all 3 services again, but only the
+		// 2 that were visible during the refresh were re-queried.
+		await page.getByRole('button', { name: 'Clear search' }).click();
+		await expect(page.getByRole('heading', { name: hiddenID })).toBeVisible();
+		await shot('04-filters-cleared');
+
+		expect(refreshedServiceIDs).toEqual(expect.arrayContaining(visibleIDs));
+		expect(refreshedServiceIDs).not.toContain(hiddenID);
+	});
+
+	test('only re-queries deployed_version for services visible under the current hide filter', async ({
+		page,
+	}, testInfo) => {
+		const upToDateID = withProject(
+			'REFRESH-HIDE, DV, up-to-date',
+			testInfo.project.name,
+		);
+		const updatableID = withProject(
+			'REFRESH-HIDE, DV, updatable',
+			testInfo.project.name,
+		);
+		createdIDs.push(upToDateID, updatableID);
+
+		await openDashboardInEditMode(page);
+
+		// GIVEN: one service already on latest_version, and one behind it.
+		await createTrackedService(page, upToDateID, LATEST_VERSION);
+		await createTrackedService(page, updatableID, '0.0.1');
+
+		await filterServices(page, 'REFRESH-HIDE');
+		await expectUpdateState(page, upToDateID, 'UP_TO_DATE');
+		await expectUpdateState(page, updatableID, 'AVAILABLE');
+
+		// WHEN: 'Hide up to date' removes the up-to-date service from view.
+		await page.getByRole('button', { name: FILTER_BUTTON_NAME }).click();
+		await page
+			.getByRole('menuitemcheckbox', { name: 'Hide up to date' })
+			.click();
+		await expect(page.getByRole('heading', { name: upToDateID })).toHaveCount(
+			0,
+		);
+		await expect(
+			page.getByRole('heading', { name: updatableID }),
+		).toBeVisible();
+
+		const refreshedServiceIDs = recordDeployedVersionRefreshes(page);
+
+		// AND: the refresh action is picked from the filter dropdown.
+		await refreshAndAwait(page, [updatableID]);
+
+		// THEN: only the still-visible service was re-queried.
+		expect(refreshedServiceIDs).toContain(updatableID);
+		expect(refreshedServiceIDs).not.toContain(upToDateID);
+	});
+
+	test('only re-queries deployed_version for services visible under the current skipped filter', async ({
+		page,
+	}, testInfo) => {
+		const skippedID = withProject(
+			'REFRESH-SKIP, DV, skipped',
+			testInfo.project.name,
+		);
+		const updatableID = withProject(
+			'REFRESH-SKIP, DV, updatable',
+			testInfo.project.name,
+		);
+		createdIDs.push(skippedID, updatableID);
+
+		await openDashboardInEditMode(page);
+
+		// GIVEN: two updatable services with a url deployed_version.
+		await createTrackedService(page, skippedID);
+		await createTrackedService(page, updatableID);
+
+		await filterServices(page, 'REFRESH-SKIP');
+		await expectUpdateState(page, skippedID, 'AVAILABLE');
+		await expectUpdateState(page, updatableID, 'AVAILABLE');
+
+		// AND: one of them has its release skipped.
+		await serviceCard(page, skippedID)
+			.getByRole('button', { name: /reject release/i })
+			.click();
+		const dialog = page.getByRole('dialog', { name: /skip this release\?/i });
+		await dialog.locator('#modal-action').click();
+		await expect(dialog).not.toBeVisible();
+		await expectUpdateState(page, skippedID, 'SKIPPED');
+
+		// WHEN: 'Hide skipped' removes it from view.
+		await page.getByRole('button', { name: FILTER_BUTTON_NAME }).click();
+		await page.getByRole('menuitemcheckbox', { name: 'Hide skipped' }).click();
+		await expect(page.getByRole('heading', { name: skippedID })).toHaveCount(0);
+		await expect(
+			page.getByRole('heading', { name: updatableID }),
+		).toBeVisible();
+
+		const refreshedServiceIDs = recordDeployedVersionRefreshes(page);
+
+		// AND: the refresh action is picked from the filter dropdown.
+		await refreshAndAwait(page, [updatableID]);
+
+		// THEN: the skipped service was not re-queried. 'SKIPPED' and
+		// 'UP_TO_DATE' both hide behind their own toggle, so this covers the
+		// third branch of the state-to-hide-value mapping.
+		expect(refreshedServiceIDs).toContain(updatableID);
+		expect(refreshedServiceIDs).not.toContain(skippedID);
+	});
+
+	test('re-queries a service whose deployed_version already matches latest_version', async ({
+		page,
+	}, testInfo) => {
+		const id = withProject('REFRESH-UP-TO-DATE, DV, 1', testInfo.project.name);
+		createdIDs.push(id);
+
+		await openDashboardInEditMode(page);
+
+		// GIVEN: a service already on latest_version - a refresh is still the
+		// only way to notice its deployed_version changing underneath us.
+		await createTrackedService(page, id, LATEST_VERSION);
+		await filterServices(page, 'REFRESH-UP-TO-DATE');
+		await expectUpdateState(page, id, 'UP_TO_DATE');
+
+		// WHEN: the refresh action is picked from the filter dropdown.
+		// THEN: it is re-queried despite being up to date.
+		await refreshAndAwait(page, [id]);
+	});
+
+	test('excludes manual deployed_version services from the refresh action', async ({
+		page,
+	}, testInfo) => {
+		const urlID = withProject(
+			'REFRESH-EXCLUDE-MANUAL, DV, url',
+			testInfo.project.name,
+		);
+		const manualID = withProject(
+			'REFRESH-EXCLUDE-MANUAL, DV, manual',
+			testInfo.project.name,
+		);
+		createdIDs.push(urlID, manualID);
+
+		await openDashboardInEditMode(page);
+
+		// GIVEN: a url deployed_version service, and a manual one - refreshing a
+		// manual deployed_version is a no-op, as it has no source to re-query.
+		await createTrackedService(page, urlID);
+		await createService(page, manualID, {
+			deployedVersion: { type: 'manual', version: '0.0.1' },
+			latestVersion: LOOKUP_LATEST_VERSION_JSON,
+		});
+
+		// AND: the search filter narrows the dashboard down to just these two,
+		// so the refresh can't reach services owned by other specs.
+		await filterServices(page, 'REFRESH-EXCLUDE-MANUAL');
+		await expectServiceLoaded(page, urlID);
+		await expectServiceLoaded(page, manualID);
+
+		const refreshedServiceIDs = recordDeployedVersionRefreshes(page);
+
+		// WHEN: the refresh action is picked from the filter dropdown.
+		await refreshAndAwait(page, [urlID]);
+
+		// THEN: only the url service was refreshed - the manual one never fired
+		// a refresh request.
+		expect(refreshedServiceIDs).toContain(urlID);
+		expect(refreshedServiceIDs).not.toContain(manualID);
+	});
+
+	test('excludes services with no deployed_version lookup from the refresh action', async ({
+		page,
+	}, testInfo) => {
+		const trackedID = withProject(
+			'REFRESH-EXCLUDE-NONE, DV, url',
+			testInfo.project.name,
+		);
+		const untrackedID = withProject(
+			'REFRESH-EXCLUDE-NONE, DV, none',
+			testInfo.project.name,
+		);
+		createdIDs.push(trackedID, untrackedID);
+
+		await openDashboardInEditMode(page);
+
+		// GIVEN: a url deployed_version service,
+		// and one with no deployed_version lookup.
+		await createTrackedService(page, trackedID);
+		await createService(page, untrackedID, {
+			latestVersion: LOOKUP_LATEST_VERSION_JSON,
+		});
+
+		// AND: the search filter narrows the dashboard down to just these two,
+		// so the refresh can't reach services owned by other specs.
+		await filterServices(page, 'REFRESH-EXCLUDE-NONE');
+		await expectServiceLoaded(page, trackedID);
+		await expectServiceLoaded(page, untrackedID);
+
+		const refreshedServiceIDs = recordDeployedVersionRefreshes(page);
+
+		// WHEN: the refresh action is picked from the filter dropdown.
+		await refreshAndAwait(page, [trackedID]);
+
+		// THEN: only the tracked service was refreshed.
+		expect(refreshedServiceIDs).toContain(trackedID);
+		expect(refreshedServiceIDs).not.toContain(untrackedID);
+	});
+
+	test('only re-queries deployed_version for services visible under the current inactive filter', async ({
+		page,
+	}, testInfo) => {
+		const activeID = withProject(
+			'REFRESH-INACTIVE, DV, active',
+			testInfo.project.name,
+		);
+		const inactiveID = withProject(
+			'REFRESH-INACTIVE, DV, inactive',
+			testInfo.project.name,
+		);
+		createdIDs.push(activeID, inactiveID);
+
+		await openDashboardInEditMode(page);
+
+		// GIVEN: 'Hide inactive' is off, so an inactive service renders once created.
+		await toggleHideOption(page, 'Hide inactive');
+
+		// AND: two url deployed_version services, one of them inactive.
+		await createTrackedService(page, activeID);
+		await createService(page, inactiveID, {
+			active: false,
+			deployedVersion: {
+				json: 'version',
+				type: 'url',
+				url: bareEndpoint('{"version":"0.0.1"}'),
+			},
+			latestVersion: LOOKUP_LATEST_VERSION_JSON,
+		});
+
+		// AND: the search filter narrows the dashboard down to just these two.
+		await filterServices(page, 'REFRESH-INACTIVE');
+		await expectServiceLoaded(page, activeID);
+		await expect(
+			serviceCard(page, inactiveID).locator('[data-version-type="deployed"]'),
+		).toBeVisible();
+
+		const refreshedServiceIDs = recordDeployedVersionRefreshes(page);
+
+		// WHEN: the refresh action runs while the inactive service is still shown.
+		// THEN: being inactive doesn't exclude it.
+		await refreshAndAwait(page, [activeID, inactiveID]);
+
+		// WHEN: 'Hide inactive' removes the paused service from view.
+		refreshedServiceIDs.length = 0;
+		await toggleHideOption(page, 'Hide inactive');
+		await expect(page.getByRole('heading', { name: inactiveID })).toHaveCount(
+			0,
+		);
+
+		// AND: the refresh action is picked again.
+		await refreshAndAwait(page, [activeID]);
+
+		// THEN: only the still-visible service was re-queried.
+		expect(refreshedServiceIDs).toContain(activeID);
+		expect(refreshedServiceIDs).not.toContain(inactiveID);
+	});
+
+	test('is hidden when the only visible service has a manual deployed_version', async ({
+		page,
+	}, testInfo) => {
+		const id = withProject('REFRESH-ONLY-MANUAL, DV, 1', testInfo.project.name);
+		createdIDs.push(id);
+
+		await openDashboardInEditMode(page);
+
+		// GIVEN: a service whose only deployed_version is manual.
+		await createService(page, id, {
+			deployedVersion: { type: 'manual', version: '0.0.1' },
+			latestVersion: LOOKUP_LATEST_VERSION_JSON,
+		});
+
+		// WHEN: the search filter narrows the visible services down to just it.
+		await filterServices(page, id);
+		await expectServiceLoaded(page, id);
+
+		// THEN: the refresh action is hidden - a manual deployed_version has
+		// nothing to re-query.
+		await expectRefreshActionHidden(page);
+	});
+
+	test('is hidden when the current filters leave no visible service with a deployed version', async ({
+		page,
+	}, testInfo) => {
+		const id = withProject(
+			'REFRESH-NONE-VISIBLE, DV, 1',
+			testInfo.project.name,
+		);
+		createdIDs.push(id);
+
+		await openDashboardInEditMode(page);
+
+		// GIVEN: a refreshable service is visible, so the action is on offer.
+		await createTrackedService(page, id);
+		await filterServices(page, 'REFRESH-NONE-VISIBLE');
+		await expectServiceLoaded(page, id);
+		await page.getByRole('button', { name: FILTER_BUTTON_NAME }).click();
+		await expect(refreshMenuItem(page)).toBeVisible();
+		await page.keyboard.press('Escape');
+
+		// WHEN: the search filter is narrowed to match no service at all.
+		await filterServices(page, 'z-no-service-matches-this-filter-z');
+		await expect(page.getByRole('heading', { name: id })).toHaveCount(0);
+
+		// THEN: the action is withdrawn.
+		await expectRefreshActionHidden(page);
 	});
 
 	test('is reachable the same way regardless of viewport width', async ({
 		page,
-	}) => {
+	}, testInfo) => {
+		const id = withProject('REFRESH-VIEWPORT, DV, 1', testInfo.project.name);
+		createdIDs.push(id);
+
+		await openDashboardInEditMode(page);
+
+		// GIVEN: a service with a url deployed_version, so the refresh action
+		// has something to act on regardless of viewport.
+		await createTrackedService(page, id);
+
 		await page.setViewportSize({ height: 844, width: 390 });
-		await page.goto('/');
+		await filterServices(page, 'REFRESH-VIEWPORT');
+		await expectServiceLoaded(page, id);
 
-		await expect(
-			page.getByRole('button', { name: 'Refresh all deployed versions' }),
-		).toHaveCount(0);
+		// The action is only ever reachable through the filter dropdown.
+		await expect(refreshMenuItem(page)).toHaveCount(0);
 
-		await page.getByRole('button', { name: 'Filter shown services' }).click();
-		await expect(
-			page.getByRole('menuitem', { name: 'Refresh all deployed versions' }),
-		).toBeVisible();
+		await page.getByRole('button', { name: FILTER_BUTTON_NAME }).click();
+		await expect(refreshMenuItem(page)).toBeVisible();
 	});
 });

--- a/web/ui/react-app/tests/refresh-deployed-versions.spec.ts
+++ b/web/ui/react-app/tests/refresh-deployed-versions.spec.ts
@@ -85,7 +85,7 @@ test.describe('refresh all deployed versions', () => {
 	test('is reachable the same way regardless of viewport width', async ({
 		page,
 	}) => {
-		await page.setViewportSize({ width: 390, height: 844 });
+		await page.setViewportSize({ height: 844, width: 390 });
 		await page.goto('/');
 
 		await expect(

--- a/web/ui/react-app/tests/service-actions-dv-manual.spec.ts
+++ b/web/ui/react-app/tests/service-actions-dv-manual.spec.ts
@@ -1,26 +1,21 @@
 import { expect, test } from '@playwright/test';
 import {
-	cleanupServices,
+	openDashboardInEditMode,
+	serviceCard,
+	waitForDeployedVersionRefresh,
+} from './fixtures/dashboard';
+import {
 	createService,
 	LOOKUP_LATEST_VERSION_JSON,
 	saveDeployedVersionManual,
 	screenshotsUnder,
+	trackCreatedServices,
 	withProject,
 } from './fixtures/service';
 import { openSection } from './fixtures/validation';
 
-// createService makes a real network call to verify the lookups before the
-// modal closes, so allow extra time.
-test.beforeEach(() => {
-	test.slow();
-});
-
 test.describe('deployed_version=manual approve/skip actions', () => {
-	let createdID: string | undefined;
-	test.afterEach(async ({ page }) => {
-		if (createdID) await cleanupServices(page, [createdID]);
-		createdID = undefined;
-	});
+	const createdIDs = trackCreatedServices();
 
 	test('Approve sets the deployed version and hides the actions', async ({
 		page,
@@ -32,10 +27,9 @@ test.describe('deployed_version=manual approve/skip actions', () => {
 		);
 		const baseID = 'DV=MANUAL, APPROVE';
 		const id = withProject(baseID, testInfo.project.name);
-		createdID = id;
+		createdIDs.push(id);
 
-		await page.goto('/');
-		await page.getByRole('button', { name: /toggle edit mode/i }).click();
+		await openDashboardInEditMode(page);
 
 		// GIVEN: a service with a manual deployed_version, an update available,
 		// and no WebHooks/Commands.
@@ -43,24 +37,23 @@ test.describe('deployed_version=manual approve/skip actions', () => {
 			deployedVersion: { type: 'manual', version: '0.0.1' },
 			latestVersion: LOOKUP_LATEST_VERSION_JSON,
 		});
-		await expect(page.getByRole('heading', { name: id })).toBeVisible();
 
-		const serviceCard = page.locator(`[data-service-id="${id}"]`);
+		const card = serviceCard(page, id);
 
 		// THEN: both the "Skip" and "Approve" actions are shown, and both the
 		// deployed and latest versions are visible.
 		await expect(
-			serviceCard.getByRole('button', { name: 'Reject release' }),
+			card.getByRole('button', { name: 'Reject release' }),
 		).toBeVisible();
 		await expect(
-			serviceCard.getByRole('button', { name: 'Approve release' }),
+			card.getByRole('button', { name: 'Approve release' }),
 		).toBeVisible();
-		await expect(serviceCard.getByText('0.0.1', { exact: true })).toBeVisible();
-		await expect(serviceCard.getByText('1.2.3', { exact: true })).toBeVisible();
-		await shot('01-update-available', serviceCard);
+		await expect(card.getByText('0.0.1', { exact: true })).toBeVisible();
+		await expect(card.getByText('1.2.3', { exact: true })).toBeVisible();
+		await shot('01-update-available', card);
 
 		// WHEN: the user clicks "Approve" and confirms in the resulting modal.
-		const approveButton = serviceCard.getByRole('button', {
+		const approveButton = card.getByRole('button', {
 			name: 'Approve release',
 		});
 		await expect(approveButton).toBeEnabled();
@@ -75,13 +68,9 @@ test.describe('deployed_version=manual approve/skip actions', () => {
 			await approveButton.click();
 			await expect(dialog).toBeVisible();
 			await expect(confirmButton).toHaveText(/^Approve$/i);
-			await shot('02-approve-modal', serviceCard);
+			await shot('02-approve-modal', card);
 			const [response] = await Promise.all([
-				page.waitForResponse(
-					(res) =>
-						res.url().includes('/api/v1/deployed_version/refresh') &&
-						res.request().method() === 'GET',
-				),
+				waitForDeployedVersionRefresh(page),
 				confirmButton.click(),
 			]);
 			expect(response.ok()).toBeTruthy();
@@ -90,19 +79,17 @@ test.describe('deployed_version=manual approve/skip actions', () => {
 
 		// THEN: the deployed version updates to the latest version, and the
 		// "Skip"/"Approve" actions disappear (nothing left to action).
-		await expect(serviceCard.getByText('1.2.3', { exact: true })).toBeVisible();
+		await expect(card.getByText('1.2.3', { exact: true })).toBeVisible();
 		await expect(
-			serviceCard.getByRole('button', { name: 'Reject release' }),
+			card.getByRole('button', { name: 'Reject release' }),
 		).toBeHidden();
 		await expect(
-			serviceCard.getByRole('button', { name: 'Approve release' }),
+			card.getByRole('button', { name: 'Approve release' }),
 		).toBeHidden();
 		// AND: the old deployed version is no longer shown - only the "@" line
 		// for the now-matching deployed/latest version remains.
-		await expect(serviceCard.getByText('0.0.1', { exact: true })).toHaveCount(
-			0,
-		);
-		await shot('03-approved', serviceCard);
+		await expect(card.getByText('0.0.1', { exact: true })).toHaveCount(0);
+		await shot('03-approved', card);
 	});
 
 	test('Skip hides Skip but keeps Approve (as secondary) and both versions displayed', async ({
@@ -115,10 +102,9 @@ test.describe('deployed_version=manual approve/skip actions', () => {
 		);
 		const baseID = 'dv=MANUAL, SKIP';
 		const id = withProject(baseID, testInfo.project.name);
-		createdID = id;
+		createdIDs.push(id);
 
-		await page.goto('/');
-		await page.getByRole('button', { name: /toggle edit mode/i }).click();
+		await openDashboardInEditMode(page);
 
 		// GIVEN: a service with a manual deployed_version, an update available,
 		// and no WebHooks/Commands.
@@ -126,24 +112,23 @@ test.describe('deployed_version=manual approve/skip actions', () => {
 			deployedVersion: { type: 'manual', version: '0.0.1' },
 			latestVersion: LOOKUP_LATEST_VERSION_JSON,
 		});
-		await expect(page.getByRole('heading', { name: id })).toBeVisible();
 
-		const serviceCard = page.locator(`[data-service-id="${id}"]`);
-		const approveButton = serviceCard.getByRole('button', {
+		const card = serviceCard(page, id);
+		const approveButton = card.getByRole('button', {
 			name: 'Approve release',
 		});
 		await expect(
-			serviceCard.getByRole('button', { name: 'Reject release' }),
+			card.getByRole('button', { name: 'Reject release' }),
 		).toBeVisible();
 		// AND: the "Approve" action is shown in its primary (not-yet-skipped) colour.
 		await expect(approveButton).toHaveClass(/bg-primary/);
-		await shot('01-update-available', serviceCard);
+		await shot('01-update-available', card);
 
 		// WHEN: the user clicks "Skip" and confirms in the resulting modal.
-		await serviceCard.getByRole('button', { name: 'Reject release' }).click();
+		await card.getByRole('button', { name: 'Reject release' }).click();
 		const dialog = page.getByRole('dialog');
 		await expect(dialog).toBeVisible();
-		await shot('02-skip-modal', serviceCard);
+		await shot('02-skip-modal', card);
 
 		const confirmButton = dialog.locator('#modal-action');
 		await expect(confirmButton).toHaveText(/^Skip release$/i);
@@ -154,13 +139,13 @@ test.describe('deployed_version=manual approve/skip actions', () => {
 		// its secondary colour, letting the user override the skip - and the
 		// deployed version AND the (skipped) latest version both remain visible.
 		await expect(
-			serviceCard.getByRole('button', { name: 'Reject release' }),
+			card.getByRole('button', { name: 'Reject release' }),
 		).toBeHidden();
 		await expect(approveButton).toBeVisible();
 		await expect(approveButton).toHaveClass(/bg-secondary/);
-		await expect(serviceCard.getByText('0.0.1', { exact: true })).toBeVisible();
-		await expect(serviceCard.getByText('1.2.3', { exact: true })).toBeVisible();
-		await shot('03-skipped', serviceCard);
+		await expect(card.getByText('0.0.1', { exact: true })).toBeVisible();
+		await expect(card.getByText('1.2.3', { exact: true })).toBeVisible();
+		await shot('03-skipped', card);
 	});
 
 	test('Saving a new deployed version from the edit modal shows the actions', async ({
@@ -173,10 +158,9 @@ test.describe('deployed_version=manual approve/skip actions', () => {
 		);
 		const baseID = 'DV=MANUAL, EDIT-SAVE NEW';
 		const id = withProject(baseID, testInfo.project.name);
-		createdID = id;
+		createdIDs.push(id);
 
-		await page.goto('/');
-		await page.getByRole('button', { name: /toggle edit mode/i }).click();
+		await openDashboardInEditMode(page);
 
 		// GIVEN: a service with a manual deployed_version already matching the
 		// latest version (up to date - no actions shown).
@@ -184,16 +168,15 @@ test.describe('deployed_version=manual approve/skip actions', () => {
 			deployedVersion: { type: 'manual', version: '1.2.3' },
 			latestVersion: LOOKUP_LATEST_VERSION_JSON,
 		});
-		await expect(page.getByRole('heading', { name: id })).toBeVisible();
 
-		const serviceCard = page.locator(`[data-service-id="${id}"]`);
+		const card = serviceCard(page, id);
 		await expect(
-			serviceCard.getByRole('button', { name: 'Reject release' }),
+			card.getByRole('button', { name: 'Reject release' }),
 		).toBeHidden();
 		await expect(
-			serviceCard.getByRole('button', { name: 'Approve release' }),
+			card.getByRole('button', { name: 'Approve release' }),
 		).toBeHidden();
-		await shot('01-up-to-date', serviceCard);
+		await shot('01-up-to-date', card);
 
 		// WHEN: the deployed version is saved to a new version (that isn't the
 		// latest version) via the edit modal's inline 'Save version' action.
@@ -202,14 +185,14 @@ test.describe('deployed_version=manual approve/skip actions', () => {
 		// THEN: the "Skip"/"Approve" actions immediately appear, reflecting the
 		// no-longer-up-to-date state.
 		await expect(
-			serviceCard.getByRole('button', { name: 'Reject release' }),
+			card.getByRole('button', { name: 'Reject release' }),
 		).toBeVisible();
 		await expect(
-			serviceCard.getByRole('button', { name: 'Approve release' }),
+			card.getByRole('button', { name: 'Approve release' }),
 		).toBeVisible();
-		await expect(serviceCard.getByText('9.9.9', { exact: true })).toBeVisible();
-		await expect(serviceCard.getByText('1.2.3', { exact: true })).toBeVisible();
-		await shot('02-actions-shown', serviceCard);
+		await expect(card.getByText('9.9.9', { exact: true })).toBeVisible();
+		await expect(card.getByText('1.2.3', { exact: true })).toBeVisible();
+		await shot('02-actions-shown', card);
 	});
 
 	test('Saving another deployed version that is not the latest version from the edit modal keeps the actions shown', async ({
@@ -222,10 +205,9 @@ test.describe('deployed_version=manual approve/skip actions', () => {
 		);
 		const baseID = 'DV=MANUAL, EDIT-SAVE OTHER';
 		const id = withProject(baseID, testInfo.project.name);
-		createdID = id;
+		createdIDs.push(id);
 
-		await page.goto('/');
-		await page.getByRole('button', { name: /toggle edit mode/i }).click();
+		await openDashboardInEditMode(page);
 
 		// GIVEN: a service with a manual deployed_version, an update already
 		// available (deployed != latest), and no WebHooks/Commands.
@@ -233,16 +215,15 @@ test.describe('deployed_version=manual approve/skip actions', () => {
 			deployedVersion: { type: 'manual', version: '0.0.1' },
 			latestVersion: LOOKUP_LATEST_VERSION_JSON,
 		});
-		await expect(page.getByRole('heading', { name: id })).toBeVisible();
 
-		const serviceCard = page.locator(`[data-service-id="${id}"]`);
+		const card = serviceCard(page, id);
 		await expect(
-			serviceCard.getByRole('button', { name: 'Reject release' }),
+			card.getByRole('button', { name: 'Reject release' }),
 		).toBeVisible();
 		await expect(
-			serviceCard.getByRole('button', { name: 'Approve release' }),
+			card.getByRole('button', { name: 'Approve release' }),
 		).toBeVisible();
-		await shot('01-update-available', serviceCard);
+		await shot('01-update-available', card);
 
 		// WHEN: the deployed version is saved to an older version (a downgrade,
 		// still not the latest version) via the edit modal's inline
@@ -252,17 +233,15 @@ test.describe('deployed_version=manual approve/skip actions', () => {
 		// THEN: the "Skip"/"Approve" actions remain visible, and the displayed
 		// deployed version updates to the new (older) value.
 		await expect(
-			serviceCard.getByRole('button', { name: 'Reject release' }),
+			card.getByRole('button', { name: 'Reject release' }),
 		).toBeVisible();
 		await expect(
-			serviceCard.getByRole('button', { name: 'Approve release' }),
+			card.getByRole('button', { name: 'Approve release' }),
 		).toBeVisible();
-		await expect(serviceCard.getByText('0.0.0', { exact: true })).toBeVisible();
-		await expect(serviceCard.getByText('1.2.3', { exact: true })).toBeVisible();
-		await expect(serviceCard.getByText('0.0.1', { exact: true })).toHaveCount(
-			0,
-		);
-		await shot('02-actions-still-shown', serviceCard);
+		await expect(card.getByText('0.0.0', { exact: true })).toBeVisible();
+		await expect(card.getByText('1.2.3', { exact: true })).toBeVisible();
+		await expect(card.getByText('0.0.1', { exact: true })).toHaveCount(0);
+		await shot('02-actions-still-shown', card);
 	});
 
 	test('Saving to the latest version then to another version in the same edit session updates the actions each time', async ({
@@ -275,10 +254,9 @@ test.describe('deployed_version=manual approve/skip actions', () => {
 		);
 		const baseID = 'DV=MANUAL, EDIT-SAVE LATEST-THEN-OTHER';
 		const id = withProject(baseID, testInfo.project.name);
-		createdID = id;
+		createdIDs.push(id);
 
-		await page.goto('/');
-		await page.getByRole('button', { name: /toggle edit mode/i }).click();
+		await openDashboardInEditMode(page);
 
 		// GIVEN: a service with a manual deployed_version, an update already
 		// available (deployed != latest), and no WebHooks/Commands.
@@ -286,20 +264,19 @@ test.describe('deployed_version=manual approve/skip actions', () => {
 			deployedVersion: { type: 'manual', version: '0.0.1' },
 			latestVersion: LOOKUP_LATEST_VERSION_JSON,
 		});
-		await expect(page.getByRole('heading', { name: id })).toBeVisible();
 
-		const serviceCard = page.locator(`[data-service-id="${id}"]`);
+		const card = serviceCard(page, id);
 		await expect(
-			serviceCard.getByRole('button', { name: 'Reject release' }),
+			card.getByRole('button', { name: 'Reject release' }),
 		).toBeVisible();
 		await expect(
-			serviceCard.getByRole('button', { name: 'Approve release' }),
+			card.getByRole('button', { name: 'Approve release' }),
 		).toBeVisible();
-		await shot('01-update-available', serviceCard);
+		await shot('01-update-available', card);
 
 		// WHEN: within a single edit-modal session, the deployed version is
 		// first saved to the current latest version.
-		await serviceCard.getByRole('button', { name: /edit/i }).click();
+		await card.getByRole('button', { name: /edit/i }).click();
 		const dialog = page.getByRole('dialog');
 		await expect(dialog).toBeVisible();
 		const section = await openSection(dialog, 'Deployed Version');
@@ -311,11 +288,7 @@ test.describe('deployed_version=manual approve/skip actions', () => {
 			expect(async () => {
 				await versionInput.fill(version);
 				const [response] = await Promise.all([
-					page.waitForResponse(
-						(res) =>
-							res.url().includes('/api/v1/deployed_version/refresh') &&
-							res.request().method() === 'GET',
-					),
+					waitForDeployedVersionRefresh(page),
 					saveButton.click(),
 				]);
 				expect(response.ok()).toBeTruthy();
@@ -324,10 +297,10 @@ test.describe('deployed_version=manual approve/skip actions', () => {
 
 		// THEN: the actions are hidden (up to date).
 		await expect(
-			serviceCard.locator('button[aria-label="Reject release"]'),
+			card.locator('button[aria-label="Reject release"]'),
 		).toBeHidden();
 		await expect(
-			serviceCard.locator('button[aria-label="Approve release"]'),
+			card.locator('button[aria-label="Approve release"]'),
 		).toBeHidden();
 
 		// WHEN: without closing the modal, a different version is saved.
@@ -337,16 +310,14 @@ test.describe('deployed_version=manual approve/skip actions', () => {
 
 		// THEN: the actions reappear.
 		await expect(
-			serviceCard.getByRole('button', { name: 'Reject release' }),
+			card.getByRole('button', { name: 'Reject release' }),
 		).toBeVisible();
 		await expect(
-			serviceCard.getByRole('button', { name: 'Approve release' }),
+			card.getByRole('button', { name: 'Approve release' }),
 		).toBeVisible();
-		await expect(serviceCard.getByText('4.5.6', { exact: true })).toBeVisible();
-		await expect(serviceCard.getByText('1.2.3', { exact: true })).toBeVisible();
-		await expect(serviceCard.getByText('0.0.1', { exact: true })).toHaveCount(
-			0,
-		);
-		await shot('02-actions-shown-again', serviceCard);
+		await expect(card.getByText('4.5.6', { exact: true })).toBeVisible();
+		await expect(card.getByText('1.2.3', { exact: true })).toBeVisible();
+		await expect(card.getByText('0.0.1', { exact: true })).toHaveCount(0);
+		await shot('02-actions-shown-again', card);
 	});
 });

--- a/web/ui/react-app/tests/service-ordering.spec.ts
+++ b/web/ui/react-app/tests/service-ordering.spec.ts
@@ -1,17 +1,12 @@
 import { expect, type Locator, type Page, test } from '@playwright/test';
+import { openDashboardInEditMode, serviceCard } from './fixtures/dashboard';
 import {
 	type CreateServiceOptions,
-	cleanupServices,
 	createService,
 	screenshot,
+	trackCreatedServices,
 } from './fixtures/service';
 import { bareEndpoint } from './fixtures/test-endpoints';
-
-// Creating a service makes a real server-side network call that can exceed the
-// default timeout under load - so triple it.
-test.beforeEach(() => {
-	test.slow();
-});
 
 /**
  * Reads the current service order from the rendered cards/rows.
@@ -106,16 +101,13 @@ test.describe('Service Ordering', () => {
 		two: `service-2-${projectName}`,
 	});
 
-	test.afterEach(async ({ page }, testInfo) => {
-		const { one, two } = ids(testInfo.project.name);
-		await cleanupServices(page, [one, two]);
-	});
+	const createdIDs = trackCreatedServices();
 
 	test('re-order in grid view', async ({ page }, testInfo) => {
 		const { one, two } = ids(testInfo.project.name);
+		createdIDs.push(one, two);
 
-		await page.goto('/');
-		await page.getByRole('button', { name: /toggle edit mode/i }).click();
+		await openDashboardInEditMode(page);
 		await createService(page, one, ORDERING_SERVICE_OPTIONS);
 		await createService(page, two, ORDERING_SERVICE_OPTIONS);
 		await screenshot(
@@ -126,12 +118,12 @@ test.describe('Service Ordering', () => {
 
 		await page.getByRole('radio', { name: 'Grid layout' }).click();
 
-		const dragHandle1Grid = page
-			.locator(`[data-service-id="${one}"]`)
-			.getByRole('button', { name: /drag handle/i });
-		const targetCard2Grid = page
-			.locator(`[data-service-id="${two}"]`)
-			.getByRole('button', { name: /drag handle/i });
+		const dragHandle1Grid = serviceCard(page, one).getByRole('button', {
+			name: /drag handle/i,
+		});
+		const targetCard2Grid = serviceCard(page, two).getByRole('button', {
+			name: /drag handle/i,
+		});
 		await expect(dragHandle1Grid).toBeVisible();
 		await expect(targetCard2Grid).toBeVisible();
 		await dragAndDrop(page, dragHandle1Grid, targetCard2Grid);
@@ -164,9 +156,9 @@ test.describe('Service Ordering', () => {
 
 	test('re-order in table view', async ({ page }, testInfo) => {
 		const { one, two } = ids(testInfo.project.name);
+		createdIDs.push(one, two);
 
-		await page.goto('/');
-		await page.getByRole('button', { name: /toggle edit mode/i }).click();
+		await openDashboardInEditMode(page);
 		await createService(page, one, ORDERING_SERVICE_OPTIONS);
 		await createService(page, two, ORDERING_SERVICE_OPTIONS);
 		await screenshot(
@@ -180,12 +172,12 @@ test.describe('Service Ordering', () => {
 			page.getByRole('radio', { name: 'Table layout' }),
 		).toBeChecked();
 
-		const dragHandle1Table = page
-			.locator(`[data-service-id="${one}"]`)
-			.getByRole('button', { name: /drag handle/i });
-		const targetCard2Table = page
-			.locator(`[data-service-id="${two}"]`)
-			.getByRole('button', { name: /drag handle/i });
+		const dragHandle1Table = serviceCard(page, one).getByRole('button', {
+			name: /drag handle/i,
+		});
+		const targetCard2Table = serviceCard(page, two).getByRole('button', {
+			name: /drag handle/i,
+		});
 		await expect(dragHandle1Table).toBeVisible();
 		await expect(targetCard2Table).toBeVisible();
 		await dragAndDrop(page, dragHandle1Table, targetCard2Table);

--- a/web/ui/react-app/tests/service-secret-inheritance.spec.ts
+++ b/web/ui/react-app/tests/service-secret-inheritance.spec.ts
@@ -1,10 +1,11 @@
 import { expect, type Locator, type Page, test } from '@playwright/test';
+import { openDashboardInEditMode, serviceCard } from './fixtures/dashboard';
 import {
-	cleanupServices,
 	createService,
 	LOOKUP_LATEST_VERSION_JSON,
 	screenshot,
 	setBooleanWithDefault,
+	trackCreatedServices,
 	withProject,
 } from './fixtures/service';
 import {
@@ -15,12 +16,6 @@ import {
 } from './fixtures/test-endpoints';
 import { openSection } from './fixtures/validation';
 
-// Each test runs a create -> reload -> edit -> save -> reopen -> exercise-secret
-// cycle, every stage hitting the backend.
-test.beforeEach(() => {
-	test.slow();
-});
-
 /**
  * Opens the edit modal for an existing service (edit mode must already be on).
  *
@@ -29,7 +24,7 @@ test.beforeEach(() => {
  * @returns The open edit dialog.
  */
 const openEditModal = async (page: Page, id: string) => {
-	const card = page.locator(`[data-service-id="${id}"]`);
+	const card = serviceCard(page, id);
 	await expect(card).toBeVisible();
 	await card.getByRole('button', { name: /edit/i }).click();
 	const dialog = page.getByRole('dialog');
@@ -58,22 +53,17 @@ const SECRET_VALUE = '<secret>';
 
 test.describe('Service secret inheritance', () => {
 	// Safety net for a test that fails before its own cleanup.
-	let createdID: string | undefined;
-	test.afterEach(async ({ page }) => {
-		if (createdID) await cleanupServices(page, [createdID]);
-		createdID = undefined;
-	});
+	const createdIDs = trackCreatedServices();
 
 	test('latest_version=url: a masked header secret survives an unrelated edit', async ({
 		page,
 	}, testInfo) => {
 		const baseID = 'SECRET_INHERIT=LATEST_VERSION';
 		const id = withProject(baseID, testInfo.project.name);
-		createdID = id;
+		createdIDs.push(id);
 		const shotDir = `secret-inheritance/${baseID}`;
 
-		await page.goto('/');
-		await page.getByRole('button', { name: /toggle edit mode/i }).click();
+		await openDashboardInEditMode(page);
 
 		// GIVEN: a service whose latest_version is a header-authenticated URL
 		// lookup - the header *value* is a secret, and the lookup only returns a
@@ -90,9 +80,6 @@ test.describe('Service secret inheritance', () => {
 				url: LOOKUP_WITH_HEADER_AUTH.urlValid,
 			},
 		});
-		await expect(
-			page.getByRole('heading', { exact: true, name: id }),
-		).toBeVisible();
 
 		// AND: the page is reloaded so the edit modal loads the secret from the
 		// backend (where it comes back masked) rather than from create-time state.
@@ -147,11 +134,10 @@ test.describe('Service secret inheritance', () => {
 	}, testInfo) => {
 		const baseID = 'SECRET_INHERIT=DEPLOYED_VERSION';
 		const id = withProject(baseID, testInfo.project.name);
-		createdID = id;
+		createdIDs.push(id);
 		const shotDir = `secret-inheritance/${baseID}`;
 
-		await page.goto('/');
-		await page.getByRole('button', { name: /toggle edit mode/i }).click();
+		await openDashboardInEditMode(page);
 
 		// GIVEN: a service whose deployed_version is a header-authenticated URL
 		// lookup - the header *value* is a secret, and the lookup only returns a
@@ -168,9 +154,6 @@ test.describe('Service secret inheritance', () => {
 				url: LOOKUP_WITH_HEADER_AUTH.urlValid,
 			},
 		});
-		await expect(
-			page.getByRole('heading', { exact: true, name: id }),
-		).toBeVisible();
 
 		// AND: the page is reloaded so the edit modal loads the secret from the
 		// backend (where it comes back masked) rather than from create-time state.
@@ -225,11 +208,10 @@ test.describe('Service secret inheritance', () => {
 	}, testInfo) => {
 		const baseID = 'SECRET_INHERIT=WEBHOOK';
 		const id = withProject(baseID, testInfo.project.name);
-		createdID = id;
+		createdIDs.push(id);
 		const shotDir = `secret-inheritance/${baseID}`;
 
-		await page.goto('/');
-		await page.getByRole('button', { name: /toggle edit mode/i }).click();
+		await openDashboardInEditMode(page);
 
 		// GIVEN: a service with an update available and a WebHook whose secret is
 		// the one the receiver requires.
@@ -247,7 +229,6 @@ test.describe('Service secret inheritance', () => {
 				},
 			],
 		});
-		await expect(page.getByRole('heading', { name: id })).toBeVisible();
 		await page.reload();
 
 		// WHEN: the service is reopened and its WebHook item expanded.
@@ -278,8 +259,8 @@ test.describe('Service secret inheritance', () => {
 
 		// THEN: sending the WebHook succeeds - only possible if the secret was
 		// inherited on save (a lost/corrupted secret is rejected by the receiver).
-		const serviceCard = page.locator(`[data-service-id="${id}"]`);
-		await serviceCard.getByRole('button', { name: /approve|resend/i }).click();
+		const card = serviceCard(page, id);
+		await card.getByRole('button', { name: /approve|resend/i }).click();
 		const actionDialog = page.getByRole('dialog');
 		await expect(actionDialog).toBeVisible();
 		await actionDialog
@@ -300,11 +281,10 @@ test.describe('Service secret inheritance', () => {
 	}, testInfo) => {
 		const baseID = 'SECRET_INHERIT=NOTIFY';
 		const id = withProject(baseID, testInfo.project.name);
-		createdID = id;
+		createdIDs.push(id);
 		const shotDir = `secret-inheritance/${baseID}`;
 
-		await page.goto('/');
-		await page.getByRole('button', { name: /toggle edit mode/i }).click();
+		await openDashboardInEditMode(page);
 
 		// GIVEN: a service with a Gotify notifier pointed at a real endpoint that
 		// only accepts the configured token.
@@ -320,7 +300,6 @@ test.describe('Service secret inheritance', () => {
 				},
 			],
 		});
-		await expect(page.getByRole('heading', { name: id })).toBeVisible();
 		await page.reload();
 
 		// WHEN: the service is reopened and its Notify item expanded.
@@ -371,11 +350,7 @@ test.describe('Service secret inheritance', () => {
 test.describe('Service secret inheritance on rename', () => {
 	// A failed test may leave the service under either its original or its
 	// renamed id, so clean up every id the test could have created.
-	let createdIDs: string[] = [];
-	test.afterEach(async ({ page }) => {
-		if (createdIDs.length) await cleanupServices(page, createdIDs);
-		createdIDs = [];
-	});
+	const createdIDs = trackCreatedServices();
 
 	test('deployed_version=url basic-auth: lookup secret survives a service rename', async ({
 		page,
@@ -383,11 +358,10 @@ test.describe('Service secret inheritance on rename', () => {
 		const baseID = 'SECRET_RENAME=SERVICE';
 		const id = withProject(baseID, testInfo.project.name);
 		const renamedId = withProject(`${baseID}-RENAMED`, testInfo.project.name);
-		createdIDs = [id, renamedId];
+		createdIDs.push(id, renamedId);
 		const shotDir = `secret-inheritance-rename/${baseID}`;
 
-		await page.goto('/');
-		await page.getByRole('button', { name: /toggle edit mode/i }).click();
+		await openDashboardInEditMode(page);
 
 		// GIVEN: a service whose deployed_version is a basic-auth URL lookup - the
 		// password is a secret, and the lookup only succeeds when it's correct.
@@ -403,9 +377,6 @@ test.describe('Service secret inheritance on rename', () => {
 			// /basic-auth returns a sentence, not a bare semver - disable semVer.
 			semanticVersioning: false,
 		});
-		await expect(
-			page.getByRole('heading', { exact: true, name: id }),
-		).toBeVisible();
 
 		// AND: the page is reloaded so the edit modal loads the secret masked from
 		// the backend rather than from create-time state.
@@ -443,11 +414,10 @@ test.describe('Service secret inheritance on rename', () => {
 	}, testInfo) => {
 		const baseID = 'SECRET_RENAME=NOTIFY';
 		const id = withProject(baseID, testInfo.project.name);
-		createdIDs = [id];
+		createdIDs.push(id);
 		const shotDir = `secret-inheritance-rename/${baseID}`;
 
-		await page.goto('/');
-		await page.getByRole('button', { name: /toggle edit mode/i }).click();
+		await openDashboardInEditMode(page);
 
 		// GIVEN: a service with a Gotify notifier pointed at a real endpoint that
 		// only accepts the configured token.
@@ -463,7 +433,6 @@ test.describe('Service secret inheritance on rename', () => {
 				},
 			],
 		});
-		await expect(page.getByRole('heading', { name: id })).toBeVisible();
 		await page.reload();
 
 		// WHEN: the service is reopened, the notifier's *name* changed (leaving the
@@ -502,11 +471,10 @@ test.describe('Service secret inheritance on rename', () => {
 	}, testInfo) => {
 		const baseID = 'SECRET_RENAME=WEBHOOK';
 		const id = withProject(baseID, testInfo.project.name);
-		createdIDs = [id];
+		createdIDs.push(id);
 		const shotDir = `secret-inheritance-rename/${baseID}`;
 
-		await page.goto('/');
-		await page.getByRole('button', { name: /toggle edit mode/i }).click();
+		await openDashboardInEditMode(page);
 
 		// GIVEN: a service with an update available and a WebHook whose secret is
 		// the one the receiver requires.
@@ -524,7 +492,6 @@ test.describe('Service secret inheritance on rename', () => {
 				},
 			],
 		});
-		await expect(page.getByRole('heading', { name: id })).toBeVisible();
 		await page.reload();
 
 		// WHEN: the service is reopened, its WebHook item expanded and *renamed*
@@ -542,8 +509,8 @@ test.describe('Service secret inheritance on rename', () => {
 
 		// THEN: sending the WebHook still succeeds - only possible if the secret
 		// was inherited across the rename.
-		const serviceCard = page.locator(`[data-service-id="${id}"]`);
-		await serviceCard.getByRole('button', { name: /approve|resend/i }).click();
+		const card = serviceCard(page, id);
+		await card.getByRole('button', { name: /approve|resend/i }).click();
 		const actionDialog = page.getByRole('dialog');
 		await expect(actionDialog).toBeVisible();
 		await actionDialog

--- a/web/ui/react-app/tests/webhook.spec.ts
+++ b/web/ui/react-app/tests/webhook.spec.ts
@@ -1,35 +1,25 @@
 import { expect, test } from '@playwright/test';
+import { openDashboardInEditMode, serviceCard } from './fixtures/dashboard';
 import {
-	cleanupServices,
 	createService,
 	LOOKUP_LATEST_VERSION_JSON,
 	screenshot,
+	trackCreatedServices,
 	withProject,
 } from './fixtures/service';
 import { WEBHOOK_GITHUB } from './fixtures/test-endpoints';
 
-// Both tests create a service and wait on a real WebHook send - each a real
-// network call that can approach the default timeout, so triple it.
-test.beforeEach(() => {
-	test.slow();
-});
-
 test.describe('WebHook actions', () => {
 	// Scoped to this test's ID so its afterEach can't race the other test's
 	// service. IDs are project-suffixed to avoid cross-browser collisions.
-	let createdID: string | undefined;
-	test.afterEach(async ({ page }) => {
-		if (createdID) await cleanupServices(page, [createdID]);
-		createdID = undefined;
-	});
+	const createdIDs = trackCreatedServices();
 
 	test('WebHook send succeeds', async ({ page }, testInfo) => {
 		const baseID = 'WEBHOOK=PASS';
 		const id = withProject(baseID, testInfo.project.name);
-		createdID = id;
+		createdIDs.push(id);
 
-		await page.goto('/');
-		await page.getByRole('button', { name: /toggle edit mode/i }).click();
+		await openDashboardInEditMode(page);
 
 		// GIVEN: a service with an update available (latest_version !==
 		// deployed_version) and a WebHook configured with valid credentials.
@@ -44,18 +34,17 @@ test.describe('WebHook actions', () => {
 				},
 			],
 		});
-		await expect(page.getByRole('heading', { name: id })).toBeVisible();
 		await screenshot(
 			page,
 			`webhook/${baseID}/01-after-create`,
 			testInfo.project.name,
 		);
 
-		const serviceCard = page.locator(`[data-service-id="${id}"]`);
+		const card = serviceCard(page, id);
 
 		// WHEN: the user opens the "Resend actions" (visible text "Approve")
 		// modal for the service.
-		await serviceCard.getByRole('button', { name: /approve|resend/i }).click();
+		await card.getByRole('button', { name: /approve|resend/i }).click();
 		const dialog = page.getByRole('dialog');
 		await expect(dialog).toBeVisible();
 		await screenshot(
@@ -114,10 +103,9 @@ test.describe('WebHook actions', () => {
 	test('WebHook send fails', async ({ page }, testInfo) => {
 		const baseID = 'WEBHOOK=FAIL';
 		const id = withProject(baseID, testInfo.project.name);
-		createdID = id;
+		createdIDs.push(id);
 
-		await page.goto('/');
-		await page.getByRole('button', { name: /toggle edit mode/i }).click();
+		await openDashboardInEditMode(page);
 
 		// GIVEN: a service with an update available and a WebHook configured
 		// with an invalid secret and a single try (fail fast).
@@ -133,18 +121,17 @@ test.describe('WebHook actions', () => {
 				},
 			],
 		});
-		await expect(page.getByRole('heading', { name: id })).toBeVisible();
 		await screenshot(
 			page,
 			`webhook/${baseID}/01-after-create`,
 			testInfo.project.name,
 		);
 
-		const serviceCard = page.locator(`[data-service-id="${id}"]`);
+		const card = serviceCard(page, id);
 
 		// WHEN: the user opens the "Resend actions" (visible text "Approve")
 		// modal for the service.
-		await serviceCard.getByRole('button', { name: /approve|resend/i }).click();
+		await card.getByRole('button', { name: /approve|resend/i }).click();
 		const dialog = page.getByRole('dialog');
 		await expect(dialog).toBeVisible();
 		await screenshot(


### PR DESCRIPTION
Reworks the toolbar's deployed-version refresh to only act on visible services

- Refreshes now run through a fixed pool of `REFRESH_CONCURRENCY` workers, so one slow upstream no longer stalls a whole batch.
- button rename `Refresh all deployed versions` -> `Refresh visible deployed versions`.
- Skips services with nothing to re-query: `manual` lookups, and those with no `deployed_version` lookup. The action is no longer visible when nothing to act on can be seen.

No DV                      | Manual DV                 | URL DV
:-------------------------:|:-------------------------:|:-------------------------:
![](https://github.com/user-attachments/assets/69a4fbf5-64b9-431d-a58d-86f1028de8cf)  |  ![](https://github.com/user-attachments/assets/c6ab9fd2-5d78-4aa5-9d32-0c2f87aa21dd) |  ![](https://github.com/user-attachments/assets/72fbbcac-6a9f-42d2-b2ee-54374b04185a)

Only DV=URL                | Multiple DV=URL           | Only visible DV=URL
:-------------------------:|:-------------------------:|:-------------------------:
![](https://github.com/user-attachments/assets/8a3dca34-3a76-415f-a48d-9740e6d9ffb0)  |  ![](https://github.com/user-attachments/assets/3c880e34-4953-4451-8f4e-8eaca40c352c) |  ![](https://github.com/user-attachments/assets/44d938fd-166d-4c75-a327-904e85769bc0)

---

- aligned error/success refresh action messaging

previously:

Success                    | Failed                 
:-------------------------:|:-------------------------:
![](https://github.com/user-attachments/assets/879e0503-9315-47df-9946-a6f12cddddbd)  |  ![](https://github.com/user-attachments/assets/e5214406-10df-425b-9f69-a0872bcc0fdc)

now:

Success                    | Failed                 
:-------------------------:|:-------------------------:
![](https://github.com/user-attachments/assets/e134405e-662c-4240-bf6b-29f1e8d40b99)  |  ![](https://github.com/user-attachments/assets/ed47eb45-5182-48c8-8996-32a49f862402)

### Fixes
- A service with no resolved version reported `UP_TO_DATE` and was hidden by `Hide up to date`. Now guards on the versions and reports no state until one resolves.
- Service *name* uniqueness was never validated: `SchemaProvider` called `useServices()` without the service order, so the name set was always empty and only ID collisions were caught.

### Tests
- Extracts shared dashboard test helpers (locators, assertions, refresh recording) into `tests/fixtures/dashboard.ts`.
- Expands refresh coverage to verify all filters, manual/no-lookup exclusions, disabled services, and name-vs-name collisions.
- Moves serial specs to a single 90s timeout in config, replacing per-spec test.slow().
- Fixes cleanup/idempotency issues so consecutive full runs succeed against the same backend.