### PR TITLE
fix(ui): toast command/webhook send failures instead of spinning forever

### DIFF
--- a/web/ui/react-app/src/modals/action-release.tsx
+++ b/web/ui/react-app/src/modals/action-release.tsx
@@ -1,6 +1,7 @@
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { formatRelative } from 'date-fns';
 import { useCallback, useEffect, useMemo, useReducer } from 'react';
+import { toast } from 'sonner';
 import { pluralise } from '@/components/generic/util';
 import { ModalList } from '@/components/modals/action-release/list';
 import { Button } from '@/components/ui/button';
@@ -19,7 +20,7 @@ import useModal from '@/hooks/use-modal';
 import { QUERY_KEYS } from '@/lib/query-keys';
 import reducerActionModal from '@/reducers/action-release';
 import type { WebSocketResponse } from '@/types/websocket';
-import { dateIsAfterNow, isEmptyObject } from '@/utils';
+import { beautifyGoErrors, dateIsAfterNow, isEmptyObject } from '@/utils';
 import { mapRequest } from '@/utils/api/types/api-request-handler';
 import type {
 	ActionAPIType,
@@ -28,6 +29,7 @@ import type {
 	WebHookSummaryListType,
 	WebHookSummaryType,
 } from '@/utils/api/types/config/summary';
+import { getErrorMessage } from '@/utils/errors';
 import { isNonEmptyObject } from '@/utils/is-empty';
 
 /**
@@ -81,6 +83,31 @@ const isActionRunnable = (
 	// Runnable if not scheduled for the future,
 	// and either all have succeeded, or this hasn't.
 	return !isScheduledForFuture && allSucceededOrThisFailed;
+};
+
+/* The target of a send, and how it was addressed. */
+type SendVariables = {
+	target: string;
+	serviceID: string;
+	isWebHook: boolean;
+	unspecificTarget: boolean;
+};
+
+/* What a send dispatched as 'sending', so a failure can undo it. */
+type SendContext = {
+	commandData: CommandSummaryListType;
+	serviceID: string;
+	webhookData: WebHookSummaryListType;
+};
+
+/**
+ * @param data - The variables the failed send was given.
+ * @returns The toast title for a send that failed before reaching the server.
+ */
+const sendFailureTitle = (data: SendVariables): string => {
+	if (data.target === 'ARGUS_SKIP') return 'Failed to skip release';
+	if (data.unspecificTarget) return 'Failed to send';
+	return `Failed to send ${data.isWebHook ? 'WebHook' : 'Command'} '${data.target}'`;
 };
 
 /**
@@ -218,18 +245,35 @@ const ActionReleaseModal = () => {
 		};
 	}, [modal.actionType, modal.service.id, modalData]);
 
-	const { mutate } = useMutation({
-		mutationFn: (data: {
-			target: string;
-			serviceID: string;
-			isWebHook: boolean;
-			unspecificTarget: boolean;
-		}) =>
+	const { mutate } = useMutation<
+		null,
+		Error,
+		SendVariables,
+		SendContext | undefined
+	>({
+		mutationFn: (data) =>
 			mapRequest('ACTION_SEND', {
 				serviceID: data.serviceID,
 				target: data.target,
 			}),
-		onMutate: (data) => {
+		onError: (error, data, context) => {
+			// No WebSocket event follows a request that never reached the server,
+			// so the sending state has to be undone here.
+			if (context)
+				setModalData({
+					command_data: context.commandData,
+					page: 'APPROVALS',
+					service_data: { id: context.serviceID },
+					sub_type: 'SEND_FAILED',
+					type: 'ACTION',
+					webhook_data: context.webhookData,
+				});
+
+			toast.error(sendFailureTitle(data), {
+				description: beautifyGoErrors(getErrorMessage(error)),
+			});
+		},
+		onMutate: (data): SendContext | undefined => {
 			if (data.target === 'ARGUS_SKIP') return;
 
 			let commandData: CommandSummaryListType = {};
@@ -247,19 +291,21 @@ const ActionReleaseModal = () => {
 				// Send these commands.
 				for (const [commandID, command] of Object.entries(modalData.commands)) {
 					if (isActionRunnable(command, allSuccessful))
-						commandData[commandID] = {};
+						commandData[commandID] = command;
 				}
 
 				// Send these webhooks.
 				for (const [webhookID, webhook] of Object.entries(modalData.webhooks)) {
 					if (isActionRunnable(webhook, allSuccessful))
-						webhookData[webhookID] = {};
+						webhookData[webhookID] = webhook;
 				}
 				// Targeting specific command/webhook.
 			} else if (data.isWebHook) {
-				webhookData = { [data.target.slice('webhook_'.length)]: {} };
+				const webhookID = data.target.slice('webhook_'.length);
+				webhookData = { [webhookID]: modalData.webhooks[webhookID] ?? {} };
 			} else {
-				commandData = { [data.target.slice('command_'.length)]: {} };
+				const commandID = data.target.slice('command_'.length);
+				commandData = { [commandID]: modalData.commands[commandID] ?? {} };
 			}
 
 			setModalData({
@@ -270,6 +316,8 @@ const ActionReleaseModal = () => {
 				type: 'ACTION',
 				webhook_data: webhookData,
 			});
+
+			return { commandData, serviceID: data.serviceID, webhookData };
 		},
 	});
 

--- a/web/ui/react-app/src/pages/account/profile/index.tsx
+++ b/web/ui/react-app/src/pages/account/profile/index.tsx
@@ -297,11 +297,6 @@ export const Account = (): ReactElement => {
 							description="Your current password is required to save any change above."
 							title="Confirm changes"
 						/>
-						{errors.root && (
-							<Alert aria-label="Account update error" variant="destructive">
-								<AlertDescription>{errors.root.message}</AlertDescription>
-							</Alert>
-						)}
 						<div className="grid gap-4 sm:grid-cols-2">
 							<Field className="gap-2" data-invalid={!!currentPasswordError}>
 								<FieldLabelWithTooltip
@@ -330,6 +325,11 @@ export const Account = (): ReactElement => {
 								/>
 							</Field>
 						</div>
+						{errors.root && (
+							<Alert aria-label="Account update error" variant="destructive">
+								<AlertDescription>{errors.root.message}</AlertDescription>
+							</Alert>
+						)}
 					</section>
 				</CardContent>
 			</Card>

--- a/web/ui/react-app/src/reducers/action-release.ts
+++ b/web/ui/react-app/src/reducers/action-release.ts
@@ -1,7 +1,11 @@
 // noinspection JSUnfilteredForInLoop
 
 import type { WebSocketResponse } from '@/types/websocket';
-import type { ActionModalData } from '@/utils/api/types/config/summary';
+import type {
+	ActionModalData,
+	CommandSummaryListType,
+	WebHookSummaryListType,
+} from '@/utils/api/types/config/summary';
 
 /**
  * A reducer that handles actions on the action modal.
@@ -31,10 +35,10 @@ const reducerActionModal = (
 				if (action.webhook_data)
 					for (const webhookID in action.webhook_data) {
 						// Remove them from the sending list.
-						newState.sentWH.splice(
-							newState.sentWH.indexOf(`${action.service_data.id} ${webhookID}`),
-							1,
+						const index = newState.sentWH.indexOf(
+							`${action.service_data.id} ${webhookID}`,
 						);
+						if (index !== -1) newState.sentWH.splice(index, 1);
 
 						// Record the success/fail (if current service in modal).
 						if (
@@ -50,10 +54,10 @@ const reducerActionModal = (
 				if (action.command_data)
 					for (const command in action.command_data) {
 						// Remove them from the sending list.
-						newState.sentC.splice(
-							newState.sentC.indexOf(`${action.service_data.id} ${command}`),
-							1,
+						const index = newState.sentC.indexOf(
+							`${action.service_data.id} ${command}`,
 						);
+						if (index !== -1) newState.sentC.splice(index, 1);
 
 						// Record the success/fail (if current service in modal).
 						if (
@@ -73,6 +77,7 @@ const reducerActionModal = (
 
 		// REFRESH
 		// RESET
+		// SEND_FAILED
 		// SENDING
 		case 'ACTION':
 			switch (action.sub_type) {
@@ -85,6 +90,25 @@ const reducerActionModal = (
 					newState.commands = {};
 					newState.webhooks = {};
 					break;
+				case 'SEND_FAILED': {
+					// The request never reached the server, so no EVENT will arrive
+					// to clear the sending state - undo it here.
+					const serviceID = action.service_data?.id;
+					const unsend = (
+						sent: string[],
+						items: CommandSummaryListType | WebHookSummaryListType,
+						data?: CommandSummaryListType | WebHookSummaryListType,
+					) => {
+						for (const id in data) {
+							const index = sent.indexOf(`${serviceID} ${id}`);
+							if (index !== -1) sent.splice(index, 1);
+							if (items[id]) items[id] = data[id];
+						}
+					};
+					unsend(newState.sentC, newState.commands, action.command_data);
+					unsend(newState.sentWH, newState.webhooks, action.webhook_data);
+					break;
+				}
 				case 'SENDING':
 					// Commands.
 					if (action.command_data)

--- a/web/ui/react-app/src/types/websocket.ts
+++ b/web/ui/react-app/src/types/websocket.ts
@@ -8,7 +8,7 @@ export type WebSocketResponse =
 	| {
 			page: 'APPROVALS';
 			type: 'ACTION';
-			sub_type: 'SENDING' | 'REFRESH' | 'RESET';
+			sub_type: 'SENDING' | 'SEND_FAILED' | 'REFRESH' | 'RESET';
 			service_data?: ServiceSummary;
 			command_data?: CommandSummaryListType;
 			webhook_data?: WebHookSummaryListType;

--- a/web/ui/react-app/tests/webhook.spec.ts
+++ b/web/ui/react-app/tests/webhook.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, type Page, type Route, test } from '@playwright/test';
 import { openDashboardInEditMode, serviceCard } from './fixtures/dashboard';
 import {
 	createService,
@@ -8,6 +8,34 @@ import {
 	withProject,
 } from './fixtures/service';
 import { WEBHOOK_GITHUB } from './fixtures/test-endpoints';
+
+/* The send endpoint, which a read-only instance refuses with a 403. */
+const ACTIONS_ROUTE = '**/api/v1/service/actions*';
+
+/**
+ * Refuses sends the way the demo guard does, leaving reads alone.
+ *
+ * @param route - The intercepted route.
+ */
+const refuseSends = async (route: Route) => {
+	if (route.request().method() !== 'POST') return route.fallback();
+
+	await route.fulfill({
+		body: JSON.stringify({ message: 'Read-only demo instance.' }),
+		contentType: 'application/json; charset=utf-8',
+		status: 403,
+	});
+};
+
+/**
+ * @param page - The page to find the toast on.
+ * @param text - Text the toast must contain.
+ * @returns The error toast containing `text`.
+ */
+const errorToast = (page: Page, text: string) =>
+	page.locator('[data-sonner-toast][data-type="error"]').filter({
+		hasText: text,
+	});
 
 test.describe('WebHook actions', () => {
 	// Scoped to this test's ID so its afterEach can't race the other test's
@@ -140,12 +168,49 @@ test.describe('WebHook actions', () => {
 			testInfo.project.name,
 		);
 
-		// AND: clicks "Send" for the WebHook.
 		const sendButton = dialog.getByRole('button', {
 			exact: true,
 			name: 'Send',
 		});
 		await expect(sendButton).toBeVisible();
+
+		// AND: the server refuses sends, as it does for a read-only demo user.
+		await page.route(ACTIONS_ROUTE, refuseSends);
+
+		// WHEN: the user confirms the send for every WebHook.
+		await dialog.locator('#modal-action').click();
+
+		// THEN: the modal closes and the refusal is surfaced as a toast.
+		await expect(dialog).not.toBeVisible();
+		const sendAllToast = errorToast(page, 'Failed to send');
+		await expect(sendAllToast.first()).toBeVisible();
+		await expect(sendAllToast.first()).toContainText(
+			'Read-only demo instance.',
+		);
+
+		// AND: reopening the modal shows nothing stuck sending.
+		await card.getByRole('button', { name: /approve|resend/i }).click();
+		await expect(dialog).toBeVisible();
+		await expect(sendButton).toBeEnabled();
+		await expect(dialog.locator('.animate-spin')).toHaveCount(0);
+
+		// WHEN: the user sends the single WebHook, still refused.
+		await sendButton.click();
+
+		// THEN: the refusal names the WebHook, and its spinner stops.
+		const sendOneToast = errorToast(page, 'Failed to send WebHook');
+		await expect(sendOneToast).toBeVisible();
+		await expect(sendOneToast).toContainText('Read-only demo instance.');
+		await expect(dialog.locator('.animate-spin')).toHaveCount(0);
+		await expect(sendButton).toBeEnabled();
+		await screenshot(
+			page,
+			`webhook/${baseID}/03-send-refused`,
+			testInfo.project.name,
+		);
+
+		// WHEN: clicks "Send" for the WebHook, with the server accepting sends again.
+		await page.unroute(ACTIONS_ROUTE, refuseSends);
 		await sendButton.click();
 
 		// THEN: the WebHook send fails (real network call - the receiver
@@ -155,7 +220,7 @@ test.describe('WebHook actions', () => {
 		});
 		await screenshot(
 			page,
-			`webhook/${baseID}/03-send-failed`,
+			`webhook/${baseID}/04-send-failed`,
 			testInfo.project.name,
 		);
 
@@ -174,7 +239,7 @@ test.describe('WebHook actions', () => {
 		await expect(page.getByText(/can resend/i).first()).toBeVisible();
 		await screenshot(
 			page,
-			`webhook/${baseID}/04-send-blocked`,
+			`webhook/${baseID}/05-send-blocked`,
 			testInfo.project.name,
 		);
 


### PR DESCRIPTION
<img width="907" height="504" alt="image" src="https://github.com/user-attachments/assets/51268aa6-fc45-411f-a5aa-f347482a0075" />
previously: no toast/indication of failure. spinner in button just span forever