### PR TITLE
feat(auth): self-service account settings

### DIFF
--- a/web/api/types/auth.go
+++ b/web/api/types/auth.go
@@ -56,6 +56,16 @@ type SetupRequest struct {
 	Password    string `json:"password"`
 }
 
+// AccountUpdateRequest is the body of PATCH /api/v1/auth/me: the signed-in
+// user changing their own account. CurrentPassword is always required;
+// nil fields stay unchanged.
+type AccountUpdateRequest struct {
+	CurrentPassword string  `json:"current_password"`
+	DisplayName     *string `json:"display_name,omitzero"`
+	Email           *string `json:"email,omitzero"`
+	NewPassword     *string `json:"new_password,omitzero"`
+}
+
 // UserCreateRequest is the body of POST /api/v1/users.
 type UserCreateRequest struct {
 	Username    string   `json:"username"`

--- a/web/api/v1/http-api-auth.go
+++ b/web/api/v1/http-api-auth.go
@@ -347,6 +347,118 @@ func (api *API) httpAuthMe(w http.ResponseWriter, r *http.Request) {
 	api.writeAuthMe(w, http.StatusOK, authCtx, logFrom)
 }
 
+// errCurrentPassword is given when an account update fails its
+// current-password check.
+var errCurrentPassword = errors.New("current password is incorrect")
+
+// httpAuthMeUpdate handles PATCH /api/v1/auth/me: the signed-in user changing
+// their own account. Every change is gated on the current password. Setting a
+// new one ends the user's other sessions, then re-issues one for this request,
+// so the caller stays signed in here but nowhere else.
+//
+// Response:
+//
+//	200 OK: JSON of the updated user and their permission grants.
+//	400 Bad Request: on a malformed body, an over-long field, a weak new
+//	                 password, or a wrong current password.
+//	401 Unauthorized: with no authenticated user.
+//	429 Too Many Requests: when this (client IP, username) pair is rate-limited.
+//	500 Internal Server Error: on a hashing, store, or session failure.
+func (api *API) httpAuthMeUpdate(w http.ResponseWriter, r *http.Request) {
+	logFrom := logx.LogFrom{Primary: "httpAuthMeUpdate", Secondary: getIP(r)}
+
+	authCtx := api.authCtxOr401(w, r)
+	if authCtx == nil {
+		return
+	}
+
+	var request apitype.AccountUpdateRequest
+	if !api.decodeAuthBody(w, r, &request) {
+		return
+	}
+	for _, field := range []struct {
+		key   string
+		value *string
+	}{
+		{key: "display_name", value: request.DisplayName},
+		{key: "email", value: request.Email},
+	} {
+		if field.value == nil {
+			continue
+		}
+		if err := validateFieldLength(field.key, *field.value); err != nil {
+			failRequest(&w, err, http.StatusBadRequest)
+			return
+		}
+	}
+	if request.NewPassword != nil {
+		if err := validatePassword(*request.NewPassword); err != nil {
+			failRequest(&w, err, http.StatusBadRequest)
+			return
+		}
+	}
+
+	// Verify the current password, spending the login rate-limiter's budget so
+	// a hijacked session cannot brute-force it.
+	if _, err := api.verifyLocalCredentials(
+		r.Context(), authCtx.User.Username, request.CurrentPassword, getIP(r),
+	); err != nil {
+		switch {
+		case errors.Is(err, errTooManyAttempts):
+			failRequest(&w, errTooManyAttempts, http.StatusTooManyRequests)
+		// 400, not 401: the session is valid, and a 401 would log the caller out.
+		case errors.Is(err, auth.ErrInvalidCredentials):
+			failRequest(&w, errCurrentPassword, http.StatusBadRequest)
+		default:
+			logx.Error(err, logFrom, true)
+			failRequest(&w, errors.New("failed to update account"), http.StatusInternalServerError)
+		}
+		return
+	}
+
+	patch := store.UserPatch{
+		DisplayName: request.DisplayName,
+		Email:       request.Email,
+	}
+	if request.NewPassword != nil {
+		hash, err := hashPassword(*request.NewPassword)
+		if err != nil {
+			logx.Error(err, logFrom, true)
+			failRequest(&w, errors.New("failed to update account"), http.StatusInternalServerError)
+			return
+		}
+		patch.PasswordHash = &hash
+	}
+	if _, err := api.auth.Store.UpdateUser(r.Context(), authCtx.User.ID, patch); err != nil {
+		api.failAuthStoreRequest(w, err, logFrom, "update account")
+		return
+	}
+
+	// A new password invalidates every session of the user, including this one.
+	if request.NewPassword != nil {
+		ctx, cancel := detachedContext(r)
+		defer cancel()
+		if err := api.auth.Sessions.RevokeUser(ctx, authCtx.User.ID); err != nil {
+			logx.Error(err, logFrom, true)
+		}
+		api.kickUserWebSocketClients(authCtx.User.ID)
+
+		if !api.startSession(w, r, authCtx, logFrom) {
+			return
+		}
+	}
+
+	// Re-read the updated account details.
+	updated, err := api.contextForUser(r.Context(), authCtx.User.ID, authCtx.Identity.Provider)
+	if err != nil {
+		logx.Error(err, logFrom, true)
+		failRequest(&w, errors.New("failed to update account"), http.StatusInternalServerError)
+		return
+	}
+
+	api.writeAuthMe(w, http.StatusOK, updated, logFrom)
+}
+
 // startSession mints a session for authCtx.User and sets the session cookie,
 // reporting false on failure. WebSocket clients of any sessions evicted by
 // the per-user cap are kicked.

--- a/web/api/v1/http-api-auth_test.go
+++ b/web/api/v1/http-api-auth_test.go
@@ -1059,6 +1059,443 @@ func TestAPI_AuthLogout__kicks(t *testing.T) {
 	}
 }
 
+func TestAPI_AuthMeUpdate__password(t *testing.T) {
+	// GIVEN: an admin with two WebSocket sessions.
+	file := "TestAPI_AuthMeUpdate__password.yml"
+	api, deps, _ := testAuthServer(t, file)
+	cookie := loginCookie(t, api, "admin", "admin-password")
+	otherCookie := loginCookie(t, api, "admin", "admin-password")
+	adminID := adminContext(t, api, deps).User.ID
+	connect := wireHub(t, api)
+	changingClient := connect(adminID, auth.HashToken(cookie.Value))
+	otherClient := connect(adminID, auth.HashToken(otherCookie.Value))
+
+	prefix := fmt.Sprintf("%s\nhttpAuthMeUpdate() password", packageName)
+
+	// WHEN: the user sets a new password.
+	w := serveAuth(api, authedRequest(
+		http.MethodPatch, "/api/v1/auth/me",
+		test.TrimJSON(`{
+			"current_password":"admin-password",
+			"new_password":"new-admin-password"
+		}`),
+		cookie,
+	))
+
+	// THEN: the change succeeds, answering with the account.
+	if got, want := w.Code, http.StatusOK; got != want {
+		t.Fatalf(
+			"%s\nstatus mismatch\ngot:  %d - %s\nwant: %d",
+			prefix, got, w.Body.String(), want,
+		)
+	}
+	var me apitype.AuthMe
+	if err := decode.Unmarshal("json", w.Body.Bytes(), &me); err != nil {
+		t.Fatalf(
+			"%s\nparse response: %v",
+			prefix, err,
+		)
+	}
+	if got, want := me.User.Username, "admin"; got != want {
+		t.Errorf(
+			"%s\nresponse user mismatch\ngot:  %q\nwant: %q",
+			prefix, got, want,
+		)
+	}
+
+	// AND: a fresh session cookie is issued.
+	var fresh *http.Cookie
+	for _, c := range w.Result().Cookies() {
+		if c.Name == authCookieName {
+			fresh = c
+		}
+	}
+	if fresh == nil || fresh.Value == "" || fresh.Value == cookie.Value {
+		t.Fatalf(
+			"%s\nshould issue a new session cookie\ngot: %+v",
+			prefix, fresh,
+		)
+	}
+
+	// AND: every session of the user loses its WebSocket clients.
+	if api.hub.hasClient(changingClient) || api.hub.hasClient(otherClient) {
+		t.Errorf(
+			"%s\na password change should kick the user's WebSocket clients",
+			prefix,
+		)
+	}
+
+	// AND: the sessions the change replaced no longer authenticate.
+	for _, stale := range []*http.Cookie{cookie, otherCookie} {
+		w := serveAuth(api,
+			authedRequest(http.MethodGet, "/api/v1/auth/me", "", stale))
+		if got, want := w.Code, http.StatusUnauthorized; got != want {
+			t.Errorf(
+				"%s\nstale session status mismatch\ngot:  %d - %s\nwant: %d",
+				prefix, got, w.Body.String(), want,
+			)
+		}
+	}
+
+	// AND: the caller stays signed in on the fresh session.
+	w = serveAuth(api,
+		authedRequest(http.MethodGet, "/api/v1/auth/me", "", fresh))
+	if got, want := w.Code, http.StatusOK; got != want {
+		t.Errorf(
+			"%s\nfresh session status mismatch\ngot:  %d - %s\nwant: %d",
+			prefix, got, w.Body.String(), want,
+		)
+	}
+
+	// AND: only the new password logs in.
+	w = serveAuth(api, httptest.NewRequest(
+		http.MethodPost, "/api/v1/auth/login",
+		strings.NewReader(test.TrimJSON(`{
+			"username":"admin",
+			"password":"admin-password"
+		}`)),
+	))
+	if got, want := w.Code, http.StatusUnauthorized; got != want {
+		t.Errorf(
+			"%s\nold password status mismatch\ngot:  %d - %s\nwant: %d",
+			prefix, got, w.Body.String(), want,
+		)
+	}
+	loginCookie(t, api, "admin", "new-admin-password")
+}
+
+func TestAPI_AuthMeUpdate__profile(t *testing.T) {
+	// GIVEN: the ways a user may patch their own profile fields.
+	const (
+		password = "profile-password"
+		wasName  = "Before"
+		wasEmail = "before@example.com"
+		nowName  = "After"
+		nowEmail = "after@example.com"
+	)
+	tests := []struct {
+		name            string
+		body            string
+		wantDisplayName string
+		wantEmail       string
+	}{
+		{
+			name: "valid/display name only",
+			body: test.TrimJSON(`{
+				"current_password":"profile-password",
+				"display_name":"After"
+			}`),
+			wantDisplayName: nowName,
+			wantEmail:       wasEmail,
+		},
+		{
+			name: "valid/email only",
+			body: test.TrimJSON(`{
+				"current_password":"profile-password",
+				"email":"after@example.com"
+			}`),
+			wantDisplayName: wasName,
+			wantEmail:       nowEmail,
+		},
+		{
+			name: "valid/both at once",
+			body: test.TrimJSON(`{
+				"current_password":"profile-password",
+				"display_name":"After","email":"after@example.com"
+			}`),
+			wantDisplayName: nowName,
+			wantEmail:       nowEmail,
+		},
+		{
+			name: "valid/clearing a field",
+			body: test.TrimJSON(`{
+				"current_password":"profile-password",
+				"display_name":"","email":""
+			}`),
+			wantDisplayName: "",
+			wantEmail:       "",
+		},
+		{
+			name: "valid/no fields, just the password check",
+			body: test.TrimJSON(`{
+				"current_password":"profile-password"
+			}`),
+			wantDisplayName: wasName,
+			wantEmail:       wasEmail,
+		},
+	}
+
+	file := "TestAPI_AuthMeUpdate__profile.yml"
+	api, deps, _ := testAuthServer(t, file)
+
+	for i, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			prefix := fmt.Sprintf("%s\nhttpAuthMeUpdate() profile", packageName)
+
+			// AND: an account of their own, with both fields already set.
+			username := fmt.Sprintf("profile-user-%d", i)
+			user := createAuthUser(t, deps, username, password)
+			seedName, seedEmail := wasName, wasEmail
+			if _, err := deps.Store.UpdateUser(t.Context(),
+				user.ID,
+				store.UserPatch{DisplayName: &seedName, Email: &seedEmail},
+			); err != nil {
+				t.Fatalf(
+					"%s\nseed %q: %v",
+					prefix, username, err,
+				)
+			}
+			cookie := loginCookie(t, api, username, password)
+
+			// WHEN: they patch their own account.
+			w := serveAuth(api, authedRequest(
+				http.MethodPatch, "/api/v1/auth/me",
+				tc.body, cookie,
+			))
+
+			// THEN: the response carries the updated account.
+			if got, want := w.Code, http.StatusOK; got != want {
+				t.Fatalf(
+					"%s\nstatus mismatch\ngot:  %d - %s\nwant: %d",
+					prefix, got, w.Body.String(), want,
+				)
+			}
+			var me apitype.AuthMe
+			if err := decode.Unmarshal("json", w.Body.Bytes(), &me); err != nil {
+				t.Fatalf(
+					"%s\nparse response: %v",
+					prefix, err,
+				)
+			}
+			if me.User.DisplayName != tc.wantDisplayName ||
+				me.User.Email != tc.wantEmail {
+				t.Errorf(
+					"%s\nresponse mismatch"+
+						"\ngot:  display_name=%q, email=%q"+
+						"\nwant: display_name=%q, email=%q",
+					prefix,
+					me.User.DisplayName, me.User.Email,
+					tc.wantDisplayName, tc.wantEmail,
+				)
+			}
+
+			// AND: the session is left alone - no password changed,
+			// so nothing to revoke.
+			for _, c := range w.Result().Cookies() {
+				if c.Name == authCookieName {
+					t.Errorf(
+						"%s\nprofile-only update should not re-issue the session"+
+							"\ngot: %+v",
+						prefix, c,
+					)
+				}
+			}
+
+			// AND: the change persisted, readable on the same session.
+			w = serveAuth(api, authedRequest(
+				http.MethodGet, "/api/v1/auth/me",
+				"",
+				cookie,
+			))
+			if got, want := w.Code, http.StatusOK; got != want {
+				t.Fatalf(
+					"%s\nsession after a profile update\ngot:  %d - %s\nwant: %d",
+					prefix, got, w.Body.String(), want,
+				)
+			}
+			me = apitype.AuthMe{}
+			if err := decode.Unmarshal("json", w.Body.Bytes(), &me); err != nil {
+				t.Fatalf(
+					"%s\nparse /auth/me: %v",
+					prefix, err,
+				)
+			}
+			if me.User.DisplayName != tc.wantDisplayName ||
+				me.User.Email != tc.wantEmail {
+				t.Errorf(
+					"%s\npersisted mismatch"+
+						"\ngot:  display_name=%q, email=%q"+
+						"\nwant: display_name=%q, email=%q",
+					prefix,
+					me.User.DisplayName, me.User.Email,
+					tc.wantDisplayName, tc.wantEmail,
+				)
+			}
+
+			// AND: the password is untouched.
+			loginCookie(t, api, username, password)
+		})
+	}
+}
+
+func TestAPI_AuthMeUpdate__refusals(t *testing.T) {
+	// GIVEN: a logged-in admin.
+	file := "TestAPI_AuthMeUpdate__refusals.yml"
+	api, _, _ := testAuthServer(t, file)
+	cookie := loginCookie(t, api, "admin", "admin-password")
+
+	tests := []struct {
+		name        string
+		body        string
+		wantStatus  int
+		wantMessage string // Checked when set - the UI maps errors by message.
+	}{
+		{
+			name:       "invalid/malformed body",
+			body:       `{`,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "invalid/over-long display name",
+			body: test.TrimJSON(`{
+				"current_password":"admin-password",
+				"display_name":"` + strings.Repeat("x", maxFieldLength+1) + `"
+			}`),
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "invalid/new password too short",
+			body: test.TrimJSON(`{
+				"current_password":"admin-password",
+				"new_password":"short"
+			}`),
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			// 400 rather than 401: the session is valid, and a 401 would
+			// log the caller out of the app.
+			name: "invalid/no current password",
+			body: test.TrimJSON(`{
+				"display_name":"Nice Try"
+			}`),
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "invalid/wrong current password",
+			body: test.TrimJSON(`{
+				"current_password":"not-my-password",
+				"display_name":"Nice Try"
+			}`),
+			wantStatus:  http.StatusBadRequest,
+			wantMessage: "current password is incorrect",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			prefix := fmt.Sprintf("%s\nhttpAuthMeUpdate() refusals", packageName)
+
+			// WHEN: the update is requested.
+			w := serveAuth(api, authedRequest(
+				http.MethodPatch, "/api/v1/auth/me",
+				tc.body,
+				cookie,
+			))
+
+			// THEN: it is refused.
+			if got := w.Code; got != tc.wantStatus {
+				t.Errorf(
+					"%s\nstatus mismatch\ngot:  %d - %s\nwant: %d",
+					prefix, got, w.Body.String(), tc.wantStatus,
+				)
+			}
+
+			// AND: the message as expected.
+			if tc.wantMessage != "" {
+				var body struct {
+					Message string `json:"message"`
+				}
+				if err := decode.Unmarshal("json", w.Body.Bytes(), &body); err != nil {
+					t.Fatalf(
+						"%s\nparse error body: %v",
+						prefix, err,
+					)
+				}
+				if body.Message != tc.wantMessage {
+					t.Errorf(
+						"%s\nmessage mismatch\ngot:  %q\nwant: %q",
+						prefix, body.Message, tc.wantMessage,
+					)
+				}
+			}
+
+			// AND: the account is left alone.
+			w = serveAuth(api, authedRequest(
+				http.MethodGet, "/api/v1/auth/me",
+				"",
+				cookie,
+			))
+			var me apitype.AuthMe
+			if err := decode.Unmarshal("json", w.Body.Bytes(), &me); err != nil {
+				t.Fatalf(
+					"%s\nparse /auth/me: %v",
+					prefix, err,
+				)
+			}
+			if me.User.DisplayName != "Administrator" {
+				t.Errorf(
+					"%s\ndisplay name should be unchanged\ngot:  %q\nwant: %q",
+					prefix, me.User.DisplayName, "Administrator",
+				)
+			}
+			loginCookie(t, api, "admin", "admin-password")
+		})
+	}
+
+	// AND: an unauthenticated request is 401.
+	w := serveAuth(api, httptest.NewRequest(http.MethodPatch, "/api/v1/auth/me",
+		strings.NewReader(test.TrimJSON(`{
+			"current_password":"admin-password","display_name":"Nice Try"}`))))
+	if got, want := w.Code, http.StatusUnauthorized; got != want {
+		t.Errorf(
+			"%s\nunauthenticated account update\ngot:  %d - %s\nwant: %d",
+			packageName, got, w.Body.String(), want,
+		)
+	}
+}
+
+func TestAPI_AuthMeUpdate__bearerRefused(t *testing.T) {
+	// GIVEN: an auth-enabled API and an admin owning an API token.
+	file := "TestAPI_AuthMeUpdate__bearerRefused.yml"
+	api, deps, _ := testAuthServer(t, file)
+	authCtx := adminContext(t, api, deps)
+	plaintext, _, err := deps.Store.CreateAPIToken(
+		t.Context(), authCtx.User.ID, "ci", nil,
+	)
+	if err != nil {
+		t.Fatalf(
+			"%s\nsetup CreateAPIToken failed: %v",
+			packageName, err,
+		)
+	}
+
+	prefix := fmt.Sprintf("%s\nhttpAuthMeUpdate() from a token", packageName)
+
+	// WHEN: the token tries to change the owner's password.
+	req := authedRequest(http.MethodPatch, "/api/v1/auth/me",
+		test.TrimJSON(`{
+			"current_password":"admin-password",
+			"new_password":"new-admin-password"
+		}`),
+		nil,
+	)
+	req.Header.Set("Authorization", "Bearer "+plaintext)
+	w := serveAuth(api, req)
+
+	// THEN: the request is refused.
+	if got, want := w.Code, http.StatusForbidden; got != want {
+		t.Errorf(
+			"%s\nstatus mismatch\ngot:  %d - %s\nwant: %d",
+			prefix, got, w.Body.String(), want,
+		)
+	}
+
+	// AND: the password is unchanged.
+	loginCookie(t, api, "admin", "admin-password")
+}
+
 func TestAPI_Auth__sessionExpired(t *testing.T) {
 	// GIVEN: a server whose sessions are already past their lifetime.
 	file := "TestAPI_Auth__sessionExpired.yml"

--- a/web/api/v1/http-api-auth_test.go
+++ b/web/api/v1/http-api-auth_test.go
@@ -18,6 +18,7 @@ package v1
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -1454,6 +1455,223 @@ func TestAPI_AuthMeUpdate__refusals(t *testing.T) {
 			packageName, got, w.Body.String(), want,
 		)
 	}
+}
+
+func TestAPI_AuthMeUpdate__failures(t *testing.T) {
+	// GIVEN: the ways an account update can fail beneath the handler.
+	t.Run("invalid/no auth context", func(t *testing.T) {
+		prefix := fmt.Sprintf("%s\nhttpAuthMeUpdate() failures", packageName)
+
+		// WHEN: the handler is called without an [auth.Context].
+		w := httptest.NewRecorder()
+		api, _, _ := testAuthServer(t, "TestAPI_AuthMeUpdate__failures_noCtx.yml")
+		api.httpAuthMeUpdate(w, httptest.NewRequest(
+			http.MethodPatch, "/api/v1/auth/me",
+			strings.NewReader(`{}`),
+		))
+
+		// THEN: 401.
+		if got, want := w.Code, http.StatusUnauthorized; got != want {
+			t.Errorf(
+				"%s\nno auth context\ngot:  %d - %s\nwant: %d",
+				prefix, got, w.Body.String(), want,
+			)
+		}
+	})
+
+	t.Run("invalid/rate-limited", func(t *testing.T) {
+		// AND: a logged-in admin who has spent the limiter's budget.
+		api, _, _ := testAuthServer(t, "TestAPI_AuthMeUpdate__failures_limit.yml")
+		cookie := loginCookie(t, api, "admin", "admin-password")
+		wrong := test.TrimJSON(`{
+				"current_password":"not-my-password",
+				"display_name":"Nope"
+			}`)
+
+		prefix := fmt.Sprintf("%s\nhttpAuthMeUpdate() failures", packageName)
+
+		for i := range loginLimitAttempts {
+			w := serveAuth(api, authedRequest(
+				http.MethodPatch, "/api/v1/auth/me",
+				wrong,
+				cookie,
+			))
+			if got, want := w.Code, http.StatusBadRequest; got != want {
+				t.Fatalf(
+					"%s\nattempt %d\ngot:  %d - %s\nwant: %d",
+					prefix, i+1, got, w.Body.String(), want,
+				)
+			}
+		}
+
+		// WHEN: one more attempt is made.
+		w := serveAuth(api, authedRequest(
+			http.MethodPatch, "/api/v1/auth/me",
+			wrong,
+			cookie,
+		))
+
+		// THEN: it is rate-limited rather than checked.
+		if got, want := w.Code, http.StatusTooManyRequests; got != want {
+			t.Errorf(
+				"%s\nover the limit\ngot:  %d - %s\nwant: %d",
+				prefix, got, w.Body.String(), want,
+			)
+		}
+	})
+
+	t.Run("invalid/credential lookup breaks", func(t *testing.T) {
+		// AND: a server whose store is gone.
+		api, deps, dbConn := testAuthServer(t,
+			"TestAPI_AuthMeUpdate__failures_lookup.yml")
+		authCtx := adminContext(t, api, deps)
+		_ = dbConn.Close()
+
+		prefix := fmt.Sprintf("%s\nhttpAuthMeUpdate() failures", packageName)
+
+		// WHEN: the current password cannot be looked up.
+		w := httptest.NewRecorder()
+		api.httpAuthMeUpdate(w, withAuthCtx(httptest.NewRequest(
+			http.MethodPatch, "/api/v1/auth/me",
+			strings.NewReader(`{"current_password":"admin-password"}`)),
+			authCtx,
+		))
+
+		// THEN: the infrastructure failure reads as 500, not a bad password.
+		if got, want := w.Code, http.StatusInternalServerError; got != want {
+			t.Errorf(
+				"%s\nlookup failure\ngot:  %d - %s\nwant: %d",
+				prefix, got, w.Body.String(), want,
+			)
+		}
+	})
+
+	t.Run("invalid/hashing breaks", func(t *testing.T) {
+		// AND: a logged-in admin, and hashing that fails.
+		api, _, _ := testAuthServer(t, "TestAPI_AuthMeUpdate__failures_hash.yml")
+		cookie := loginCookie(t, api, "admin", "admin-password")
+		hashPasswordHad := hashPassword
+		t.Cleanup(func() { hashPassword = hashPasswordHad })
+		hashPassword = func(_ string) (string, error) {
+			return "", errors.New("hash broke")
+		}
+
+		prefix := fmt.Sprintf("%s\nhttpAuthMeUpdate() failures", packageName)
+
+		// WHEN: a new password cannot be hashed.
+		w := serveAuth(api, authedRequest(
+			http.MethodPatch, "/api/v1/auth/me",
+			test.TrimJSON(`{
+				"current_password":"admin-password",
+				"new_password":"new-admin-password"
+			}`),
+			cookie,
+		))
+
+		// THEN: 500.
+		if got, want := w.Code, http.StatusInternalServerError; got != want {
+			t.Errorf(
+				"%s\nhash failure\ngot:  %d - %s\nwant: %d",
+				prefix, got, w.Body.String(), want,
+			)
+		}
+	})
+
+	t.Run("invalid/the account vanished", func(t *testing.T) {
+		// AND: a context naming an account the store does not hold.
+		api, deps, _ := testAuthServer(t, "TestAPI_AuthMeUpdate__failures_gone.yml")
+		authCtx := *adminContext(t, api, deps)
+		authCtx.User.ID = "no-such-id"
+
+		prefix := fmt.Sprintf("%s\nhttpAuthMeUpdate() failures", packageName)
+
+		// WHEN: the update is applied to it.
+		w := httptest.NewRecorder()
+		api.httpAuthMeUpdate(w,
+			withAuthCtx(httptest.NewRequest(
+				http.MethodPatch, "/api/v1/auth/me",
+				strings.NewReader(test.TrimJSON(`{
+						"current_password":"admin-password",
+						"display_name":"Ghost"
+					}`),
+				)),
+				&authCtx,
+			))
+
+		// THEN: the store failure surfaces as a 404.
+		if got, want := w.Code, http.StatusNotFound; got != want {
+			t.Errorf(
+				"%s\nvanished account\ngot:  %d - %s\nwant: %d",
+				prefix, got, w.Body.String(), want,
+			)
+		}
+	})
+
+	t.Run("invalid/sessions break on a password change", func(t *testing.T) {
+		// AND: a server whose session manager fails every call.
+		api, deps, _ := testAuthServer(t,
+			"TestAPI_AuthMeUpdate__failures_sessions.yml")
+		authCtx := adminContext(t, api, deps)
+		deps.Sessions = session.New(
+			failingSessionStore{},
+			session.Config{Lifetime: time.Hour, IdleTimeout: time.Hour},
+		)
+
+		prefix := fmt.Sprintf("%s\nhttpAuthMeUpdate() failures", packageName)
+
+		// WHEN: the password changes, so sessions must be revoked and re-minted.
+		w := httptest.NewRecorder()
+		api.httpAuthMeUpdate(w, withAuthCtx(httptest.NewRequest(
+			http.MethodPatch, "/api/v1/auth/me",
+			strings.NewReader(test.TrimJSON(`{
+				"current_password":"admin-password",
+				"new_password":"new-admin-password"
+			}`))),
+			authCtx,
+		))
+
+		// THEN: the failure to re-mint reads as 500.
+		if got, want := w.Code, http.StatusInternalServerError; got != want {
+			t.Errorf(
+				"%s\nsession failure\ngot:  %d - %s\nwant: %d",
+				prefix, got, w.Body.String(), want,
+			)
+		}
+	})
+
+	t.Run("invalid/grants unreadable after the update", func(t *testing.T) {
+		// AND: a server whose grants are gone, leaving the update itself fine.
+		api, deps, dbConn := testAuthServer(t,
+			"TestAPI_AuthMeUpdate__failures_grants.yml")
+		authCtx := adminContext(t, api, deps)
+		if _, err := dbConn.Exec(`DROP TABLE permissions;`); err != nil {
+			t.Fatalf(
+				"%s\nsetup drop failed: %v",
+				packageName, err,
+			)
+		}
+
+		prefix := fmt.Sprintf("%s\nhttpAuthMeUpdate() failures", packageName)
+
+		// WHEN: the account is re-read for the response.
+		w := httptest.NewRecorder()
+		api.httpAuthMeUpdate(w, withAuthCtx(httptest.NewRequest(
+			http.MethodPatch, "/api/v1/auth/me",
+			strings.NewReader(test.TrimJSON(`{
+				"current_password":"admin-password",
+				"display_name":"Renamed"
+			}`))),
+			authCtx,
+		))
+
+		// THEN: 500.
+		if got, want := w.Code, http.StatusInternalServerError; got != want {
+			t.Errorf(
+				"%s\ngrant failure\ngot:  %d - %s\nwant: %d",
+				prefix, got, w.Body.String(), want,
+			)
+		}
+	})
 }
 
 func TestAPI_AuthMeUpdate__bearerRefused(t *testing.T) {

--- a/web/api/v1/http-ui.go
+++ b/web/api/v1/http-ui.go
@@ -29,6 +29,7 @@ import (
 func (api *API) SetupRoutesNodeJS() {
 	nodeRoutes := []string{
 		"/account",
+		"/account/profile",
 		"/account/tokens",
 		"/admin",
 		"/admin/groups",

--- a/web/api/v1/http-ui_test.go
+++ b/web/api/v1/http-ui_test.go
@@ -38,6 +38,12 @@ func TestHTTP_SetupRoutesNodeJS(t *testing.T) {
 		wantContent string
 	}{
 		{
+			name:        "account profile route",
+			route:       "/account/profile",
+			wantStatus:  http.StatusOK,
+			wantContent: "text/html",
+		},
+		{
 			name:        "account tokens route",
 			route:       "/account/tokens",
 			wantStatus:  http.StatusOK,

--- a/web/api/v1/http.go
+++ b/web/api/v1/http.go
@@ -71,6 +71,9 @@ func (api *API) SetupRoutesAPI() {
 
 		//   GET, the authenticated user and their permissions.
 		v1Router.HandleFunc("/auth/me", api.httpAuthMe).Methods(http.MethodGet)
+		//   PATCH, change your own account (gated on the current password).
+		v1Router.HandleFunc("/auth/me",
+			api.requireSessionAuth(api.httpAuthMeUpdate)).Methods(http.MethodPatch)
 		// Users - CRUD.
 		v1Router.HandleFunc("/users",
 			api.requireAdmin(api.httpUserList)).Methods(http.MethodGet)

--- a/web/api/v1/middleware-auth_test.go
+++ b/web/api/v1/middleware-auth_test.go
@@ -1902,6 +1902,7 @@ func TestAPI_SetupRoutesAPI__everyRouteIsGuarded(t *testing.T) {
 		"POST   /api/v1/auth/setup":    true,
 		"POST   /api/v1/auth/logout":   true,
 		"GET    /api/v1/auth/me":       true,
+		"PATCH  /api/v1/auth/me":       true,
 		"GET    /api/v1/tokens":        true,
 		"POST   /api/v1/tokens":        true,
 		"DELETE /api/v1/tokens/{id}":   true,

--- a/web/ui/react-app/playwright.config.ts
+++ b/web/ui/react-app/playwright.config.ts
@@ -37,6 +37,7 @@ const MUTATING_TEST_TIMEOUT = 90_000;
  */
 const AUTH_SPECS = [
 	'auth.spec.ts',
+	'auth-account.spec.ts',
 	'auth-permissions.spec.ts',
 	'auth-responsive.spec.ts',
 ];

--- a/web/ui/react-app/src/App.tsx
+++ b/web/ui/react-app/src/App.tsx
@@ -23,11 +23,13 @@ import { WebSocketProvider } from '@/contexts/websocket';
 import { notifyUnauthorised } from '@/lib/auth-events';
 import { QUERY_KEYS } from '@/lib/query-keys';
 import {
+	AccountPage,
 	ApprovalsPage,
 	ConfigPage,
 	FlagsPage,
 	GroupsPage,
 	LoginPage,
+	SettingsLayout,
 	StatusPage,
 	TokensPage,
 	UsersPage,
@@ -99,8 +101,11 @@ const ProtectedApp = (): ReactElement => {
 								}
 								path="/account"
 							>
-								<Route element={<Navigate replace to="tokens" />} index />
-								<Route element={<TokensPage />} path="tokens" />
+								<Route element={<SettingsLayout />}>
+									<Route element={<Navigate replace to="profile" />} index />
+									<Route element={<AccountPage />} path="profile" />
+									<Route element={<TokensPage />} path="tokens" />
+								</Route>
 							</Route>
 						</Routes>
 					</div>

--- a/web/ui/react-app/src/components/auth/user-menu.tsx
+++ b/web/ui/react-app/src/components/auth/user-menu.tsx
@@ -1,4 +1,4 @@
-import { KeyRound, LogOut, UserCircle, Users } from 'lucide-react';
+import { LogOut, Settings, UserCircle, Users } from 'lucide-react';
 import type { ReactElement } from 'react';
 import { Link, useNavigate } from 'react-router';
 import { Button } from '@/components/ui/button';
@@ -44,8 +44,8 @@ export const UserMenu = (): ReactElement | null => {
 				</DropdownMenuLabel>
 				<DropdownMenuSeparator />
 				<DropdownMenuItem asChild>
-					<Link to="/account/tokens">
-						<KeyRound aria-hidden /> API Tokens
+					<Link to="/account/profile">
+						<Settings aria-hidden /> Settings
 					</Link>
 				</DropdownMenuItem>
 				{isAdmin && (

--- a/web/ui/react-app/src/pages/account/layout.tsx
+++ b/web/ui/react-app/src/pages/account/layout.tsx
@@ -1,0 +1,96 @@
+import { ChevronDown, KeyRound, UserCircle } from 'lucide-react';
+import type { ReactElement } from 'react';
+import { Link, NavLink, Outlet, useLocation } from 'react-router';
+import { Button } from '@/components/ui/button';
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { cn } from '@/lib/utils';
+
+const SECTIONS = [
+	{ icon: UserCircle, label: 'Account', to: '/account/profile' },
+	{ icon: KeyRound, label: 'API Tokens', to: '/account/tokens' },
+];
+
+const linkStyle = (isActive: boolean) =>
+	cn(
+		'flex items-center gap-2 rounded-md px-3 py-2 text-sm transition-colors',
+		isActive
+			? 'bg-muted font-medium text-foreground'
+			: 'text-muted-foreground hover:bg-muted/50 hover:text-foreground',
+	);
+
+/**
+ * The settings shell: its sections as a sidebar on wide screens, and as a
+ * dropdown below that.
+ */
+export const SettingsLayout = (): ReactElement => {
+	const { pathname } = useLocation();
+	const active =
+		SECTIONS.find((section) => pathname.startsWith(section.to)) ?? SECTIONS[0];
+	const ActiveIcon = active.icon;
+
+	return (
+		<div className="flex flex-col gap-4">
+			<h2 className="scroll-m-20 font-semibold text-3xl tracking-tight">
+				Settings
+			</h2>
+			<div className="flex flex-col gap-6 lg:flex-row lg:gap-10">
+				<nav
+					aria-label="Settings sections"
+					className="hidden lg:block lg:w-52 lg:shrink-0"
+				>
+					<ul className="flex flex-col gap-1">
+						{SECTIONS.map(({ icon: Icon, label, to }) => (
+							<li key={to}>
+								<NavLink
+									className={({ isActive }) => linkStyle(isActive)}
+									to={to}
+								>
+									<Icon aria-hidden className="size-4" />
+									{label}
+								</NavLink>
+							</li>
+						))}
+					</ul>
+				</nav>
+				<div className="lg:hidden">
+					<DropdownMenu>
+						<DropdownMenuTrigger asChild>
+							<Button
+								aria-label="Settings sections"
+								className="w-full justify-between"
+								variant="outline"
+							>
+								<span className="flex items-center gap-2">
+									<ActiveIcon aria-hidden />
+									{active.label}
+								</span>
+								<ChevronDown aria-hidden />
+							</Button>
+						</DropdownMenuTrigger>
+						<DropdownMenuContent
+							align="start"
+							className="w-(--radix-dropdown-menu-trigger-width)"
+						>
+							{SECTIONS.map(({ icon: Icon, label, to }) => (
+								<DropdownMenuItem asChild key={to}>
+									<Link to={to}>
+										<Icon aria-hidden />
+										{label}
+									</Link>
+								</DropdownMenuItem>
+							))}
+						</DropdownMenuContent>
+					</DropdownMenu>
+				</div>
+				<div className="min-w-0 flex-1">
+					<Outlet />
+				</div>
+			</div>
+		</div>
+	);
+};

--- a/web/ui/react-app/src/pages/account/profile/index.tsx
+++ b/web/ui/react-app/src/pages/account/profile/index.tsx
@@ -1,0 +1,347 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { type ReactElement, useEffect } from 'react';
+import { useWatch } from 'react-hook-form';
+import { toast } from 'sonner';
+import { PasswordMismatchError } from '@/components/auth/password-mismatch-error';
+import FieldLabelWithTooltip from '@/components/generic/field-label';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { Field, FieldDescription, FieldError } from '@/components/ui/field';
+import { Input } from '@/components/ui/input';
+import { TextOrLoading } from '@/components/ui/loading-ellipsis';
+import { MaskedInput } from '@/components/ui/masked-input';
+import { Separator } from '@/components/ui/separator';
+import { useAuth } from '@/contexts/auth';
+import usePasswordMismatch from '@/hooks/use-password-mismatch';
+import useZodForm from '@/hooks/use-zod-form';
+import { QUERY_KEYS } from '@/lib/query-keys';
+import {
+	type AccountFormValues,
+	accountSchema,
+} from '@/pages/account/profile/schema';
+import type { AuthMe, AuthUser } from '@/types/auth';
+import * as authAPI from '@/utils/api/auth';
+import type { AccountUpdateRequest } from '@/utils/api/types/requests/auth';
+import { getErrorMessage } from '@/utils/errors';
+
+/** The API's message when the current password does not match. */
+const WRONG_CURRENT_PASSWORD = 'current password is incorrect';
+
+/** Form field of an API field error, keyed by the name the API reports. */
+const FIELD_OF_KEY: Record<string, keyof AccountFormValues> = {
+	display_name: 'display_name',
+	email: 'email',
+	password: 'password',
+};
+
+type ServerError = {
+	field: keyof AccountFormValues | 'root';
+	message: string;
+};
+
+/** Sentence-cases an API message, which arrives lower-case and unpunctuated. */
+const sentence = (text: string) =>
+	text
+		? `${text[0].toUpperCase()}${text.slice(1)}${text.endsWith('.') ? '' : '.'}`
+		: text;
+
+/** Where an API error belongs, and how the form words it. */
+const serverError = (message: string): ServerError => {
+	const field =
+		message === WRONG_CURRENT_PASSWORD
+			? 'currentPassword'
+			: FIELD_OF_KEY[message.split(':')[0]];
+	if (!field) return { field: 'root', message: sentence(message) };
+
+	// Field errors arrive as `key: "value" <invalid> (why)`; show just the why.
+	const why = /\((.+)\)$/.exec(message)?.[1];
+	return { field: field, message: sentence(why ?? message) };
+};
+
+const formFor = (user?: AuthUser): AccountFormValues => ({
+	confirmPassword: '',
+	currentPassword: '',
+	display_name: user?.display_name ?? '',
+	email: user?.email ?? '',
+	password: '',
+});
+
+type GroupHeadingProps = {
+	title: string;
+	description: string;
+};
+
+const GroupHeading = ({ title, description }: GroupHeadingProps) => (
+	<div className="grid gap-1">
+		<h3 className="font-semibold text-base">{title}</h3>
+		<p className="text-muted-foreground text-sm">{description}</p>
+	</div>
+);
+
+/** Divides the card's groups. */
+const GroupRule = () => (
+	<div className="-mx-4">
+		<Separator />
+	</div>
+);
+
+/**
+ * The signed-in user's own account details. Every change is confirmed with
+ * the current password; a blank new password leaves password unchanged.
+ */
+export const Account = (): ReactElement => {
+	const { user } = useAuth();
+	const queryClient = useQueryClient();
+	const form = useZodForm({
+		defaultValues: formFor(user),
+		schema: accountSchema,
+	});
+	const { errors } = form.formState;
+
+	// biome-ignore lint/correctness/useExhaustiveDependencies: form stable.
+	useEffect(() => {
+		form.reset(formFor(user));
+	}, [user]);
+
+	const { currentPassword, display_name, email, password } = useWatch({
+		control: form.control,
+	});
+	const {
+		mismatch: passwordsMismatch,
+		show: showPasswordMismatch,
+		describedBy: passwordDescribedBy,
+		errorID,
+		mismatchID,
+	} = usePasswordMismatch(form, { active: !!password, idPrefix: 'account-' });
+
+	// Against the values last loaded from the API, so reverting an edit counts
+	// as no change. The password fields confirm rather than change the account,
+	// so they are not what makes it savable.
+	const { defaultValues } = form.formState;
+	const changed =
+		(display_name ?? '') !== (defaultValues?.display_name ?? '') ||
+		(email ?? '') !== (defaultValues?.email ?? '') ||
+		!!password;
+
+	// Blur validates (useZodForm's default), so hold back 'Required.' until
+	// there is actually something to save.
+	const currentPasswordError = changed ? errors.currentPassword : undefined;
+
+	const save = useMutation({
+		mutationFn: (values: AccountFormValues) => {
+			const patch: AccountUpdateRequest = {
+				current_password: values.currentPassword,
+			};
+			if (values.display_name !== (defaultValues?.display_name ?? ''))
+				patch.display_name = values.display_name;
+			if (values.email !== (defaultValues?.email ?? ''))
+				patch.email = values.email;
+			if (values.password) patch.new_password = values.password;
+			return authAPI.updateAccount(patch);
+		},
+		onError: (error) => {
+			const { field, message } = serverError(getErrorMessage(error));
+			form.setError(field, { message: message, type: 'server' });
+			if (field !== 'root') form.setFocus(field);
+		},
+		onSuccess: (me: AuthMe) => {
+			queryClient.setQueryData(QUERY_KEYS.AUTH.ME(), me);
+			toast.success(
+				password
+					? 'Account updated - other sessions signed out'
+					: 'Account updated',
+			);
+			form.reset(formFor(me.user));
+		},
+	});
+
+	return (
+		<form
+			className="flex flex-col gap-6"
+			onSubmit={form.handleSubmit((values) => {
+				if (passwordsMismatch) return;
+				form.clearErrors('root');
+				save.mutate(values);
+			})}
+		>
+			<Card>
+				<CardContent className="grid gap-6">
+					<section className="grid gap-4">
+						<GroupHeading
+							description="How you are identified across Argus."
+							title="Profile"
+						/>
+						<div className="grid gap-4 sm:grid-cols-2">
+							<Field className="gap-2">
+								<FieldLabelWithTooltip
+									htmlFor="account-username"
+									size="sm"
+									text="Username"
+								/>
+								<Input
+									disabled
+									id="account-username"
+									readOnly
+									value={user?.username ?? ''}
+								/>
+								<FieldDescription>
+									Usernames cannot be changed.
+								</FieldDescription>
+							</Field>
+							<Field className="gap-2" data-invalid={!!errors.display_name}>
+								<FieldLabelWithTooltip
+									htmlFor="account-display-name"
+									size="sm"
+									text="Display name"
+								/>
+								<Input
+									aria-describedby={
+										errors.display_name
+											? 'account-display-name-error'
+											: undefined
+									}
+									aria-invalid={!!errors.display_name}
+									id="account-display-name"
+									{...form.register('display_name')}
+								/>
+								<FieldError
+									className="min-h-5"
+									errors={[errors.display_name]}
+									id="account-display-name-error"
+								/>
+							</Field>
+							<Field className="gap-2" data-invalid={!!errors.email}>
+								<FieldLabelWithTooltip
+									htmlFor="account-email"
+									size="sm"
+									text="Email"
+								/>
+								<Input
+									aria-describedby={
+										errors.email ? 'account-email-error' : undefined
+									}
+									aria-invalid={!!errors.email}
+									id="account-email"
+									type="email"
+									{...form.register('email')}
+								/>
+								<FieldError
+									className="min-h-5"
+									errors={[errors.email]}
+									id="account-email-error"
+								/>
+							</Field>
+						</div>
+					</section>
+
+					<GroupRule />
+
+					<section className="grid gap-4">
+						<GroupHeading
+							description="Leave blank to keep your current password. Setting a new one signs out your other sessions."
+							title="Password"
+						/>
+						<div className="grid gap-4 sm:grid-cols-2">
+							<Field
+								className="gap-2"
+								data-invalid={!!errors.password || showPasswordMismatch}
+							>
+								<FieldLabelWithTooltip
+									htmlFor="account-new-password"
+									size="sm"
+									text="New password"
+								/>
+								<MaskedInput
+									aria-describedby={passwordDescribedBy}
+									aria-invalid={!!errors.password || showPasswordMismatch}
+									autoComplete="new-password"
+									id="account-new-password"
+									valueLabel="new password"
+									{...form.register('password')}
+								/>
+								<FieldError
+									className="min-h-5"
+									errors={[errors.password]}
+									id={errorID}
+								/>
+							</Field>
+							<Field className="gap-2" data-invalid={showPasswordMismatch}>
+								<FieldLabelWithTooltip
+									htmlFor="account-confirm-password"
+									size="sm"
+									text="Confirm new password"
+								/>
+								<MaskedInput
+									aria-describedby={
+										showPasswordMismatch ? mismatchID : undefined
+									}
+									aria-invalid={showPasswordMismatch}
+									autoComplete="new-password"
+									disabled={!password}
+									id="account-confirm-password"
+									valueLabel="new password confirmation"
+									{...form.register('confirmPassword')}
+								/>
+								{showPasswordMismatch && (
+									<PasswordMismatchError id={mismatchID} />
+								)}
+							</Field>
+						</div>
+					</section>
+
+					<GroupRule />
+
+					<section className="grid gap-4">
+						<GroupHeading
+							description="Your current password is required to save any change above."
+							title="Confirm changes"
+						/>
+						{errors.root && (
+							<Alert aria-label="Account update error" variant="destructive">
+								<AlertDescription>{errors.root.message}</AlertDescription>
+							</Alert>
+						)}
+						<div className="grid gap-4 sm:grid-cols-2">
+							<Field className="gap-2" data-invalid={!!currentPasswordError}>
+								<FieldLabelWithTooltip
+									htmlFor="account-current-password"
+									required
+									size="sm"
+									text="Current password"
+								/>
+								<MaskedInput
+									aria-describedby={
+										currentPasswordError
+											? 'account-current-password-error'
+											: undefined
+									}
+									aria-invalid={!!currentPasswordError}
+									aria-required
+									autoComplete="current-password"
+									id="account-current-password"
+									valueLabel="current password"
+									{...form.register('currentPassword')}
+								/>
+								<FieldError
+									className="min-h-5"
+									errors={[currentPasswordError]}
+									id="account-current-password-error"
+								/>
+							</Field>
+						</div>
+					</section>
+				</CardContent>
+			</Card>
+
+			{/* Left, not right: the toaster occupies the bottom-right corner. */}
+			{changed && (
+				<div className="flex">
+					<Button disabled={save.isPending || !currentPassword} type="submit">
+						<TextOrLoading loading={save.isPending} text="Save changes" />
+					</Button>
+				</div>
+			)}
+		</form>
+	);
+};

--- a/web/ui/react-app/src/pages/account/profile/schema.ts
+++ b/web/ui/react-app/src/pages/account/profile/schema.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+import { MIN_PASSWORD_LENGTH, PASSWORD_LENGTH_MESSAGE } from '@/types/auth';
+import { REQUIRED_MESSAGE } from '@/utils/api/types/config-edit/validators';
+
+/** A blank password leaves the current one in place. */
+export const accountSchema = z.object({
+	confirmPassword: z.string(),
+	currentPassword: z.string().min(1, REQUIRED_MESSAGE),
+	display_name: z.string(),
+	email: z.string(),
+	password: z
+		.string()
+		.refine(
+			(value) => value === '' || value.length >= MIN_PASSWORD_LENGTH,
+			PASSWORD_LENGTH_MESSAGE,
+		),
+});
+
+export type AccountFormValues = z.infer<typeof accountSchema>;

--- a/web/ui/react-app/src/pages/index.tsx
+++ b/web/ui/react-app/src/pages/index.tsx
@@ -1,3 +1,5 @@
+export { SettingsLayout } from './account/layout';
+export { Account as AccountPage } from './account/profile';
 export { Tokens as TokensPage } from './account/tokens';
 export { Groups as GroupsPage } from './admin/groups';
 export { Users as UsersPage } from './admin/users';

--- a/web/ui/react-app/src/utils/api/auth.ts
+++ b/web/ui/react-app/src/utils/api/auth.ts
@@ -8,6 +8,7 @@ import type {
 } from '@/types/auth';
 import { API_BASE } from '@/utils/api/types/api-request';
 import type {
+	AccountUpdateRequest,
 	APITokenCreateRequest,
 	GroupCreateRequest,
 	GroupPatchRequest,
@@ -51,6 +52,13 @@ export const setup = (account: SetupRequest) =>
 		body: JSON.stringify(account),
 		method: 'POST',
 		url: `${API_BASE}/auth/setup`,
+	});
+
+export const updateAccount = (patch: AccountUpdateRequest) =>
+	fetchJSON<AuthMe>({
+		body: JSON.stringify(patch),
+		method: 'PATCH',
+		url: `${API_BASE}/auth/me`,
 	});
 
 // Users.

--- a/web/ui/react-app/src/utils/api/types/requests/auth.ts
+++ b/web/ui/react-app/src/utils/api/types/requests/auth.ts
@@ -28,6 +28,17 @@ export type SetupRequest = {
 	password: string;
 };
 
+/**
+ * PATCH /auth/me - the signed-in user changing their own account. The current
+ * password is always required; omitted fields stay unchanged.
+ */
+export type AccountUpdateRequest = {
+	current_password: string;
+	display_name?: string;
+	email?: string;
+	new_password?: string;
+};
+
 export type UserCreateRequest = {
 	username: string;
 	password: string;

--- a/web/ui/react-app/tests/auth-account.spec.ts
+++ b/web/ui/react-app/tests/auth-account.spec.ts
@@ -1,0 +1,181 @@
+import {
+	type APIRequestContext,
+	type BrowserContext,
+	expect,
+	type Page,
+	test,
+} from '@playwright/test';
+import {
+	ADMIN_PASSWORD,
+	ADMIN_USER,
+	cleanupByName,
+	cleanupStack,
+	RUN_ID,
+	signedInContext,
+} from './fixtures/auth';
+
+/**
+ * Account settings e2e specs - run only in the `chromium-auth` project,
+ * against the auth-enabled Argus instance.
+ *
+ * Scope: what a user may change about their own account at /account/profile -
+ * their profile fields, and their password. Each test owns a user of its own.
+ */
+
+const PASSWORD = 'e2e-account-password';
+const NEW_PASSWORD = 'e2e-account-password-2';
+
+test.describe('Account settings', () => {
+	let adminAPI: APIRequestContext;
+	const cleanup = cleanupStack();
+
+	/** Signs in through the login form. */
+	const signIn = async (page: Page, username: string, password: string) => {
+		await page.goto('/login');
+		await page.getByLabel('Username').fill(username);
+		await page.getByLabel('Password', { exact: true }).fill(password);
+		await page.getByRole('button', { name: 'Sign in' }).click();
+	};
+
+	/** Creates a user, registering its removal, and returns its username. */
+	const createUser = async (suffix: string) => {
+		const username = `e2e-account-${suffix}-${RUN_ID}`;
+		cleanupByName(cleanup, adminAPI, 'users', username);
+		const created = await adminAPI.post('api/v1/users', {
+			data: { password: PASSWORD, username: username },
+		});
+		expect(created.status(), `create ${username}`).toBe(201);
+		return username;
+	};
+
+	/**
+	 * A signed-in browser context for username, closed during teardown. Logs in
+	 * through the API: only the password test exercises the login form itself.
+	 */
+	const sessionFor = async (
+		browser: Parameters<typeof signedInContext>[0],
+		username: string,
+		password: string,
+	): Promise<BrowserContext> => {
+		const context = await signedInContext(browser, username, password);
+		cleanup.add(() => context.close());
+		return context;
+	};
+
+	test.beforeAll(async ({ browser }) => {
+		const adminContext = await signedInContext(
+			browser,
+			ADMIN_USER,
+			ADMIN_PASSWORD,
+		);
+		cleanup.add(() => adminContext.close());
+		adminAPI = adminContext.request;
+	});
+
+	test.afterAll(async () => {
+		await cleanup.run();
+	});
+
+	test('renames the display name and email', async ({ browser }) => {
+		const username = await createUser('profile');
+		const context = await sessionFor(browser, username, PASSWORD);
+		const page = await context.newPage();
+
+		await page.goto('/account/profile');
+
+		// The username identifies the account, so it is shown but not editable.
+		await expect(page.getByLabel('Username')).toBeDisabled();
+		await expect(page.getByLabel('Username')).toHaveValue(username);
+
+		// Saving needs the current password, whatever the change.
+		await page.getByLabel('Display name').fill('Renamed User');
+		await page.getByLabel('Email').fill('renamed@example.com');
+		await expect(
+			page.getByRole('button', { name: 'Save changes' }),
+		).toBeDisabled();
+
+		await page
+			.getByRole('textbox', { exact: true, name: 'Current password' })
+			.fill(PASSWORD);
+		await page.getByRole('button', { name: 'Save changes' }).click();
+		await expect(page.getByText('Account updated')).toBeVisible();
+
+		// The header picks the new name up without a reload.
+		await page.getByRole('button', { name: 'User menu' }).click();
+		await expect(page.getByText('Renamed User')).toBeVisible();
+		await page.keyboard.press('Escape');
+
+		// AND: the change survives a reload, so it reached the API.
+		await page.reload();
+		await expect(page.getByLabel('Display name')).toHaveValue('Renamed User');
+		await expect(page.getByLabel('Email')).toHaveValue('renamed@example.com');
+	});
+
+	test('form rejects a wrong current password', async ({ browser }) => {
+		const username = await createUser('wrong-pw');
+		const context = await sessionFor(browser, username, PASSWORD);
+		const page = await context.newPage();
+
+		await page.goto('/account/profile');
+		await page.getByLabel('Display name').fill('Nice Try');
+		await page
+			.getByRole('textbox', { exact: true, name: 'Current password' })
+			.fill('not-my-password');
+		await page.getByRole('button', { name: 'Save changes' }).click();
+
+		// The error belongs to the field, and the session survives it.
+		await expect(page.locator('#account-current-password-error')).toHaveText(
+			'Current password is incorrect.',
+		);
+		await expect(page).toHaveURL(/\/account\/profile/);
+
+		// AND: nothing was saved.
+		await page.reload();
+		await expect(page.getByLabel('Display name')).toHaveValue('');
+	});
+
+	test('changes the password, and only the new one works afterwards', async ({
+		browser,
+	}) => {
+		const username = await createUser('password');
+		const context = await sessionFor(browser, username, PASSWORD);
+		const page = await context.newPage();
+
+		// WHEN: the user sets a new password.
+		await page.goto('/account/profile');
+		await page
+			.getByRole('textbox', { exact: true, name: 'New password' })
+			.fill(NEW_PASSWORD);
+		await page
+			.getByRole('textbox', { exact: true, name: 'Confirm new password' })
+			.fill(NEW_PASSWORD);
+		await page
+			.getByRole('textbox', { exact: true, name: 'Current password' })
+			.fill(PASSWORD);
+		await page.getByRole('button', { name: 'Save changes' }).click();
+
+		// THEN: it succeeds, and this session survives its own change.
+		await expect(
+			page.getByText('Account updated - other sessions signed out'),
+		).toBeVisible();
+		await page.goto('/account/profile');
+		await expect(page.getByLabel('Username')).toHaveValue(username);
+
+		// WHEN: they log out.
+		await page.getByRole('button', { name: 'User menu' }).click();
+		await page.getByRole('menuitem', { name: 'Log out' }).click();
+		await expect(page).toHaveURL(/\/login/);
+
+		// THEN: the old password no longer gets them in.
+		await signIn(page, username, PASSWORD);
+		await expect(
+			page.getByText(/invalid credentials|too many login attempts/),
+		).toBeVisible();
+		await expect(page).toHaveURL(/\/login/);
+
+		// AND: the new one does - landing back on the page they logged out of.
+		await signIn(page, username, NEW_PASSWORD);
+		await expect(page).not.toHaveURL(/\/login/);
+		await expect(page.getByRole('button', { name: 'User menu' })).toBeVisible();
+	});
+});

--- a/web/ui/react-app/tests/auth-permissions.spec.ts
+++ b/web/ui/react-app/tests/auth-permissions.spec.ts
@@ -606,9 +606,9 @@ test.describe('Permission gating', () => {
 			try {
 				await page.goto('/approvals');
 				await page.getByRole('button', { name: 'User menu' }).click();
-				// Tokens are per-user, so everyone keeps them.
+				// Settings are per-user, so everyone keeps them.
 				await expect(
-					page.getByRole('menuitem', { name: 'API Tokens' }),
+					page.getByRole('menuitem', { name: 'Settings' }),
 				).toBeVisible();
 				for (const entry of ['Users', 'Groups']) {
 					await expect

--- a/web/ui/react-app/tests/auth.spec.ts
+++ b/web/ui/react-app/tests/auth.spec.ts
@@ -114,8 +114,8 @@ test.describe('Authentication', () => {
 		for (const [parent, landing] of [
 			['/admin', '/admin/users'],
 			['/admin/', '/admin/users'],
-			['/account', '/account/tokens'],
-			['/account/', '/account/tokens'],
+			['/account', '/account/profile'],
+			['/account/', '/account/profile'],
 		]) {
 			await page.goto(parent);
 			await expect(page, `${parent} lands on ${landing}`).toHaveURL(


### PR DESCRIPTION
Adds PATCH /api/v1/auth/me and a /account/settings area reached from the user menu, with Account and API Tokens sections. Users can change their display name, email and password. A new password signs out their other sessions.

<img width="1710" height="961" alt="image" src="https://github.com/user-attachments/assets/bd97dd76-5ae8-4f8d-9e9a-2dc4d3c42c5f" />
<img width="412" height="891" alt="image" src="https://github.com/user-attachments/assets/7528cabb-749f-4ef9-a36d-163fc2ee7f64" />

<img width="412" height="273" alt="image" src="https://github.com/user-attachments/assets/bfa0b401-e9b0-4a70-822c-4533fbbf9743" />