### PR TITLE
feat(auth): per-user dashboard display defaults

### DIFF
--- a/auth/store/errors_test.go
+++ b/auth/store/errors_test.go
@@ -512,6 +512,60 @@ func TestStore__faultInjection(t *testing.T) {
 			},
 		},
 
+		// preferences.go
+		{
+			name:    "PreferencesForUser/load fails",
+			pattern: `SELECT hide, view, timestamps`,
+			invoke: func(t *testing.T, store *Store) error {
+				_, err := store.PreferencesForUser(t.Context(), "any")
+				return err
+			},
+		},
+		{
+			name:    "SetPreferences/upsert fails",
+			pattern: `INSERT INTO user_preferences`,
+			invoke: func(t *testing.T, store *Store) error {
+				_, err := store.SetPreferences(t.Context(), "any", DashboardPreferences{
+					View: ViewTable,
+				})
+				return err
+			},
+		},
+		{
+			name:    "SetPreferences/zero set deletes, and that fails",
+			pattern: `DELETE FROM user_preferences WHERE user_id`,
+			invoke: func(t *testing.T, store *Store) error {
+				_, err := store.SetPreferences(t.Context(), "any", DashboardPreferences{})
+				return err
+			},
+		},
+		{
+			name:    "DeletePreferences/delete fails",
+			pattern: `DELETE FROM user_preferences WHERE user_id`,
+			invoke: func(t *testing.T, store *Store) error {
+				return store.DeletePreferences(t.Context(), "any")
+			},
+		},
+		{
+			name: "DeleteUser/preferences cascade fails",
+			setup: func(t *testing.T, store *Store) {
+				mustCreateUser(t, store, "target", "")
+			},
+			pattern: `DELETE FROM user_preferences WHERE user_id`,
+			invoke: func(t *testing.T, store *Store) error {
+				return store.DeleteUser(t.Context(), mustUserID(t, store, "target"))
+			},
+			wantRolledBack: func(t *testing.T, store *Store) {
+				// The cascade runs before the user row is removed.
+				if got := countRows(t, store, "users"); got != 1 {
+					t.Errorf(
+						"%s\nusers row lost to a failed preferences cascade\ngot:  %d\nwant: 1",
+						packageName, got,
+					)
+				}
+			},
+		},
+
 		{
 			name:    "migrate/version read fails",
 			pattern: `SELECT version FROM schema_migrations`,

--- a/auth/store/preferences.go
+++ b/auth/store/preferences.go
@@ -1,0 +1,246 @@
+// Copyright [2026] [Argus]
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/release-argus/Argus/util/polymorphic"
+)
+
+// The 'hide' filters a user can default to.
+const (
+	HideUpToDate  = "up_to_date"
+	HideUpdatable = "updatable"
+	HideSkipped   = "skipped"
+	HideInactive  = "inactive"
+)
+
+// The dashboard layouts a user can default to.
+const (
+	ViewGrid  = "grid"
+	ViewTable = "table"
+)
+
+// The service card timestamps a user can default to showing.
+const (
+	TimestampDeployed = "deployed"
+	TimestampFound    = "found"
+	TimestampQueried  = "queried"
+)
+
+// The accepted values of each [DashboardPreferences] field, in the order they
+// are stored.
+var (
+	hideNames      = []string{HideUpToDate, HideUpdatable, HideSkipped, HideInactive}
+	viewNames      = []string{ViewGrid, ViewTable}
+	timestampNames = []string{TimestampDeployed, TimestampFound, TimestampQueried}
+)
+
+// DashboardPreferences are a user's saved dashboard preferences.
+// A zero field inherits the built-in default; an empty (non-nil) slice is an
+// explicit "none".
+type DashboardPreferences struct {
+	Hide       []string `json:"hide,omitzero"`
+	View       string   `json:"view,omitzero"`
+	Timestamps []string `json:"timestamps,omitzero"`
+}
+
+// CheckValues validates the fields of the receiver,
+// wrapping [ErrInvalidPreference] so callers can answer 400.
+func (p DashboardPreferences) CheckValues() error {
+	var errs []error
+
+	for _, field := range []struct {
+		key    string
+		values []string
+		valid  []string
+	}{
+		{key: "hide", values: p.Hide, valid: hideNames},
+		{key: "timestamps", values: p.Timestamps, valid: timestampNames},
+	} {
+		var invalid []string
+		for _, value := range field.values {
+			if !slices.Contains(field.valid, value) {
+				invalid = append(invalid, value)
+			}
+		}
+		if invalid == nil {
+			continue
+		}
+		errs = append(errs, polymorphic.ErrInvalidValues{
+			Key:     field.key,
+			Values:  invalid,
+			Allowed: field.valid,
+		})
+	}
+
+	if p.View != "" && !slices.Contains(viewNames, p.View) {
+		errs = append(errs, polymorphic.ErrInvalidType{
+			Key:     "view",
+			Value:   p.View,
+			Allowed: viewNames,
+		})
+	}
+
+	if len(errs) == 0 {
+		return nil
+	}
+	return fmt.Errorf(
+		"%w: %w",
+		ErrInvalidPreference, errors.Join(errs...),
+	)
+}
+
+// IsZero reports whether no preferences are set (overridden).
+func (p DashboardPreferences) IsZero() bool {
+	return p.Hide == nil && p.View == "" && p.Timestamps == nil
+}
+
+// PreferencesForUser returns userID's saved preferences,
+// or (nil, nil) when they have none.
+func (s *Store) PreferencesForUser(
+	ctx context.Context,
+	userID string,
+) (*DashboardPreferences, error) {
+	var hide, view, timestamps sql.NullString
+	if err := s.db.QueryRowContext(ctx, `
+		SELECT hide, view, timestamps
+		FROM user_preferences
+		WHERE user_id = ?;`,
+		userID,
+	).Scan(&hide, &view, &timestamps); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil //nolint:nilnil
+		}
+		return nil, fmt.Errorf("load preferences: %w", err)
+	}
+
+	return &DashboardPreferences{
+		Hide:       canonical(decodeNames(hide), hideNames),
+		View:       knownView(view.String),
+		Timestamps: canonical(decodeNames(timestamps), timestampNames),
+	}, nil
+}
+
+// knownView returns view when it is a layout this build knows, else empty.
+func knownView(view string) string {
+	if slices.Contains(viewNames, view) {
+		return view
+	}
+	return ""
+}
+
+// SetPreferences replaces userID's saved preferences, returning them as stored.
+// Zero fields are stored as inheriting the built-in default.
+// Values outside the catalogues are an error.
+func (s *Store) SetPreferences(
+	ctx context.Context,
+	userID string,
+	prefs DashboardPreferences,
+) (*DashboardPreferences, error) {
+	if err := prefs.CheckValues(); err != nil {
+		return nil, err
+	}
+
+	// Setting nothing is discarding.
+	if prefs.IsZero() {
+		return nil, s.DeletePreferences(ctx, userID)
+	}
+
+	hide := canonical(prefs.Hide, hideNames)
+	timestamps := canonical(prefs.Timestamps, timestampNames)
+
+	now := timeNow().Format(timeFormat)
+	if _, err := s.db.ExecContext(ctx, `
+		INSERT INTO user_preferences (
+			user_id,
+			hide,
+			view,
+			timestamps,
+			created_at,
+			updated_at
+		)
+		VALUES (?, ?, ?, ?, ?, ?)
+		ON CONFLICT(user_id) DO UPDATE SET
+			hide       = excluded.hide,
+			view       = excluded.view,
+			timestamps = excluded.timestamps,
+			updated_at = excluded.updated_at;`,
+		userID,
+		encodeNames(hide),
+		sql.NullString{String: prefs.View, Valid: prefs.View != ""},
+		encodeNames(timestamps),
+		now,
+		now,
+	); err != nil {
+		return nil, fmt.Errorf("set preferences: %w", err)
+	}
+
+	return &DashboardPreferences{
+		Hide:       hide,
+		View:       prefs.View,
+		Timestamps: timestamps,
+	}, nil
+}
+
+// DeletePreferences drops userID's saved preferences, returning them to the
+// built-in defaults.
+func (s *Store) DeletePreferences(ctx context.Context, userID string) error {
+	if _, err := s.db.ExecContext(ctx,
+		`DELETE FROM user_preferences WHERE user_id = ?;`, userID,
+	); err != nil {
+		return fmt.Errorf("delete preferences: %w", err)
+	}
+	return nil
+}
+
+// canonical filters names down to the catalogue, in catalogue order, for stable
+// ordering and deduplication. A nil list stays nil.
+func canonical(names []string, catalogue []string) []string {
+	if names == nil {
+		return nil
+	}
+
+	kept := make([]string, 0, len(catalogue))
+	for _, name := range catalogue {
+		if slices.Contains(names, name) {
+			kept = append(kept, name)
+		}
+	}
+	return kept
+}
+
+// encodeNames renders a canonical name list for storage:
+// NULL when unset, else the names joined.
+func encodeNames(names []string) sql.NullString {
+	return sql.NullString{String: strings.Join(names, ","), Valid: names != nil}
+}
+
+// decodeNames reverses [encodeNames].
+func decodeNames(column sql.NullString) []string {
+	if !column.Valid {
+		return nil
+	}
+	if column.String == "" {
+		return []string{}
+	}
+	return strings.Split(column.String, ",")
+}

--- a/auth/store/preferences.go
+++ b/auth/store/preferences.go
@@ -93,7 +93,7 @@ func (p DashboardPreferences) CheckValues() error {
 	}
 
 	if p.View != "" && !slices.Contains(viewNames, p.View) {
-		errs = append(errs, polymorphic.ErrInvalidType{
+		errs = append(errs, polymorphic.ErrInvalidValue{
 			Key:     "view",
 			Value:   p.View,
 			Allowed: viewNames,

--- a/auth/store/preferences_test.go
+++ b/auth/store/preferences_test.go
@@ -1,0 +1,514 @@
+// Copyright [2026] [Argus]
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build unit
+
+package store
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/release-argus/Argus/internal/test"
+	"github.com/release-argus/Argus/util"
+	"github.com/release-argus/Argus/util/errfmt"
+)
+
+func TestStore_Preferences__roundTrip(t *testing.T) {
+	// GIVEN: a Store with a user who has saved no preferences.
+	store := testStore(t)
+	user := mustCreateUser(t, store, "argus", "")
+
+	prefix := fmt.Sprintf("%s\npreferences round-trip", packageName)
+
+	// WHEN: their preferences are read.
+	got, err := store.PreferencesForUser(t.Context(), user.ID)
+
+	// THEN: they have none.
+	if err != nil || got != nil {
+		t.Fatalf(
+			"%s expected no preferences\ngot:  %+v, err=%v\nwant: nil, nil",
+			prefix, got, err,
+		)
+	}
+
+	// WHEN: preferences are saved, out of catalogue order and with a duplicate.
+	want := DashboardPreferences{
+		Hide:       []string{HideInactive, HideUpToDate, HideInactive},
+		View:       ViewTable,
+		Timestamps: []string{TimestampQueried, TimestampDeployed},
+	}
+	stored, err := store.SetPreferences(t.Context(), user.ID, want)
+	if err != nil {
+		t.Fatalf(
+			"%s SetPreferences failed: %v",
+			prefix, err,
+		)
+	}
+
+	// AND: it reports what it stored, so a caller need not re-read.
+	if testErr := test.AssertSlicesEqual(
+		t, stored.Hide, []string{HideUpToDate, HideInactive}, prefix, "stored hide",
+	); testErr != nil {
+		t.Error(testErr)
+	}
+	if testErr := test.AssertSlicesEqual(
+		t, stored.Timestamps, []string{TimestampDeployed, TimestampQueried}, prefix, "stored timestamps",
+	); testErr != nil {
+		t.Error(testErr)
+	}
+
+	got, err = store.PreferencesForUser(t.Context(), user.ID)
+	if err != nil {
+		t.Fatalf(
+			"%s PreferencesForUser failed: %v",
+			prefix, err,
+		)
+	}
+
+	// THEN: they come back deduplicated, in catalogue order.
+	if testErr := test.AssertSlicesEqual(
+		t, got.Hide, []string{HideUpToDate, HideInactive}, prefix, "hide",
+	); testErr != nil {
+		t.Error(testErr)
+	}
+	if testErr := test.AssertSlicesEqual(
+		t, got.Timestamps, []string{TimestampDeployed, TimestampQueried}, prefix, "timestamps",
+	); testErr != nil {
+		t.Error(testErr)
+	}
+	if got.View != ViewTable {
+		t.Errorf(
+			"%s view mismatch\ngot:  %q\nwant: %q",
+			prefix, got.View, ViewTable,
+		)
+	}
+
+	// AND: saving again replaces the row rather than adding one.
+	if _, err := store.SetPreferences(t.Context(), user.ID, DashboardPreferences{
+		Hide:       []string{},
+		View:       ViewGrid,
+		Timestamps: []string{TimestampFound},
+	}); err != nil {
+		t.Fatalf(
+			"%s second SetPreferences failed: %v",
+			prefix, err,
+		)
+	}
+	if got := countRows(t, store, "user_preferences"); got != 1 {
+		t.Errorf(
+			"%s row count mismatch\ngot:  %d\nwant: 1",
+			prefix, got,
+		)
+	}
+	got, err = store.PreferencesForUser(t.Context(), user.ID)
+	if err != nil {
+		t.Fatalf(
+			"%s PreferencesForUser failed: %v",
+			prefix, err,
+		)
+	}
+
+	// AND: an explicitly empty list stays empty rather than reverting to nil.
+	if testErr := test.AssertSlicesEqual(
+		t, got.Hide, []string{}, prefix, "hide",
+	); testErr != nil {
+		t.Error(testErr)
+	}
+	if testErr := test.AssertSlicesEqual(
+		t, got.Timestamps, []string{TimestampFound}, prefix, "timestamps",
+	); testErr != nil {
+		t.Error(testErr)
+	}
+
+	// AND: DeletePreferences returns them to inheriting everything.
+	if err := store.DeletePreferences(t.Context(), user.ID); err != nil {
+		t.Fatalf(
+			"%s DeletePreferences failed: %v",
+			prefix, err,
+		)
+	}
+	got, err = store.PreferencesForUser(t.Context(), user.ID)
+	if err != nil || got != nil {
+		t.Errorf(
+			"%s preferences should be gone\ngot:  %+v, err=%v\nwant: nil, nil",
+			prefix, got, err,
+		)
+	}
+
+	// AND: deleting again is not an error.
+	if err := store.DeletePreferences(t.Context(), user.ID); err != nil {
+		t.Errorf(
+			"%s second DeletePreferences failed: %v",
+			prefix, err,
+		)
+	}
+}
+
+func TestStore_Preferences__nilFieldsInherit(t *testing.T) {
+	// GIVEN: preferences with some fields set.
+	tests := []struct {
+		name           string
+		saved          DashboardPreferences
+		wantHide       []string
+		wantView       string
+		wantTimestamps []string
+	}{
+		{
+			name:     "layout alone",
+			saved:    DashboardPreferences{View: ViewTable},
+			wantView: ViewTable,
+		},
+		{
+			name:     "filters alone",
+			saved:    DashboardPreferences{Hide: []string{HideSkipped}},
+			wantHide: []string{HideSkipped},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			store := testStore(t)
+			user := mustCreateUser(t, store, "argus", "")
+
+			prefix := fmt.Sprintf("%s\npreferences with nil fields", packageName)
+
+			// WHEN: they are saved and read back.
+			if _, err := store.SetPreferences(t.Context(), user.ID, tc.saved); err != nil {
+				t.Fatalf(
+					"%s SetPreferences failed: %v",
+					prefix, err,
+				)
+			}
+			got, err := store.PreferencesForUser(t.Context(), user.ID)
+			if err != nil {
+				t.Fatalf(
+					"%s PreferencesForUser failed: %v",
+					prefix, err,
+				)
+			}
+
+			// THEN: the fields left unset come back nil, so they keep inheriting.
+			if testErr := test.AssertSlicesEqual(
+				t, got.Hide, tc.wantHide, prefix, "hide",
+			); testErr != nil {
+				t.Error(testErr)
+			}
+			if testErr := test.AssertSlicesEqual(
+				t, got.Timestamps, tc.wantTimestamps, prefix, "timestamps",
+			); testErr != nil {
+				t.Error(testErr)
+			}
+			if got.View != tc.wantView {
+				t.Errorf(
+					"%s view mismatch\ngot:  %q\nwant: %q",
+					prefix, got.View, tc.wantView,
+				)
+			}
+		})
+	}
+}
+
+func TestStore_Preferences__deletedWithTheirUser(t *testing.T) {
+	// GIVEN: a Store with two users, both holding preferences.
+	store := testStore(t)
+	target := mustCreateUser(t, store, "target", "")
+	other := mustCreateUser(t, store, "other", "")
+
+	prefix := fmt.Sprintf("%s\npreferences cascade", packageName)
+
+	for _, user := range []string{target.ID, other.ID} {
+		if _, err := store.SetPreferences(t.Context(), user, DashboardPreferences{
+			View: ViewTable,
+		}); err != nil {
+			t.Fatalf(
+				"%s SetPreferences failed: %v",
+				prefix, err,
+			)
+		}
+	}
+
+	// WHEN: one user is deleted.
+	if err := store.DeleteUser(t.Context(), target.ID); err != nil {
+		t.Fatalf(
+			"%s DeleteUser failed: %v",
+			prefix, err,
+		)
+	}
+
+	// THEN: their preferences go with them, and nobody else's do.
+	if got, err := store.PreferencesForUser(t.Context(), target.ID); err != nil || got != nil {
+		t.Errorf(
+			"%s preferences outlived their user\ngot:  %+v, err=%v\nwant: nil, nil",
+			prefix, got, err,
+		)
+	}
+	if got, err := store.PreferencesForUser(t.Context(), other.ID); err != nil || got == nil {
+		t.Errorf(
+			"%s the other user's preferences were taken too\ngot:  %+v, err=%v",
+			prefix, got, err,
+		)
+	}
+}
+
+func TestDashboardPreferences_CheckValues(t *testing.T) {
+	// GIVEN: preferences to validate.
+	tests := []struct {
+		name     string
+		prefs    DashboardPreferences
+		errRegex string
+	}{
+		{
+			name:  "valid/everything unset",
+			prefs: DashboardPreferences{},
+		},
+		{
+			name: "valid/every field set",
+			prefs: DashboardPreferences{
+				Hide: []string{
+					HideUpToDate, HideUpdatable, HideSkipped, HideInactive,
+				},
+				View: ViewGrid,
+				Timestamps: []string{
+					TimestampDeployed, TimestampFound, TimestampQueried,
+				},
+			},
+		},
+		{
+			name: "valid/explicitly empty lists",
+			prefs: DashboardPreferences{
+				Hide:       []string{},
+				Timestamps: []string{},
+			},
+		},
+		{
+			name:     "invalid/unknown hide name",
+			prefs:    DashboardPreferences{Hide: []string{HideSkipped, "upToDate"}},
+			errRegex: `^hide: "upToDate" <invalid> \(.*$`,
+		},
+		{
+			name:     "invalid/unknown view",
+			prefs:    DashboardPreferences{View: "list"},
+			errRegex: `^view: "list" <invalid> \(.*$`,
+		},
+		{
+			name:     "invalid/unknown timestamp name",
+			prefs:    DashboardPreferences{Timestamps: []string{"last_queried"}},
+			errRegex: `^timestamps: "last_queried" <invalid> \(.*$`,
+		},
+		{
+			name: "invalid/every field reported",
+			prefs: DashboardPreferences{
+				Hide:       []string{"nope"},
+				View:       "nope",
+				Timestamps: []string{"nope"},
+			},
+			errRegex: test.TrimYAML(`
+				^hide: "nope" <invalid> \(supported values = \['up_to_date', 'updatable', 'skipped', 'inactive'\]\)
+				timestamps: "nope" <invalid> \(supported values = \['deployed', 'found', 'queried'\]\)
+				view: "nope" <invalid> \(supported values = \['grid', 'table'\]\)`,
+			),
+		},
+		{
+			name: "invalid/at the cap, every value is named",
+			prefs: DashboardPreferences{
+				Hide: []string{
+					"nope1", "nope2", HideSkipped, "nope3", "nope4", "nope5",
+				},
+			},
+			errRegex: `^hide: "nope1", "nope2", "nope3", "nope4", "nope5" <invalid> \(.*$`,
+		},
+		{
+			name: "invalid/over the cap, the rest are counted",
+			prefs: DashboardPreferences{
+				Hide: []string{
+					"nope1", "nope2", "nope3", "nope4", "nope5", "nope6", "nope7",
+				},
+				Timestamps: []string{
+					"nope1", "nope2", "nope3", "nope4", "nope5", "nope6",
+				},
+			},
+			errRegex: test.TrimYAML(`
+				hide: "nope1", "nope2", "nope3", "nope4", "nope5", and 2 more <invalid> \(.*
+				timestamps: "nope1", "nope2", "nope3", "nope4", "nope5", and 1 more <invalid> \(.*$`,
+			),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			prefix := fmt.Sprintf("%s\nCheckValues()", packageName)
+
+			// WHEN: they are validated.
+			err := tc.prefs.CheckValues()
+
+			// THEN: it errors when expected.
+			if err == nil && tc.errRegex == "" {
+				return
+			}
+
+			// AND: it errors as expected.
+			if !errors.Is(err, ErrInvalidPreference) {
+				t.Fatalf(
+					"%s error doesn't wrap the expected error\ngot:  %v\nwant: %v",
+					prefix, err, ErrInvalidPreference,
+				)
+			}
+			e := errfmt.FormatError(err)
+			e = strings.TrimPrefix(e, ErrInvalidPreference.Error()+"\n")
+			if !util.RegexCheck(tc.errRegex, e) {
+				t.Errorf(
+					"%s error mismatch\nwant: %v\ngot: %v",
+					prefix, tc.errRegex, e,
+				)
+			}
+		})
+	}
+}
+
+func TestStore_SetPreferences__rejectsUnknownValues(t *testing.T) {
+	// GIVEN: a Store with a user.
+	store := testStore(t)
+	user := mustCreateUser(t, store, "argus", "")
+
+	// WHEN: a name outside the catalogue is saved.
+	invalidHide := "upToDate"
+	prefs := DashboardPreferences{
+		Hide: []string{HideSkipped, invalidHide},
+	}
+	stored, err := store.SetPreferences(t.Context(), user.ID, prefs)
+
+	prefix := fmt.Sprintf(
+		"%s\nSetPreferences(prefs=%+v) unknown value",
+		packageName, prefs,
+	)
+
+	// THEN: it is refused with an error.
+	if err == nil {
+		t.Fatalf(
+			"%s expected an error\ngot: %+v",
+			prefix, stored,
+		)
+	}
+	if !strings.Contains(err.Error(), invalidHide) {
+		t.Errorf(
+			"%s error should name the offending value\ngot: %v",
+			prefix, err,
+		)
+	}
+
+	// AND: nothing was written.
+	if got := countRows(t, store, "user_preferences"); got != 0 {
+		t.Errorf(
+			"%s row written despite the error\ngot:  %d\nwant: 0",
+			prefix, got,
+		)
+	}
+}
+
+func TestStore_SetPreferences__zeroSetDiscards(t *testing.T) {
+	// GIVEN: a Store with a user who has saved preferences.
+	store := testStore(t)
+	user := mustCreateUser(t, store, "argus", "")
+
+	prefix := fmt.Sprintf("%s\nSetPreferences() zero set", packageName)
+
+	prefs := DashboardPreferences{
+		View: ViewTable,
+	}
+	if _, err := store.SetPreferences(t.Context(), user.ID, prefs); err != nil {
+		t.Fatalf(
+			"%s setup SetPreferences(prefs=%+v) failed: %v",
+			prefix, prefs, err,
+		)
+	}
+
+	// WHEN: a set with nothing in it is saved.
+	prefs = DashboardPreferences{}
+	stored, err := store.SetPreferences(t.Context(), user.ID, prefs)
+	if err != nil {
+		t.Fatalf(
+			"%s SetPreferences(prefs=%+v) failed: %v",
+			prefix, prefs, err,
+		)
+	}
+
+	// THEN: it reports nothing saved.
+	if stored != nil {
+		t.Errorf(
+			"%s expected no preferences\ngot: %+v",
+			prefix, *stored,
+		)
+	}
+
+	// AND: the row is gone, so a read agrees.
+	if got := countRows(t, store, "user_preferences"); got != 0 {
+		t.Errorf(
+			"%s row survived a zero set\ngot:  %d\nwant: 0",
+			prefix, got,
+		)
+	}
+	if got, err := store.PreferencesForUser(t.Context(), user.ID); err != nil || got != nil {
+		t.Errorf(
+			"%s read should find none\ngot:  %+v, err=%v",
+			prefix, got, err,
+		)
+	}
+}
+
+func TestStore_PreferencesForUser__canonicalisesOnRead(t *testing.T) {
+	// GIVEN: a Store holding a row written from an earlier build's catalogues.
+	store := testStore(t)
+	user := mustCreateUser(t, store, "argus", "")
+	mustExec(t, store, fmt.Sprintf(`
+		INSERT INTO user_preferences
+			(user_id, hide, view, timestamps, created_at, updated_at)
+		VALUES
+			('%s', '%s,retired_hide', 'compact', '%s,retired_timestamp', '%s', '%s');`,
+		user.ID, HideSkipped, TimestampFound, timeNow().Format(timeFormat), timeNow().Format(timeFormat),
+	))
+
+	prefix := fmt.Sprintf("%s\nPreferencesForUser() canonicalise", packageName)
+
+	// WHEN: they are read.
+	got, err := store.PreferencesForUser(t.Context(), user.ID)
+	if err != nil {
+		t.Fatalf(
+			"%s PreferencesForUser failed: %v",
+			prefix, err,
+		)
+	}
+
+	// THEN: values this build no longer knows are dropped.
+	if testErr := test.AssertSlicesEqual(
+		t, got.Hide, []string{HideSkipped}, prefix, "hide",
+	); testErr != nil {
+		t.Error(testErr)
+	}
+	if testErr := test.AssertSlicesEqual(
+		t, got.Timestamps, []string{TimestampFound}, prefix, "timestamps",
+	); testErr != nil {
+		t.Error(testErr)
+	}
+	if got.View != "" {
+		t.Errorf(
+			"%s unknown view should be blanked\ngot: %q",
+			prefix, got.View,
+		)
+	}
+}

--- a/auth/store/store.go
+++ b/auth/store/store.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // Package store persists the authentication and authorisation entities
-// (users, groups, permission grants, sessions, API tokens) in the
+// (users, groups, permission grants, sessions, API tokens, preferences) in the
 // Argus SQLite database, and owns their schema migrations.
 //
 // Deletions cascade explicitly inside transactions rather than relying on
@@ -45,6 +45,7 @@ var (
 	ErrSetupComplete     = errors.New("setup already completed")
 	ErrNoPassword        = errors.New("a password is required")
 	ErrTokenLimitReached = errors.New("API token limit reached for this user")
+	ErrInvalidPreference = errors.New("invalid preference value")
 )
 
 // Well-known seeded group names.
@@ -160,6 +161,16 @@ var migrations = []migration{
 		`CREATE INDEX IF NOT EXISTS idx_sessions_user_id ON sessions (user_id, last_seen_at DESC);`,
 		`CREATE INDEX IF NOT EXISTS idx_sessions_expires_at ON sessions (expires_at);`,
 		`CREATE INDEX IF NOT EXISTS idx_api_tokens_user_id ON api_tokens (user_id, created_at DESC);`,
+	}},
+	{version: 2, statements: []string{
+		`CREATE TABLE IF NOT EXISTS user_preferences (
+			user_id    TEXT NOT NULL PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+			hide       TEXT,
+			view       TEXT,
+			timestamps TEXT,
+			created_at DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL
+		);`,
 	}},
 }
 

--- a/auth/store/store_test.go
+++ b/auth/store/store_test.go
@@ -51,6 +51,14 @@ func TestNew(t *testing.T) {
 		)
 	}
 
+	// AND: the preferences table exists, holding nothing yet.
+	if got := countRows(t, store, "user_preferences"); got != 0 {
+		t.Errorf(
+			"%s user_preferences row count mismatch\ngot:  %d\nwant: 0",
+			prefix, got,
+		)
+	}
+
 	// AND: the three groups are seeded (admin protected; the rest not).
 	groups, err := store.Groups(t.Context())
 	if err != nil {
@@ -895,6 +903,12 @@ func TestMigrate__hotQueriesUseAnIndex(t *testing.T) {
 			args:      []any{"user"},
 			wantIndex: "idx_api_tokens_user_id",
 		},
+		{
+			name:      "user_preferences/load a user's preferences",
+			query:     `SELECT hide, view, timestamps FROM user_preferences WHERE user_id = ?;`,
+			args:      []any{"user"},
+			wantIndex: "sqlite_autoindex_user_preferences_1",
+		},
 	}
 
 	for _, tc := range tests {
@@ -942,7 +956,8 @@ func TestMigrate__hotQueriesUseAnIndex(t *testing.T) {
 				)
 			}
 			if strings.Contains(plan, "SCAN sessions") ||
-				strings.Contains(plan, "SCAN api_tokens") {
+				strings.Contains(plan, "SCAN api_tokens") ||
+				strings.Contains(plan, "SCAN user_preferences") {
 				t.Errorf(
 					"%s\nfull table scan\nquery: %s\ngot plan:\n%s",
 					prefix, tc.query, plan,

--- a/auth/store/users.go
+++ b/auth/store/users.go
@@ -312,7 +312,7 @@ func (s *Store) UpdateUser(
 }
 
 // DeleteUser removes the user with id and everything hanging off it
-// (memberships, sessions, API tokens), enforcing the rails.
+// (memberships, sessions, API tokens, preferences), enforcing the rails.
 func (s *Store) DeleteUser(ctx context.Context, id string) error {
 	return s.inTx(ctx, func(tx *sql.Tx) error {
 		var enabled bool
@@ -336,6 +336,7 @@ func (s *Store) DeleteUser(ctx context.Context, id string) error {
 			`DELETE FROM user_groups WHERE user_id = ?;`,
 			`DELETE FROM sessions WHERE user_id = ?;`,
 			`DELETE FROM api_tokens WHERE user_id = ?;`,
+			`DELETE FROM user_preferences WHERE user_id = ?;`,
 			`DELETE FROM users WHERE id = ?;`,
 		} {
 			if _, err := tx.ExecContext(ctx, statement, id); err != nil {

--- a/auth/store/users_test.go
+++ b/auth/store/users_test.go
@@ -290,8 +290,11 @@ func TestStore_CreateUser_And_UserByID(t *testing.T) {
 			}
 
 			// AND: group memberships match (sorted).
-			wantGroups := append([]string{}, tc.groups...)
-			slices.Sort(wantGroups)
+			var wantGroups []string
+			if len(tc.groups) > 0 {
+				wantGroups = append(wantGroups, tc.groups...)
+				slices.Sort(wantGroups)
+			}
 			if testErr := test.AssertSlicesEqualFunc(
 				t,
 				got.Groups,

--- a/command/init_test.go
+++ b/command/init_test.go
@@ -158,7 +158,7 @@ func TestController_Metrics(t *testing.T) {
 	controller := NewController(
 		&status.Status{
 			ServiceInfo: serviceinfo.ServiceInfo{
-				ID: "TestController_Metrics",
+				ID: t.Name(),
 			},
 		},
 		Commands{

--- a/config/types_test.go
+++ b/config/types_test.go
@@ -549,7 +549,7 @@ func TestConfig_Decode__serviceExtractError(t *testing.T) {
 }
 
 func TestConfig_GetDefaults(t *testing.T) {
-	name := "TestConfig_GetDefaults"
+	name := t.Name()
 
 	// GIVEN: a Config.
 	cfg := testConfig(t)

--- a/db/init_test.go
+++ b/db/init_test.go
@@ -56,7 +56,7 @@ func TestAPI_Get(t *testing.T) {
 
 	// THEN: the cell was changed in the DB.
 	otherCfg := testConfig(t)
-	otherCfg.Settings.Data.DatabaseFile = "TestAPI_Get-copy.db"
+	otherCfg.Settings.Data.DatabaseFile = t.Name() + "-copy.db"
 	bytesRead, err := os.ReadFile(cfg.Settings.Data.DatabaseFile)
 	if err != nil {
 		t.Fatalf("%s\n%v", packageName, err)

--- a/internal/test/decode_assert_test.go
+++ b/internal/test/decode_assert_test.go
@@ -490,7 +490,7 @@ func TestAssertApplyOverrides_AddressMatch(t *testing.T) {
 func TestTestStruct_Foo(t *testing.T) {
 	// GIVEN: a testStruct with a String.
 	v := testStruct{
-		String: "TestTestStruct_Foo",
+		String: t.Name(),
 	}
 	// WHEN: Foo is called.
 	got := v.Foo()

--- a/internal/test/permutations_test.go
+++ b/internal/test/permutations_test.go
@@ -31,7 +31,7 @@ func TestPermutations(t *testing.T) {
 		{
 			name:  "empty",
 			input: []int{},
-			want:  [][]int{},
+			want:  nil,
 		},
 		{
 			name:  "single",

--- a/internal/test/slice_assert.go
+++ b/internal/test/slice_assert.go
@@ -31,6 +31,16 @@ func AssertSlicesEqualFunc[T any, U any](
 ) error {
 	t.Helper()
 
+	// nil vs empty (non-nil).
+	if (got == nil) != (want == nil) {
+		msg := "%s %s nil mismatch\ngot:  %v\nwant: %v"
+		if target == "" {
+			msg = "%s%s nil mismatch\ngot:  %v\nwant: %v"
+		}
+
+		return fmt.Errorf(msg, prefix, target, got, want)
+	}
+
 	// Length.
 	if gotLen, wantLen := len(got), len(want); gotLen != wantLen {
 		msg := "%s %s length mismatch\ngot:  %d (%+v)\nwant: %d (%+v)"
@@ -70,4 +80,24 @@ func AssertSlicesEqualFunc[T any, U any](
 		return nil
 	}
 	return errors.Join(errs...)
+}
+
+// AssertSlicesEqual compares two slices of comparable elements, distinguishing
+// unset (nil) from an explicitly empty slice.
+// target names the compared field in any mismatch, e.g. "hide".
+func AssertSlicesEqual[T comparable](
+	t *testing.T,
+	got, want []T,
+	prefix, target string,
+) error {
+	t.Helper()
+
+	return AssertSlicesEqualFunc(
+		t,
+		got,
+		want,
+		func(a, b T) bool { return a == b },
+		prefix,
+		target,
+	)
 }

--- a/internal/test/slice_assert_test.go
+++ b/internal/test/slice_assert_test.go
@@ -30,27 +30,59 @@ func TestAssertSlicesEqualFunc(t *testing.T) {
 	// GIVEN: two slices to compare.
 	tests := []struct {
 		name                             string
-		a, b                             []interface{}
-		eq                               func(interface{}, interface{}) bool
+		a, b                             []any
+		eq                               func(any, any) bool
 		want                             bool
 		noTargetErrRegex, targetErrRegex string
 	}{
 		{
 			name: "equal",
-			a:    []interface{}{"foo", "bar"},
-			b:    []interface{}{"foo", "bar"},
+			a:    []any{"foo", "bar"},
+			b:    []any{"foo", "bar"},
 			want: true,
-			eq: func(a, b interface{}) bool {
+			eq: func(a, b any) bool {
 				return a == b
 			},
 			noTargetErrRegex: `^$`,
 			targetErrRegex:   `^$`,
 		},
 		{
+			name:             "unset is not explicitly empty",
+			a:                nil,
+			b:                []any{},
+			eq:               func(a, b any) bool { return a == b },
+			noTargetErrRegex: fmt.Sprintf("%s nil mismatch", prefix),
+			targetErrRegex:   fmt.Sprintf("%s %s nil mismatch", prefix, targetToUse),
+		},
+		{
+			name:             "explicitly empty is not unset",
+			a:                []any{},
+			b:                nil,
+			eq:               func(a, b any) bool { return a == b },
+			noTargetErrRegex: fmt.Sprintf("%s nil mismatch", prefix),
+			targetErrRegex:   fmt.Sprintf("%s %s nil mismatch", prefix, targetToUse),
+		},
+		{
+			name:             "both unset",
+			a:                nil,
+			b:                nil,
+			eq:               func(a, b any) bool { return a == b },
+			noTargetErrRegex: `^$`,
+			targetErrRegex:   `^$`,
+		},
+		{
+			name:             "both explicitly empty",
+			a:                []any{},
+			b:                []any{},
+			eq:               func(a, b any) bool { return a == b },
+			noTargetErrRegex: `^$`,
+			targetErrRegex:   `^$`,
+		},
+		{
 			name: "length mismatch",
-			a:    []interface{}{"foo", "bar"},
-			b:    []interface{}{"foo", "bar", "baz", "qux"},
-			eq: func(a, b interface{}) bool {
+			a:    []any{"foo", "bar"},
+			b:    []any{"foo", "bar", "baz", "qux"},
+			eq: func(a, b any) bool {
 				return a == b
 			},
 			noTargetErrRegex: fmt.Sprintf("%s length mismatch", prefix),
@@ -58,9 +90,9 @@ func TestAssertSlicesEqualFunc(t *testing.T) {
 		},
 		{
 			name: "element mismatch",
-			a:    []interface{}{"foo", "bar"},
-			b:    []interface{}{"foo", "baz"},
-			eq: func(a, b interface{}) bool {
+			a:    []any{"foo", "bar"},
+			b:    []any{"foo", "baz"},
+			eq: func(a, b any) bool {
 				return a == b
 			},
 			noTargetErrRegex: fmt.Sprintf(`%s\[1\] element mismatch`, prefix),
@@ -100,6 +132,158 @@ func TestAssertSlicesEqualFunc(t *testing.T) {
 					"%s\nAssertSlicesEqualFunc(a=%v, b=%v, target=%q) error mismatch\ngot:  %q\nwant: %q",
 					packageName, tc.a, tc.b, target,
 					e, tc.targetErrRegex,
+				)
+			}
+		})
+	}
+}
+
+func TestAssertSlicesEqual(t *testing.T) {
+	prefix := "TestAssertSlicesEqual"
+	targetToUse := "target"
+	// GIVEN: two slices of comparable elements to compare.
+	tests := []struct {
+		name                             string
+		a, b                             []string
+		noTargetErrRegex, targetErrRegex string
+	}{
+		{
+			name:             "equal/both unset",
+			noTargetErrRegex: `^$`,
+			targetErrRegex:   `^$`,
+		},
+		{
+			name:             "equal/both explicitly empty",
+			a:                []string{},
+			b:                []string{},
+			noTargetErrRegex: `^$`,
+			targetErrRegex:   `^$`,
+		},
+		{
+			name:             "equal/same values",
+			a:                []string{"foo", "bar"},
+			b:                []string{"foo", "bar"},
+			noTargetErrRegex: `^$`,
+			targetErrRegex:   `^$`,
+		},
+		{
+			name:             "nil (unset) != empty",
+			b:                []string{},
+			noTargetErrRegex: fmt.Sprintf("%s nil mismatch", prefix),
+			targetErrRegex:   fmt.Sprintf("%s %s nil mismatch", prefix, targetToUse),
+		},
+		{
+			name:             "empty != nil (unset)",
+			a:                []string{},
+			noTargetErrRegex: fmt.Sprintf("%s nil mismatch", prefix),
+			targetErrRegex:   fmt.Sprintf("%s %s nil mismatch", prefix, targetToUse),
+		},
+		{
+			name:             "length mismatch",
+			a:                []string{"foo"},
+			b:                []string{"foo", "bar"},
+			noTargetErrRegex: fmt.Sprintf("%s length mismatch", prefix),
+			targetErrRegex:   fmt.Sprintf("%s %s length mismatch", prefix, targetToUse),
+		},
+		{
+			name:             "element mismatch",
+			a:                []string{"foo", "bar"},
+			b:                []string{"foo", "baz"},
+			noTargetErrRegex: fmt.Sprintf(`%s\[1\] element mismatch`, prefix),
+			targetErrRegex:   fmt.Sprintf(`%s %s\[1\] element mismatch`, prefix, targetToUse),
+		},
+		{
+			name:             "order mismatch",
+			a:                []string{"foo", "bar"},
+			b:                []string{"bar", "foo"},
+			noTargetErrRegex: fmt.Sprintf(`%s\[0\] element mismatch`, prefix),
+			targetErrRegex:   fmt.Sprintf(`%s %s\[0\] element mismatch`, prefix, targetToUse),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// GIVEN: no target.
+			target := ""
+
+			// WHEN: AssertSlicesEqual is called with no target.
+			err := AssertSlicesEqual(t, tc.a, tc.b, prefix, target)
+
+			// THEN: the error is as expected.
+			e := errfmt.FormatError(err)
+			if !regexp.MustCompile(tc.noTargetErrRegex).MatchString(e) {
+				t.Errorf(
+					"%s\nAssertSlicesEqual(a=%v, b=%v, target=%q) error mismatch\ngot:  %q\nwant: %q",
+					packageName, tc.a, tc.b, target,
+					e, tc.noTargetErrRegex,
+				)
+			}
+
+			// GIVEN: a target.
+			target = targetToUse
+
+			// WHEN: AssertSlicesEqual is called with a target.
+			err = AssertSlicesEqual(t, tc.a, tc.b, prefix, target)
+
+			// THEN: the error names it.
+			e = errfmt.FormatError(err)
+			if !regexp.MustCompile(tc.targetErrRegex).MatchString(e) {
+				t.Errorf(
+					"%s\nAssertSlicesEqual(a=%v, b=%v, target=%q) error mismatch\ngot:  %q\nwant: %q",
+					packageName, tc.a, tc.b, target,
+					e, tc.targetErrRegex,
+				)
+			}
+		})
+	}
+}
+
+func TestAssertSlicesEqual__otherComparableTypes(t *testing.T) {
+	prefix := "TestAssertSlicesEqual__otherComparableTypes"
+	// GIVEN: slices of types other than string.
+	tests := []struct {
+		name     string
+		invoke   func(t *testing.T) error
+		errRegex string
+	}{
+		{
+			name: "ints/equal",
+			invoke: func(t *testing.T) error {
+				return AssertSlicesEqual(t, []int{1, 2}, []int{1, 2}, prefix, "")
+			},
+			errRegex: `^$`,
+		},
+		{
+			name: "ints/mismatch",
+			invoke: func(t *testing.T) error {
+				return AssertSlicesEqual(t, []int{1, 2}, []int{1, 3}, prefix, "")
+			},
+			errRegex: `\[1\] element mismatch`,
+		},
+		{
+			name: "bools/mismatch",
+			invoke: func(t *testing.T) error {
+				return AssertSlicesEqual(t, []bool{true}, []bool{false}, prefix, "")
+			},
+			errRegex: `\[0\] element mismatch`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// WHEN: AssertSlicesEqual is called.
+			err := tc.invoke(t)
+
+			// THEN: the error is as expected.
+			e := errfmt.FormatError(err)
+			if !regexp.MustCompile(tc.errRegex).MatchString(e) {
+				t.Errorf(
+					"%s\nerror mismatch\ngot:  %q\nwant: %q",
+					packageName, e, tc.errRegex,
 				)
 			}
 		})

--- a/internal/test/slice_assert_test.go
+++ b/internal/test/slice_assert_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestAssertSlicesEqualFunc(t *testing.T) {
-	prefix := "TestAssertSlicesEqualFunc"
+	prefix := t.Name()
 	targetToUse := "target"
 	// GIVEN: two slices to compare.
 	tests := []struct {
@@ -139,7 +139,7 @@ func TestAssertSlicesEqualFunc(t *testing.T) {
 }
 
 func TestAssertSlicesEqual(t *testing.T) {
-	prefix := "TestAssertSlicesEqual"
+	prefix := t.Name()
 	targetToUse := "target"
 	// GIVEN: two slices of comparable elements to compare.
 	tests := []struct {
@@ -241,7 +241,7 @@ func TestAssertSlicesEqual(t *testing.T) {
 }
 
 func TestAssertSlicesEqual__otherComparableTypes(t *testing.T) {
-	prefix := "TestAssertSlicesEqual__otherComparableTypes"
+	prefix := t.Name()
 	// GIVEN: slices of types other than string.
 	tests := []struct {
 		name     string

--- a/notify/shoutrrr/verify.go
+++ b/notify/shoutrrr/verify.go
@@ -236,7 +236,7 @@ func (d *Defaults) CheckValues(id string) (error, bool) {
 	if !slices.Contains(SupportedTypes, typeName) {
 		errs = append(
 			errs,
-			polymorphic.ErrInvalidType{
+			polymorphic.ErrInvalidValue{
 				Key:     "type",
 				Value:   typeName,
 				Allowed: SupportedTypes,
@@ -465,7 +465,7 @@ func (s *Shoutrrr) checkValuesType() error {
 
 	// Invalid/Unknown type.
 	if !slices.Contains(SupportedTypes, sType) {
-		return polymorphic.ErrInvalidType{
+		return polymorphic.ErrInvalidValue{
 			Key:     "type",
 			Value:   sType,
 			Allowed: SupportedTypes,
@@ -1152,7 +1152,7 @@ func (b *Base) validateParamSelect(key string, allowed []string) error {
 		return nil
 	}
 
-	return polymorphic.ErrInvalidType{
+	return polymorphic.ErrInvalidValue{
 		Key:     key,
 		Value:   value,
 		Allowed: allowed,

--- a/notify/shoutrrr/verify_test.go
+++ b/notify/shoutrrr/verify_test.go
@@ -3398,12 +3398,12 @@ func TestBase_CheckValuesParamsSelects(t *testing.T) {
 			errRegex: "^" + test.RegexBracketEscaper.Replace(
 				errfmt.FormatError(
 					errors.Join(
-						polymorphic.ErrInvalidType{
+						polymorphic.ErrInvalidValue{
 							Key:     "scheme",
 							Value:   "-",
 							Allowed: barkNtfyParamScheme,
 						},
-						polymorphic.ErrInvalidType{
+						polymorphic.ErrInvalidValue{
 							Key:     "sound",
 							Value:   "nope",
 							Allowed: barkParamSound,
@@ -3431,7 +3431,7 @@ func TestBase_CheckValuesParamsSelects(t *testing.T) {
 				"method": "FETCH",
 			},
 			errRegex: "^" + test.RegexBracketEscaper.Replace(
-				polymorphic.ErrInvalidType{
+				polymorphic.ErrInvalidValue{
 					Key:     "method",
 					Value:   "FETCH",
 					Allowed: genericParamMethod,
@@ -3462,12 +3462,12 @@ func TestBase_CheckValuesParamsSelects(t *testing.T) {
 			errRegex: "^" + test.RegexBracketEscaper.Replace(
 				errfmt.FormatError(
 					errors.Join(
-						polymorphic.ErrInvalidType{
+						polymorphic.ErrInvalidValue{
 							Key:     "priority",
 							Value:   "urgENT",
 							Allowed: ntfyParamPriority,
 						},
-						polymorphic.ErrInvalidType{
+						polymorphic.ErrInvalidValue{
 							Key:     "scheme",
 							Value:   "ftp",
 							Allowed: barkNtfyParamScheme,
@@ -3511,12 +3511,12 @@ func TestBase_CheckValuesParamsSelects(t *testing.T) {
 			errRegex: "^" + test.RegexBracketEscaper.Replace(
 				errfmt.FormatError(
 					errors.Join(
-						polymorphic.ErrInvalidType{
+						polymorphic.ErrInvalidValue{
 							Key:     "auth",
 							Value:   "basic",
 							Allowed: smtpParamAuth,
 						},
-						polymorphic.ErrInvalidType{
+						polymorphic.ErrInvalidValue{
 							Key:     "encryption",
 							Value:   "tls1.3",
 							Allowed: smtpParamEncryption,
@@ -3544,7 +3544,7 @@ func TestBase_CheckValuesParamsSelects(t *testing.T) {
 				"parsemode": "mdx",
 			},
 			errRegex: "^" + test.RegexBracketEscaper.Replace(
-				polymorphic.ErrInvalidType{
+				polymorphic.ErrInvalidValue{
 					Key:     "parsemode",
 					Value:   "mdx",
 					Allowed: telegramParamParsemode,

--- a/service/api_test.go
+++ b/service/api_test.go
@@ -1513,7 +1513,7 @@ func TestService_CheckFetches(t *testing.T) {
 	svcCfg := plainDefaultsConfig(t)
 	notifyCfg := shoutrrrtest.PlainConfig(t)
 	whCfg := whtest.PlainConfig(t)
-	id := "TestService_CheckFetches"
+	id := t.Name()
 
 	// GIVEN: a Service.
 	testLV := lvtest.Lookup(t, "url", false)
@@ -1723,7 +1723,7 @@ func TestService_GiveSecrets(t *testing.T) {
 	svcCfg := plainDefaultsConfig(t)
 	notifyCfg := shoutrrrtest.PlainConfig(t)
 	whCfg := whtest.PlainConfig(t)
-	id := "TestService_GiveSecrets"
+	id := t.Name()
 
 	type statusTests struct {
 		oldLatestVersion, expectedLatestVersion                       string

--- a/service/deployed_version/decode.go
+++ b/service/deployed_version/decode.go
@@ -48,7 +48,7 @@ func Decode(
 		ServiceMapInheritable,
 	)
 	if err != nil {
-		var ite *polymorphic.ErrInvalidType
+		var ite *polymorphic.ErrInvalidValue
 		// Override constructor type names.
 		if errors.As(err, &ite) {
 			ite.Allowed = PossibleTypes

--- a/service/deployed_version/types/base/defaults.go
+++ b/service/deployed_version/types/base/defaults.go
@@ -104,7 +104,7 @@ func (d *Defaults) CheckValues() error {
 	if d.Method != "" && !slices.Contains(constants.SupportedMethods, d.Method) {
 		errs = append(
 			errs,
-			polymorphic.ErrInvalidType{
+			polymorphic.ErrInvalidValue{
 				Key:     "method",
 				Value:   d.Method,
 				Allowed: constants.SupportedMethods,

--- a/service/deployed_version/types/base/metric_test.go
+++ b/service/deployed_version/types/base/metric_test.go
@@ -36,7 +36,7 @@ func TestLookup_Metrics(t *testing.T) {
 	}
 	lookup.Status = &status.Status{
 		ServiceInfo: serviceinfo.ServiceInfo{
-			ID: "TestLookup_Metrics",
+			ID: t.Name(),
 		},
 	}
 

--- a/service/deployed_version/types/manual/types_test.go
+++ b/service/deployed_version/types/manual/types_test.go
@@ -155,7 +155,7 @@ func TestString(t *testing.T) {
 		time.Now().Add(-time.Minute).UTC().Format(time.RFC3339),
 		false,
 	)
-	lookup.Status.ServiceInfo.ID = "TestString"
+	lookup.Status.ServiceInfo.ID = t.Name()
 	tests := []struct {
 		name   string
 		lookup *Lookup

--- a/service/deployed_version/types/web/init_test.go
+++ b/service/deployed_version/types/web/init_test.go
@@ -72,7 +72,7 @@ func TestLookup_Metrics(t *testing.T) {
 		{
 			name:        "non-nil",
 			lookup:      testLookup(t, false),
-			serviceID:   "TestLookup_Metrics",
+			serviceID:   t.Name(),
 			wantMetrics: true,
 		},
 	}

--- a/service/deployed_version/types/web/verify.go
+++ b/service/deployed_version/types/web/verify.go
@@ -48,7 +48,7 @@ func (l *Lookup) CheckValues() error {
 	if !slices.Contains(constants.SupportedMethods, method) {
 		errs = append(
 			errs,
-			polymorphic.ErrInvalidType{
+			polymorphic.ErrInvalidValue{
 				Key:     "method",
 				Value:   method,
 				Allowed: constants.SupportedMethods,

--- a/service/latest_version/decode.go
+++ b/service/latest_version/decode.go
@@ -48,7 +48,7 @@ func Decode(
 		ServiceMapInheritable,
 	)
 	if err != nil {
-		var ite *polymorphic.ErrInvalidType
+		var ite *polymorphic.ErrInvalidValue
 		// Override constructor type names.
 		if errors.As(err, &ite) {
 			ite.Allowed = PossibleTypes

--- a/service/latest_version/filter/docker/defaults.go
+++ b/service/latest_version/filter/docker/defaults.go
@@ -158,7 +158,7 @@ func (d *Defaults) CheckValues() error {
 
 	// Type.
 	if d.Type != "" && !slices.Contains(PossibleTypes, d.Type) {
-		return polymorphic.ErrInvalidType{
+		return polymorphic.ErrInvalidValue{
 			Key:     "type",
 			Value:   d.Type,
 			Allowed: PossibleTypes,

--- a/service/latest_version/filter/urlcommand.go
+++ b/service/latest_version/filter/urlcommand.go
@@ -172,7 +172,7 @@ func (s *URLCommands) CheckValues() error {
 // CheckValues validates the fields of the receiver.
 func (c *URLCommand) CheckValues() error {
 	if !slices.Contains(urlCommandTypes, c.Type) {
-		return polymorphic.ErrInvalidType{
+		return polymorphic.ErrInvalidValue{
 			Key:     "type",
 			Value:   c.Type,
 			Allowed: urlCommandTypes,

--- a/service/latest_version/types/base/metric_test.go
+++ b/service/latest_version/types/base/metric_test.go
@@ -33,7 +33,7 @@ func TestLookup_Metrics(t *testing.T) {
 		Type: "test",
 	}
 	lookup.Status = &status.Status{}
-	lookup.Status.ServiceInfo.ID = "TestLookup_Metrics"
+	lookup.Status.ServiceInfo.ID = t.Name()
 
 	// WHEN: the Prometheus metrics are initialised with initMetrics.
 	hadC := testutil.CollectAndCount(metric.LatestVersionQueryResultTotal)

--- a/service/latest_version/types/github/githubdata_test.go
+++ b/service/latest_version/types/github/githubdata_test.go
@@ -92,8 +92,7 @@ func TestNewData(t *testing.T) {
 			eTag:     "",
 			releases: nil,
 			want: &Data{
-				eTag:     startingEmptyListETag,
-				releases: []ghtypes.Release{},
+				eTag: startingEmptyListETag,
 			},
 		},
 		{
@@ -101,8 +100,7 @@ func TestNewData(t *testing.T) {
 			eTag:     "foo",
 			releases: nil,
 			want: &Data{
-				eTag:     "foo",
-				releases: []ghtypes.Release{},
+				eTag: "foo",
 			},
 		},
 		{

--- a/service/shared/headers_test.go
+++ b/service/shared/headers_test.go
@@ -71,8 +71,8 @@ func TestHeaders_Copy(t *testing.T) {
 
 			prefix := fmt.Sprintf("%s\nHeaders.Copy()", packageName)
 
-			// THEN: Copy on nil returns nil.
-			if tc.headers == nil {
+			// THEN: Copy on nil (or on an empty set) returns nil.
+			if tc.headers == nil || len(*tc.headers) == 0 {
 				if got != nil {
 					t.Errorf("%s result mismatch\ngot:  non-nil\nwant: nil", prefix)
 				}

--- a/service/track_test.go
+++ b/service/track_test.go
@@ -136,7 +136,7 @@ func TestService_Track(t *testing.T) {
 	notifyCfg := shoutrrrtest.PlainConfig(t)
 	whCfg := whtest.PlainConfig(t)
 
-	testURLService := testService(t, "TestService_Track", "url", "url")
+	testURLService := testService(t, t.Name(), "url", "url")
 	_, _ = testURLService.LatestVersion.Query(false, logx.LogFrom{})
 	testURLLatestVersion := testURLService.Status.LatestVersion()
 

--- a/util/polymorphic/decode.go
+++ b/util/polymorphic/decode.go
@@ -81,7 +81,7 @@ func Construct(
 ) (Inheritable, error) {
 	constructor, ok := constructors[typ]
 	if !ok {
-		return nil, &ErrInvalidType{
+		return nil, &ErrInvalidValue{
 			Key:     "type",
 			Value:   typ,
 			Allowed: util.SortedKeys(constructors),

--- a/util/polymorphic/errors.go
+++ b/util/polymorphic/errors.go
@@ -16,6 +16,7 @@ package polymorphic
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -43,8 +44,56 @@ func (e ErrInvalidType) Error() string {
 		valueMsg = fmt.Sprintf("%q <invalid>", e.Value)
 	}
 
+	return invalidMessage(e.Key, valueMsg, e.Allowed)
+}
+
+// ErrInvalidValues is returned when values outside the Allowed values are given
+// for the list-valued Key.
+type ErrInvalidValues struct {
+	Key     string
+	Values  []string
+	Allowed []string
+}
+
+// maxNamedValues caps how many values one error names, so a large body cannot
+// amplify into a far larger error response.
+const maxNamedValues = 5
+
+// Error implements the [error] interface.
+//
+// Output formats:
+//
+// With values:
+//
+//	KEY: "X", "Y" <invalid> (supported values = ['A', 'B', 'C'])
+//
+// With more than [maxNamedValues] values:
+//
+//	KEY: "V", "W", "X", "Y", "Z", and 2 more <invalid> (supported values = ['A', 'B', 'C'])
+//
+// Without values (required):
+//
+//	KEY: <required> (supported values = ['A', 'B', 'C'])
+func (e ErrInvalidValues) Error() string {
+	valueMsg := "<required>"
+	if named := min(len(e.Values), maxNamedValues); named > 0 {
+		parts := make([]string, 0, named+1)
+		for _, value := range e.Values[:named] {
+			parts = append(parts, strconv.Quote(value))
+		}
+		if extra := len(e.Values) - named; extra > 0 {
+			parts = append(parts, fmt.Sprintf("and %d more", extra))
+		}
+		valueMsg = strings.Join(parts, ", ") + " <invalid>"
+	}
+
+	return invalidMessage(e.Key, valueMsg, e.Allowed)
+}
+
+// invalidMessage renders the shared grammar of the invalid-value errors.
+func invalidMessage(key, valueMsg string, allowed []string) string {
 	return fmt.Sprintf(
 		"%s: %s (supported values = ['%s'])",
-		e.Key, valueMsg, strings.Join(e.Allowed, "', '"),
+		key, valueMsg, strings.Join(allowed, "', '"),
 	)
 }

--- a/util/polymorphic/errors.go
+++ b/util/polymorphic/errors.go
@@ -20,8 +20,8 @@ import (
 	"strings"
 )
 
-// ErrInvalidType is returned when a value outside the Allowed values is given for the Key.
-type ErrInvalidType struct {
+// ErrInvalidValue is returned when a value outside the Allowed values is given for the Key.
+type ErrInvalidValue struct {
 	Key     string
 	Value   string
 	Allowed []string
@@ -38,7 +38,7 @@ type ErrInvalidType struct {
 // Without value (required):
 //
 //	KEY: <required> (supported values = ['A', 'B', 'C'])
-func (e ErrInvalidType) Error() string {
+func (e ErrInvalidValue) Error() string {
 	valueMsg := "<required>"
 	if e.Value != "" {
 		valueMsg = fmt.Sprintf("%q <invalid>", e.Value)

--- a/util/polymorphic/errors_test.go
+++ b/util/polymorphic/errors_test.go
@@ -16,16 +16,16 @@ package polymorphic
 
 import "testing"
 
-func TestErrInvalidType_Error(t *testing.T) {
-	// GIVEN: an ErrInvalidType.
+func TestErrInvalidValue_Error(t *testing.T) {
+	// GIVEN: an ErrInvalidValue.
 	tests := []struct {
 		name     string
-		err      *ErrInvalidType
+		err      *ErrInvalidValue
 		expected string
 	}{
 		{
 			name: "value provided with multiple allowed types",
-			err: &ErrInvalidType{
+			err: &ErrInvalidValue{
 				Key:     "type",
 				Value:   "mysql",
 				Allowed: []string{"postgres", "sqlite", "mysql"},
@@ -34,7 +34,7 @@ func TestErrInvalidType_Error(t *testing.T) {
 		},
 		{
 			name: "empty value uses required placeholder",
-			err: &ErrInvalidType{
+			err: &ErrInvalidValue{
 				Key:     "type",
 				Value:   "",
 				Allowed: []string{"postgres", "sqlite"},
@@ -43,7 +43,7 @@ func TestErrInvalidType_Error(t *testing.T) {
 		},
 		{
 			name: "single allowed type",
-			err: &ErrInvalidType{
+			err: &ErrInvalidValue{
 				Key:     "type",
 				Value:   "redis",
 				Allowed: []string{"redis"},
@@ -52,7 +52,7 @@ func TestErrInvalidType_Error(t *testing.T) {
 		},
 		{
 			name: "multiple allowed types preserve order",
-			err: &ErrInvalidType{
+			err: &ErrInvalidValue{
 				Key:     "type",
 				Value:   "mongo",
 				Allowed: []string{"mongo", "cassandra", "dynamodb"},
@@ -61,7 +61,7 @@ func TestErrInvalidType_Error(t *testing.T) {
 		},
 		{
 			name: "empty allowed list",
-			err: &ErrInvalidType{
+			err: &ErrInvalidValue{
 				Key:     "type",
 				Value:   "unknown",
 				Allowed: []string{},
@@ -80,7 +80,7 @@ func TestErrInvalidType_Error(t *testing.T) {
 			// THEN: the error is formatted as expected.
 			if got != tc.expected {
 				t.Fatalf(
-					"%s\nErrInvalidType stringified mismatch\ngot:  %q\nwant: %q",
+					"%s\nErrInvalidValue stringified mismatch\ngot:  %q\nwant: %q",
 					packageName, got, tc.expected,
 				)
 			}

--- a/util/polymorphic/errors_test.go
+++ b/util/polymorphic/errors_test.go
@@ -87,3 +87,102 @@ func TestErrInvalidType_Error(t *testing.T) {
 		})
 	}
 }
+
+func TestErrInvalidValues_Error(t *testing.T) {
+	// GIVEN: an ErrInvalidValues.
+	tests := []struct {
+		name     string
+		err      *ErrInvalidValues
+		expected string
+	}{
+		{
+			name: "single value",
+			err: &ErrInvalidValues{
+				Key:     "hide",
+				Values:  []string{"mysql"},
+				Allowed: []string{"postgres", "sqlite", "mysql"},
+			},
+			expected: `hide: "mysql" <invalid> (supported values = ['postgres', 'sqlite', 'mysql'])`,
+		},
+		{
+			name: "values are named in the order given",
+			err: &ErrInvalidValues{
+				Key:     "hide",
+				Values:  []string{"mongo", "cassandra"},
+				Allowed: []string{"postgres", "sqlite"},
+			},
+			expected: `hide: "mongo", "cassandra" <invalid> (supported values = ['postgres', 'sqlite'])`,
+		},
+		{
+			name: "at the cap, every value is named",
+			err: &ErrInvalidValues{
+				Key:     "hide",
+				Values:  []string{"a", "b", "c", "d", "e"},
+				Allowed: []string{"postgres"},
+			},
+			expected: `hide: "a", "b", "c", "d", "e" <invalid> (supported values = ['postgres'])`,
+		},
+		{
+			name: "over the cap, the rest are counted",
+			err: &ErrInvalidValues{
+				Key:     "hide",
+				Values:  []string{"a", "b", "c", "d", "e", "f", "g"},
+				Allowed: []string{"postgres"},
+			},
+			expected: `hide: "a", "b", "c", "d", "e", and 2 more <invalid> (supported values = ['postgres'])`,
+		},
+		{
+			name: "one over the cap",
+			err: &ErrInvalidValues{
+				Key:     "hide",
+				Values:  []string{"a", "b", "c", "d", "e", "f"},
+				Allowed: []string{"postgres"},
+			},
+			expected: `hide: "a", "b", "c", "d", "e", and 1 more <invalid> (supported values = ['postgres'])`,
+		},
+		{
+			name: "empty value stays visible",
+			err: &ErrInvalidValues{
+				Key:     "hide",
+				Values:  []string{""},
+				Allowed: []string{"postgres"},
+			},
+			expected: `hide: "" <invalid> (supported values = ['postgres'])`,
+		},
+		{
+			name: "no values uses 'required' placeholder",
+			err: &ErrInvalidValues{
+				Key:     "hide",
+				Values:  nil,
+				Allowed: []string{"postgres", "sqlite"},
+			},
+			expected: `hide: <required> (supported values = ['postgres', 'sqlite'])`,
+		},
+		{
+			name: "empty allowed list",
+			err: &ErrInvalidValues{
+				Key:     "hide",
+				Values:  []string{"unknown"},
+				Allowed: []string{},
+			},
+			expected: `hide: "unknown" <invalid> (supported values = [''])`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// WHEN: the error is stringified.
+			got := tc.err.Error()
+
+			// THEN: the error is formatted as expected.
+			if got != tc.expected {
+				t.Fatalf(
+					"%s\nErrInvalidValues stringified mismatch\ngot:  %q\nwant: %q",
+					packageName, got, tc.expected,
+				)
+			}
+		})
+	}
+}

--- a/web/api/types/auth.go
+++ b/web/api/types/auth.go
@@ -26,11 +26,14 @@ type LoginRequest struct {
 	Password string `json:"password"`
 }
 
-// AuthMe is the response of /auth/login, /auth/setup and /auth/me:
-// the authenticated user and their effective permission grants.
+// AuthMe is the shared response of the /auth/me-shaped endpoints - /auth/login,
+// /auth/setup, GET and PATCH /auth/me, and PUT and DELETE
+// /auth/me/preferences: the authenticated user, their effective permission
+// grants, and any dashboard preferences they have saved.
 type AuthMe struct {
-	User        auth.User    `json:"user"`
-	Permissions []rbac.Grant `json:"permissions"`
+	User        auth.User                   `json:"user"`
+	Permissions []rbac.Grant                `json:"permissions"`
+	Preferences *store.DashboardPreferences `json:"preferences,omitzero"`
 }
 
 // SetupState is the response of GET /api/v1/auth/setup: the pre-login state
@@ -64,6 +67,15 @@ type AccountUpdateRequest struct {
 	DisplayName     *string `json:"display_name,omitzero"`
 	Email           *string `json:"email,omitzero"`
 	NewPassword     *string `json:"new_password,omitzero"`
+}
+
+// PreferencesUpdateRequest is the body of PUT /api/v1/auth/me/preferences: the
+// signed-in user's dashboard preferences. An omitted field inherits the
+// built-in default; an empty list is an explicit "none", e.g. hide nothing.
+type PreferencesUpdateRequest struct {
+	Hide       []string `json:"hide,omitzero"`
+	View       string   `json:"view,omitzero"`
+	Timestamps []string `json:"timestamps,omitzero"`
 }
 
 // UserCreateRequest is the body of POST /api/v1/users.

--- a/web/api/v1/convert_test.go
+++ b/web/api/v1/convert_test.go
@@ -1872,7 +1872,7 @@ func TestConvertCommands(t *testing.T) {
 		{
 			name:  "empty",
 			input: command.Commands{},
-			want:  apitype.Commands{},
+			want:  nil,
 		},
 		{
 			name: "one",
@@ -2364,7 +2364,7 @@ func TestConvertWebhookHeaders(t *testing.T) {
 		{
 			name:  "empty",
 			input: webhook.Headers{},
-			want:  []apitype.Header{},
+			want:  nil,
 		},
 		{
 			name: "one header",

--- a/web/api/v1/http-api-action_test.go
+++ b/web/api/v1/http-api-action_test.go
@@ -49,7 +49,7 @@ func TestHTTP_HTTPServiceGetActions(t *testing.T) {
 	}
 
 	// GIVEN: an API and a request for the Actions of a Service.
-	file := "TestHTTP_HTTPServiceGetActions.yml"
+	file := t.Name() + ".yml"
 	api := testAPI(t, file)
 	tests := []struct {
 		name      string
@@ -283,7 +283,7 @@ func TestHTTP_HTTPServiceGetActions(t *testing.T) {
 func TestHTTP_HTTPServiceGetActions__requiresActionExecute(t *testing.T) {
 	// GIVEN: an auth-enabled API with two services, only one of which a
 	// scope-limited user can read.
-	file := "TestHTTP_HTTPServiceGetActions__requiresActionExecute.yml"
+	file := t.Name() + ".yml"
 	api, deps, _ := testAuthServer(t, file)
 
 	for _, serviceID := range []string{"readable", "hidden"} {
@@ -420,7 +420,7 @@ func TestHTTP_HTTPServiceRunActions(t *testing.T) {
 	}
 
 	// GIVEN: an API and a request for the Actions of a Service.
-	file := "TestHTTP_HTTPServiceRunActions.yml"
+	file := t.Name() + ".yml"
 	api := testAPI(t, file)
 	tests := []struct {
 		name          string
@@ -951,7 +951,7 @@ func TestHTTP_HTTPServiceRunActions(t *testing.T) {
 func TestHTTP_HTTPServiceRunActions__requiresServiceRead(t *testing.T) {
 	// GIVEN: an auth-enabled API with two services, only one of which a
 	// scope-limited user can read.
-	file := "TestHTTP_HTTPServiceRunActions__requiresServiceRead.yml"
+	file := t.Name() + ".yml"
 	api, deps, _ := testAuthServer(t, file)
 
 	for _, serviceID := range []string{"readable", "hidden"} {

--- a/web/api/v1/http-api-auth-integration_test.go
+++ b/web/api/v1/http-api-auth-integration_test.go
@@ -29,7 +29,7 @@ import (
 
 func TestAPI_Auth__RBAC(t *testing.T) {
 	// GIVEN: users in groups of differing power.
-	file := "TestAPI_Auth__RBAC.yml"
+	file := t.Name() + ".yml"
 	api, deps, _ := testAuthServer(t, file)
 	createAuthUser(t, deps, "viewer", "viewer-password", store.GroupViewer)
 	createAuthUser(t, deps, "loner", "loner-password") // No groups.
@@ -158,7 +158,7 @@ func TestAPI_Auth__RBAC(t *testing.T) {
 
 func TestAPI_Auth__infrastructureFailures(t *testing.T) {
 	// GIVEN: a logged-in admin whose auth store then breaks.
-	file := "TestAPI_Auth__infrastructureFailures.yml"
+	file := t.Name() + ".yml"
 	api, _, dbConn := testAuthServer(t, file)
 	cookie := loginCookie(t, api, "admin", "admin-password")
 
@@ -192,7 +192,7 @@ func TestAPI_Auth__infrastructureFailures(t *testing.T) {
 
 func TestAPI_Auth__disabledMidSession(t *testing.T) {
 	// GIVEN: a logged-in user who is then disabled behind the API's back.
-	file := "TestAPI_Auth__disabledMidSession.yml"
+	file := t.Name() + ".yml"
 	api, deps, dbConn := testAuthServer(t, file)
 	createAuthUser(t, deps, "victim", "victim-password", store.GroupViewer)
 	cookie := loginCookie(t, api, "victim", "victim-password")
@@ -220,7 +220,7 @@ func TestAPI_Auth__disabledMidSession(t *testing.T) {
 
 func TestAPI_Auth__originCheck(t *testing.T) {
 	// GIVEN: a logged-in admin.
-	file := "TestAPI_Auth__originCheck.yml"
+	file := t.Name() + ".yml"
 	api, _, _ := testAuthServer(t, file)
 	cookie := loginCookie(t, api, "admin", "admin-password")
 
@@ -261,7 +261,7 @@ func TestAPI_Auth__originCheck(t *testing.T) {
 
 func TestAPI_Auth__guardDisabled(t *testing.T) {
 	// GIVEN: an API without auth enabled.
-	file := "TestAPI_Auth__guardDisabled.yml"
+	file := t.Name() + ".yml"
 	apiValue := testAPI(t, file)
 	api := &apiValue
 
@@ -300,7 +300,7 @@ func TestAPI_Auth__guardDisabled(t *testing.T) {
 
 func TestAPI_Auth__tokenFallbackMetrics(t *testing.T) {
 	// GIVEN: an auth-enabled API, a guarded metrics handler, and an API token.
-	file := "TestAPI_Auth__tokenFallbackMetrics.yml"
+	file := t.Name() + ".yml"
 	api, deps, _ := testAuthServer(t, file)
 	adminCtx := adminContext(t, api, deps)
 	token, _, err := deps.Store.CreateAPIToken(t.Context(), adminCtx.User.ID, "scrape", nil)
@@ -372,7 +372,7 @@ func TestAPI_Auth__tokenFallbackMetrics(t *testing.T) {
 
 func TestAPI_Auth__guardMetricsErrors(t *testing.T) {
 	// GIVEN: an auth-enabled API.
-	file := "TestAPI_Auth__guardMetricsErrors.yml"
+	file := t.Name() + ".yml"
 	api, deps, dbConn := testAuthServer(t, file)
 	// AND: a user with no grants.
 	loner := createAuthUser(t, deps, "loner", "loner-password")
@@ -428,7 +428,7 @@ func TestAPI_Auth__guardMetricsErrors(t *testing.T) {
 
 func TestAPI_Auth__webSocket(t *testing.T) {
 	// GIVEN: an auth-enabled API with a logged-in admin.
-	file := "TestAPI_Auth__webSocket.yml"
+	file := t.Name() + ".yml"
 	api, _, _ := testAuthServer(t, file)
 	cookie := loginCookie(t, api, "admin", "admin-password")
 
@@ -478,7 +478,7 @@ func TestAPI_Auth__webSocket(t *testing.T) {
 func TestAPI_Auth__serviceScopeHooks(t *testing.T) {
 	// GIVEN: an auth-enabled API whose config holds the fixture service
 	// "test", and a group with a grant scoped to it.
-	file := "TestAPI_Auth__serviceScopeHooks.yml"
+	file := t.Name() + ".yml"
 	api, deps, _ := testAuthServer(t, file)
 	adminCookie := loginCookie(t, api, "admin", "admin-password")
 	group, err := deps.Store.CreateGroup(t.Context(), "scoped", "", []rbac.Grant{
@@ -572,7 +572,7 @@ func TestAPI_Auth__serviceScopeHooks__storeFailure(t *testing.T) {
 	// directly (bypassing the middleware, which would fail first).
 	// Grant maintenance runs before config changes, so a store failure must
 	// abort the request rather than leave grants and services out of step.
-	file := "TestAPI_Auth__serviceScopeHooks__storeFailure.yml"
+	file := t.Name() + ".yml"
 	api, deps, dbConn := testAuthServer(t, file)
 	authCtx := adminContext(t, api, deps)
 	if _, err := dbConn.Exec(`DROP TABLE group_permissions;`); err != nil {

--- a/web/api/v1/http-api-auth.go
+++ b/web/api/v1/http-api-auth.go
@@ -15,6 +15,7 @@
 package v1
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
@@ -163,7 +164,8 @@ func (l *loginLimiter) recordFailure(key string) {
 //
 // Response:
 //
-//	200 OK: with the user and their permission grants (session cookie set).
+//	200 OK: with the user, their permission grants and any saved dashboard
+//	        preferences (session cookie set).
 //	400 Bad Request: on a malformed or oversized body.
 //	401 Unauthorized: uniformly for any credential failure.
 //	429 Too Many Requests: when this (client IP, username) pair is rate-limited.
@@ -210,7 +212,7 @@ func (api *API) httpAuthLogin(w http.ResponseWriter, r *http.Request) {
 	if !api.startSession(w, r, authCtx, logFrom) {
 		return
 	}
-	api.writeAuthMe(w, http.StatusOK, authCtx, logFrom)
+	api.writeAuthMe(r.Context(), w, http.StatusOK, authCtx, logFrom)
 }
 
 // httpAuthSetupState handles GET /api/v1/auth/setup: first-run setup state
@@ -248,7 +250,8 @@ func (api *API) httpAuthSetupState(w http.ResponseWriter, r *http.Request) {
 //
 // Response:
 //
-//	201 Created: with the user and their grants (session cookie set).
+//	201 Created: with the user, their grants and any saved dashboard
+//	             preferences (session cookie set).
 //	400 Bad Request: on a validation fail.
 //	409 Conflict: once setup has completed.
 //	500 Internal Server Error: on an unexpected internal failure.
@@ -302,7 +305,7 @@ func (api *API) httpAuthSetup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	api.writeAuthMe(w, http.StatusCreated, authCtx, logFrom)
+	api.writeAuthMe(r.Context(), w, http.StatusCreated, authCtx, logFrom)
 }
 
 // httpAuthLogout handles POST /api/v1/auth/logout: revokes the session and
@@ -334,8 +337,10 @@ func (api *API) httpAuthLogout(w http.ResponseWriter, r *http.Request) {
 //
 // Response:
 //
-//	200 OK: JSON of the user and their permission grants.
+//	200 OK: JSON of the user, their permission grants and any saved
+//	        dashboard preferences.
 //	401 Unauthorized: with no authenticated user.
+//	500 Internal Server Error: when the preferences cannot be read.
 func (api *API) httpAuthMe(w http.ResponseWriter, r *http.Request) {
 	logFrom := logx.LogFrom{Primary: "httpAuthMe", Secondary: getIP(r)}
 
@@ -344,7 +349,7 @@ func (api *API) httpAuthMe(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	api.writeAuthMe(w, http.StatusOK, authCtx, logFrom)
+	api.writeAuthMeOrFail(r.Context(), w, http.StatusOK, authCtx, logFrom)
 }
 
 // errCurrentPassword is given when an account update fails its
@@ -358,7 +363,8 @@ var errCurrentPassword = errors.New("current password is incorrect")
 //
 // Response:
 //
-//	200 OK: JSON of the updated user and their permission grants.
+//	200 OK: JSON of the updated user, their permission grants and any saved
+//	        dashboard preferences.
 //	400 Bad Request: on a malformed body, an over-long field, a weak new
 //	                 password, or a wrong current password.
 //	401 Unauthorized: with no authenticated user.
@@ -456,7 +462,7 @@ func (api *API) httpAuthMeUpdate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	api.writeAuthMe(w, http.StatusOK, updated, logFrom)
+	api.writeAuthMeOrFail(r.Context(), w, http.StatusOK, updated, logFrom)
 }
 
 // startSession mints a session for authCtx.User and sets the session cookie,
@@ -478,18 +484,51 @@ func (api *API) startSession(
 	return true
 }
 
-// writeAuthMe writes the authenticated user and their grants - the body shared
-// by /auth/login, /auth/setup and /auth/me.
+// authMe builds the body shared by the '/auth/me'-shaped endpoints.
+func authMe(
+	authCtx *auth.Context,
+	preferences *store.DashboardPreferences,
+) apitype.AuthMe {
+	return apitype.AuthMe{
+		User:        authCtx.User,
+		Permissions: authCtx.Grants,
+		Preferences: preferences,
+	}
+}
+
+// writeAuthMe writes the body shared by /auth/login and /auth/setup, degrading
+// to no preferences (logged) when they cannot be read.
 func (api *API) writeAuthMe(
+	ctx context.Context,
 	w http.ResponseWriter,
 	status int,
 	authCtx *auth.Context,
 	logFrom logx.LogFrom,
 ) {
-	api.writeJSONStatus(w, status,
-		apitype.AuthMe{User: authCtx.User, Permissions: authCtx.Grants},
-		logFrom,
-	)
+	preferences, err := api.auth.Store.PreferencesForUser(ctx, authCtx.User.ID)
+	if err != nil {
+		logx.Error(err, logFrom, true)
+	}
+
+	api.writeJSONStatus(w, status, authMe(authCtx, preferences), logFrom)
+}
+
+// writeAuthMeOrFail writes the same body for GET and PATCH /auth/me, but fails
+// the request when the preferences cannot be read.
+func (api *API) writeAuthMeOrFail(
+	ctx context.Context,
+	w http.ResponseWriter,
+	status int,
+	authCtx *auth.Context,
+	logFrom logx.LogFrom,
+) {
+	preferences, err := api.auth.Store.PreferencesForUser(ctx, authCtx.User.ID)
+	if err != nil {
+		api.failAuthStoreRequest(w, err, logFrom, "read preferences")
+		return
+	}
+
+	api.writeJSONStatus(w, status, authMe(authCtx, preferences), logFrom)
 }
 
 // sessionCookie builds the session cookie (maxAge < 0 clears it).

--- a/web/api/v1/http-api-auth_test.go
+++ b/web/api/v1/http-api-auth_test.go
@@ -310,7 +310,7 @@ func TestLoginLimiter_LockKey(t *testing.T) {
 
 func TestAPI_AuthLogin(t *testing.T) {
 	// GIVEN: an auth-enabled API with an admin and a disabled user.
-	file := "TestAPI_AuthLogin.yml"
+	file := t.Name() + ".yml"
 	api, deps, _ := testAuthServer(t, file)
 	disabledUser := createAuthUser(t, deps, "sleeper", "sleeper-password", store.GroupViewer)
 	if _, err := deps.Store.UpdateUser(t.Context(), disabledUser.ID,
@@ -414,7 +414,7 @@ func TestAPI_AuthLogin(t *testing.T) {
 
 func TestAPI_AuthLogin__perIPRateLimit(t *testing.T) {
 	// GIVEN: an auth-enabled API.
-	file := "TestAPI_AuthLogin__perIPRateLimit.yml"
+	file := t.Name() + ".yml"
 	api, _, _ := testAuthServer(t, file)
 
 	prefix := fmt.Sprintf("%s\nPOST /auth/login per-IP rate limit", packageName)
@@ -457,7 +457,7 @@ func TestAPI_AuthLogin__perIPRateLimit(t *testing.T) {
 
 func TestAPI_AuthLogin__rateLimit(t *testing.T) {
 	// GIVEN: an auth-enabled API.
-	file := "TestAPI_AuthLogin__rateLimit.yml"
+	file := t.Name() + ".yml"
 	api, _, _ := testAuthServer(t, file)
 
 	prefix := fmt.Sprintf("%s\nPOST /auth/login rate limit", packageName)
@@ -482,7 +482,7 @@ func TestAPI_AuthLogin__rateLimit(t *testing.T) {
 func TestAPI_AuthLogin__sessionCap(t *testing.T) {
 	// GIVEN: an auth-enabled API whose admin is at the session cap,
 	// with a WebSocket client on their oldest session.
-	file := "TestAPI_AuthLogin__sessionCap.yml"
+	file := t.Name() + ".yml"
 	api, deps, _ := testAuthServer(t, file)
 	oldestCookie := loginCookie(t, api, "admin", "admin-password")
 	for range session.DefaultMaxSessionsPerUser - 1 {
@@ -526,7 +526,7 @@ func TestAPI_AuthLogin__sessionCap(t *testing.T) {
 
 func TestAPI_Auth__noProviders(t *testing.T) {
 	// GIVEN: an API whose provider registry is empty.
-	file := "TestAPI_Auth__noProviders.yml"
+	file := t.Name() + ".yml"
 	api, deps, _ := testAuthServer(t, file)
 	deps.Providers = provider.NewRegistry()
 
@@ -548,7 +548,7 @@ func TestAPI_Auth__noProviders(t *testing.T) {
 
 func TestAPI_Auth__loginEdgeCases(t *testing.T) {
 	// GIVEN: an auth-enabled API.
-	file := "TestAPI_Auth__loginEdgeCases.yml"
+	file := t.Name() + ".yml"
 	api, deps, dbConn := testAuthServer(t, file)
 
 	prefix := fmt.Sprintf("%s\nlogin edge cases", packageName)
@@ -599,7 +599,7 @@ func TestAPI_Auth__loginEdgeCases(t *testing.T) {
 
 func TestAPI_Auth__sessionManagerFailures(t *testing.T) {
 	// GIVEN: an API whose session manager persists to a broken store.
-	file := "TestAPI_Auth__sessionManagerFailures.yml"
+	file := t.Name() + ".yml"
 	api, deps, _ := testAuthServer(t, file)
 	cookie := loginCookie(t, api, "admin", "admin-password")
 
@@ -660,7 +660,7 @@ func TestAPI_Auth__sessionManagerFailures(t *testing.T) {
 
 func TestAPI_AuthSetup(t *testing.T) {
 	// GIVEN: an auth-enabled API with no users yet (first-run setup pending).
-	file := "TestAPI_AuthSetup.yml"
+	file := t.Name() + ".yml"
 	api, deps, _ := testAuthServerPendingSetup(t, file)
 
 	prefix := fmt.Sprintf("%s\nfirst-run setup", packageName)
@@ -828,7 +828,7 @@ func TestAPI_AuthSetup(t *testing.T) {
 
 func TestAPI_AuthSetup__concurrent(t *testing.T) {
 	// GIVEN: first-run setup pending.
-	file := "TestAPI_AuthSetup__concurrent.yml"
+	file := t.Name() + ".yml"
 	api, _, _ := testAuthServerPendingSetup(t, file)
 
 	prefix := fmt.Sprintf("%s\nconcurrent /auth/setup", packageName)
@@ -911,8 +911,7 @@ func TestAPI_AuthSetup__errors(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			file := fmt.Sprintf("TestAPI_AuthSetup__errors_%s.yml",
-				strings.ReplaceAll(tc.name, " ", "_"))
+			file := strings.ReplaceAll(t.Name(), "/", "_") + ".yml"
 			api, _, dbConn := testAuthServerPendingSetup(t, file)
 			if tc.closeDB {
 				_ = dbConn.Close()
@@ -954,7 +953,7 @@ func TestAPI_AuthSetup__errors(t *testing.T) {
 
 func TestAPI__AuthMe_and_Logout(t *testing.T) {
 	// GIVEN: a logged-in admin.
-	file := "TestAPI_AuthMe_And_Logout.yml"
+	file := t.Name() + ".yml"
 	api, _, _ := testAuthServer(t, file)
 	cookie := loginCookie(t, api, "admin", "admin-password")
 
@@ -1029,7 +1028,7 @@ func TestAPI__AuthMe_and_Logout(t *testing.T) {
 func TestAPI_AuthLogout__kicks(t *testing.T) {
 	// GIVEN: an auth-enabled API with a WebSocket client on each of a user's
 	// two sessions.
-	file := "TestAPI_AuthLogout__kicks.yml"
+	file := t.Name() + ".yml"
 	api, deps, _ := testAuthServer(t, file)
 	cookie := loginCookie(t, api, "admin", "admin-password")
 	otherCookie := loginCookie(t, api, "admin", "admin-password")
@@ -1062,7 +1061,7 @@ func TestAPI_AuthLogout__kicks(t *testing.T) {
 
 func TestAPI_AuthMeUpdate__password(t *testing.T) {
 	// GIVEN: an admin with two WebSocket sessions.
-	file := "TestAPI_AuthMeUpdate__password.yml"
+	file := t.Name() + ".yml"
 	api, deps, _ := testAuthServer(t, file)
 	cookie := loginCookie(t, api, "admin", "admin-password")
 	otherCookie := loginCookie(t, api, "admin", "admin-password")
@@ -1226,7 +1225,7 @@ func TestAPI_AuthMeUpdate__profile(t *testing.T) {
 		},
 	}
 
-	file := "TestAPI_AuthMeUpdate__profile.yml"
+	file := t.Name() + ".yml"
 	api, deps, _ := testAuthServer(t, file)
 
 	for i, tc := range tests {
@@ -1332,7 +1331,7 @@ func TestAPI_AuthMeUpdate__profile(t *testing.T) {
 
 func TestAPI_AuthMeUpdate__refusals(t *testing.T) {
 	// GIVEN: a logged-in admin.
-	file := "TestAPI_AuthMeUpdate__refusals.yml"
+	file := t.Name() + ".yml"
 	api, _, _ := testAuthServer(t, file)
 	cookie := loginCookie(t, api, "admin", "admin-password")
 
@@ -1676,7 +1675,7 @@ func TestAPI_AuthMeUpdate__failures(t *testing.T) {
 
 func TestAPI_AuthMeUpdate__bearerRefused(t *testing.T) {
 	// GIVEN: an auth-enabled API and an admin owning an API token.
-	file := "TestAPI_AuthMeUpdate__bearerRefused.yml"
+	file := t.Name() + ".yml"
 	api, deps, _ := testAuthServer(t, file)
 	authCtx := adminContext(t, api, deps)
 	plaintext, _, err := deps.Store.CreateAPIToken(
@@ -1716,7 +1715,7 @@ func TestAPI_AuthMeUpdate__bearerRefused(t *testing.T) {
 
 func TestAPI_Auth__sessionExpired(t *testing.T) {
 	// GIVEN: a server whose sessions are already past their lifetime.
-	file := "TestAPI_Auth__sessionExpired.yml"
+	file := t.Name() + ".yml"
 	api, deps, _ := testAuthServer(t, file)
 	deps.Sessions = session.New(
 		deps.Store,
@@ -1754,7 +1753,7 @@ func TestAPI_Auth__sessionExpired(t *testing.T) {
 
 func TestAPI_Auth__directHandlerBranches(t *testing.T) {
 	// GIVEN: handlers invoked directly with crafted contexts.
-	file := "TestAPI_Auth__directHandlerBranches.yml"
+	file := t.Name() + ".yml"
 	api, deps, _ := testAuthServer(t, file)
 	authCtx := adminContext(t, api, deps)
 
@@ -1793,7 +1792,7 @@ func TestAPI_Auth__directHandlerBranches(t *testing.T) {
 
 func TestAPI_Auth__sessionCookie(t *testing.T) {
 	// GIVEN: APIs with differing prefix/TLS settings.
-	file := "TestAPI_Auth__sessionCookie.yml"
+	file := t.Name() + ".yml"
 	api, _, _ := testAuthServer(t, file)
 
 	prefix := fmt.Sprintf("%s\nsessionCookie", packageName)
@@ -1839,7 +1838,7 @@ func TestAPI_Auth__sessionCookie(t *testing.T) {
 
 func TestAPI_Auth__sessionCookie__secureCookieOverride(t *testing.T) {
 	// GIVEN: an auth-enabled API with no TLS of its own.
-	file := "TestAPI_Auth__sessionCookie__secureCookieOverride.yml"
+	file := t.Name() + ".yml"
 	api, _, _ := testAuthServer(t, file)
 	secureOn, secureOff := true, false
 

--- a/web/api/v1/http-api-config_test.go
+++ b/web/api/v1/http-api-config_test.go
@@ -43,7 +43,7 @@ func TestHTTP_Config(t *testing.T) {
 	lvCfg := lvtest.PlainDefaultsConfig(t)
 
 	// AND: an API and a request for the config.
-	file := "TestHTTP_Config.yml"
+	file := t.Name() + ".yml"
 	api := testAPI(t, file)
 
 	tests := []struct {

--- a/web/api/v1/http-api-edit_auth_test.go
+++ b/web/api/v1/http-api-edit_auth_test.go
@@ -28,7 +28,7 @@ import (
 
 func TestAPI__auth__ServiceEdit__preventsSelfLockout(t *testing.T) {
 	// GIVEN: an auth-enabled API.
-	file := "TestAPI__auth__ServiceEdit__preventsSelfLockout.yml"
+	file := t.Name() + ".yml"
 	api, deps, _ := testAuthServer(t, file)
 	const editID = "retag-me"
 	const outOfScopeID = "team-b-svc"
@@ -208,7 +208,7 @@ func TestAPI__auth__ServiceEdit__preventsSelfLockout(t *testing.T) {
 
 func TestAPI__auth__notifyTestInheritRequiresServiceUpdate(t *testing.T) {
 	// GIVEN: an auth-enabled API.
-	file := "TestAPI__Auth__NotifyTestInherit.yml"
+	file := t.Name() + ".yml"
 	api, deps, _ := testAuthServer(t, file)
 
 	// AND: a user holding notify:execute but no service:update.
@@ -312,7 +312,7 @@ func TestAPI__auth__notifyTestInheritRequiresServiceUpdate(t *testing.T) {
 
 func TestAPI__auth__notifyTestRootInheritRequiresGlobalServiceUpdate(t *testing.T) {
 	// GIVEN: an auth-enabled API with a root notifier holding a secret.
-	file := "TestAPI__Auth__NotifyTestRootInherit.yml"
+	file := t.Name() + ".yml"
 	api, deps, _ := testAuthServer(t, file)
 	api.Config.Notify = shoutrrr.ShoutrrrsDefaults{
 		"root-gotify": shoutrrr.NewDefaults(
@@ -431,7 +431,7 @@ func TestAPI__auth__notifyTestRootInheritRequiresGlobalServiceUpdate(t *testing.
 
 func TestAPI__auth__versionRefreshOverridesRequireServiceUpdate(t *testing.T) {
 	// GIVEN: an auth-enabled API.
-	file := "TestAPI__auth__versionRefreshOverridesRequireServiceUpdate.yml"
+	file := t.Name() + ".yml"
 	api, deps, _ := testAuthServer(t, file)
 
 	// AND: a user able to refresh and read "test", but not update it.

--- a/web/api/v1/http-api-edit_test.go
+++ b/web/api/v1/http-api-edit_test.go
@@ -54,7 +54,7 @@ func TestHTTP_LatestVersionRefreshUncreated(t *testing.T) {
 	}
 
 	// GIVEN: an API and a request to refresh the latest_version of a service.
-	file := "TestHTTP_LatestVersionRefreshUncreated.yml"
+	file := t.Name() + ".yml"
 	api := testAPI(t, file)
 	tests := []struct {
 		name   string
@@ -188,7 +188,7 @@ func TestHTTP_DeployedVersionRefreshUncreated(t *testing.T) {
 	}
 
 	// GIVEN: an API and a request to refresh the deployed_version of a service.
-	file := "TestHTTP_DeployedVersionRefreshUncreated.yml"
+	file := t.Name() + ".yml"
 	api := testAPI(t, file)
 	tests := []struct {
 		name   string
@@ -327,7 +327,7 @@ func TestHTTP_LatestVersionRefresh(t *testing.T) {
 	}
 
 	// GIVEN: an API and a request to refresh the latest_version of a service.
-	file := "TestHTTP_LatestVersionRefresh.yml"
+	file := t.Name() + ".yml"
 	api := testAPI(t, file)
 	apiMu := sync.RWMutex{}
 
@@ -702,7 +702,7 @@ func TestHTTP_DeployedVersionRefresh(t *testing.T) {
 	}
 
 	// GIVEN: an API and a request to refresh the deployed_version of a service.
-	file := "TestHTTP_DeployedVersionRefresh.yml"
+	file := t.Name() + ".yml"
 	api := testAPI(t, file)
 	apiMu := sync.RWMutex{}
 
@@ -1058,7 +1058,7 @@ func TestHTTP_ServiceDetail(t *testing.T) {
 	}
 
 	// GIVEN: an API and a request for detail of a service.
-	file := "TestHTTP_ServiceDetail.yml"
+	file := t.Name() + ".yml"
 	api := testAPI(t, file)
 	apiMu := sync.RWMutex{}
 
@@ -1265,11 +1265,11 @@ func TestHTTP_TemplateParse(t *testing.T) {
 	}
 
 	// GIVEN: an API and a request to parse a template.
-	file := "TestHTTP_TemplateParse.yml"
+	file := t.Name() + ".yml"
 	api := testAPI(t, file)
 	apiMu := sync.RWMutex{}
 
-	testSVC := testService(t, "TestHTTP_TemplateParse", "url", "url", true)
+	testSVC := testService(t, t.Name(), "url", "url", true)
 	apiMu.Lock()
 	api.Config.Service[testSVC.ID] = testSVC
 	apiMu.Unlock()
@@ -1423,7 +1423,7 @@ func TestHTTP_TemplateParse(t *testing.T) {
 
 func TestHTTP_ServiceEdit__routeValidation(t *testing.T) {
 	// GIVEN: an API.
-	file := "TestHTTP_ServiceEdit__routeBinding.yml"
+	file := t.Name() + ".yml"
 	api := testAPI(t, file)
 
 	// AND: requests to a handler with invalid serviceID query params.
@@ -1493,7 +1493,7 @@ func TestHTTP_ServiceEdit__create(t *testing.T) {
 	}
 
 	// GIVEN: an API and a request to create a service.
-	file := "TestHTTP_ServiceEdit__create.yml"
+	file := t.Name() + ".yml"
 	api := testAPI(t, file)
 	apiMu := sync.RWMutex{}
 
@@ -1870,7 +1870,7 @@ func TestHTTP_ServiceEdit__create(t *testing.T) {
 func TestHTTP_ServiceEdit__create__concurrentConflict(t *testing.T) {
 	// GIVEN: an API where the op lock for a not-yet-created service ID is already
 	// held by an in-flight operation (e.g. a concurrent create of the same ID).
-	file := "TestHTTP_ServiceEdit__create__concurrentConflict.yml"
+	file := t.Name() + ".yml"
 	api := testAPI(t, file)
 	const serviceID = "TestHTTP_ServiceEdit_createConflict"
 
@@ -1930,7 +1930,7 @@ func TestHTTP_ServiceEdit__edit(t *testing.T) {
 	}
 
 	// GIVEN: an API and a request to edit a service.
-	file := "TestHTTP_ServiceEdit__edit.yml"
+	file := t.Name() + ".yml"
 	api := testAPI(t, file)
 	apiMu := sync.RWMutex{}
 
@@ -2351,7 +2351,7 @@ func TestHTTP_ServiceEdit__edit__missingID(t *testing.T) {
 
 func TestHTTP_ServiceEdit__edit__renameToExistingID(t *testing.T) {
 	// GIVEN: an API with two services - one to edit, and one whose ID we rename to.
-	file := "TestHTTP_ServiceEdit__edit__renameToExistingID.yml"
+	file := t.Name() + ".yml"
 	api := testAPI(t, file)
 
 	const (
@@ -2409,7 +2409,7 @@ func TestHTTP_ServiceEdit__edit__renameToExistingID(t *testing.T) {
 
 func TestHTTP_ServiceEdit__edit__renameToExistingName(t *testing.T) {
 	// GIVEN: an API with two services - one to edit, and one whose Name we rename another ID to.
-	file := "TestHTTP_ServiceEdit__edit__renameToExistingName.yml"
+	file := t.Name() + ".yml"
 	api := testAPI(t, file)
 
 	const (
@@ -2468,7 +2468,7 @@ func TestHTTP_ServiceEdit__edit__renameToExistingName(t *testing.T) {
 func TestHTTP_ServiceEdit__edit__rejectsAnIDHeldAsAnotherServiceName(t *testing.T) {
 	// GIVEN: an auth-enabled API, a group holding a service-scoped grant, and a
 	// second service named after the ID the first is about to take.
-	file := "TestHTTP_ServiceEdit__edit__restoresGrants.yml"
+	file := t.Name() + ".yml"
 	api, deps, _ := testAuthServer(t, file)
 
 	const (
@@ -2569,7 +2569,7 @@ func TestHTTP_ServiceEdit__edit__secrets(t *testing.T) {
 	}
 
 	// GIVEN: an API and a request to edit a service.
-	file := "TestHTTP_ServiceEdit__edit__secrets.yml"
+	file := t.Name() + ".yml"
 	api := testAPI(t, file)
 	apiMu := sync.RWMutex{}
 
@@ -2968,7 +2968,7 @@ func TestHTTP_ServiceEdit__edit__secrets(t *testing.T) {
 func TestHTTP_ServiceEdit__edit__waitsForInFlightOp(t *testing.T) {
 	// GIVEN: an API and an absent service whose op lock is held by an in-flight
 	// operation (a refresh, or another edit/delete).
-	file := "TestHTTP_ServiceEdit__edit__waitsForInFlightOp.yml"
+	file := t.Name() + ".yml"
 	api := testAPI(t, file)
 	const serviceID = "TestHTTP_ServiceEdit_waits-absent"
 
@@ -3118,9 +3118,9 @@ func TestHTTP_ServiceDelete(t *testing.T) {
 	}
 
 	// GIVEN: an API and a request to delete a service.
-	file := "TestHTTP_ServiceDelete.yml"
+	file := t.Name() + ".yml"
 	api := testAPI(t, file)
-	svc := testService(t, "TestHTTP_ServiceDelete", "url", "url", true)
+	svc := testService(t, t.Name(), "url", "url", true)
 	svc.HardDefaults.Status.DatabaseChannel = api.Config.DatabaseChannel
 	_ = api.Config.AddService("", svc)
 	// Drain db from the Service addition.
@@ -3249,7 +3249,7 @@ func TestHTTP_NotifyTest(t *testing.T) {
 	}
 
 	// GIVEN: an API and a request to test a notify.
-	file := "TestHTTP_NotifyTest.yml"
+	file := t.Name() + ".yml"
 	api := testAPI(t, file)
 
 	validNotify := shoutrrrtest.Shoutrrr(t, false, false)
@@ -3668,7 +3668,7 @@ func TestHTTP_ServiceOpLock__conflict(t *testing.T) {
 	)
 
 	// GIVEN: an API.
-	file := "TestHTTP_ServiceOpLock__conflict.yml"
+	file := t.Name() + ".yml"
 	api := testAPI(t, file)
 
 	tests := []struct {
@@ -3768,7 +3768,7 @@ func TestHTTP_ServiceOpLock__conflict(t *testing.T) {
 
 func TestHTTP_ServiceDelete__waitsForInFlightOp(t *testing.T) {
 	// GIVEN: an API with a service whose op lock is held by an in-flight operation.
-	file := "TestHTTP_ServiceDelete__waitsForInFlightOp.yml"
+	file := t.Name() + ".yml"
 	api := testAPI(t, file)
 	svc := testService(t, "TestHTTP_ServiceDelete_waits", "url", "url", true)
 	svc.HardDefaults.Status.DatabaseChannel = api.Config.DatabaseChannel

--- a/web/api/v1/http-api-flags_test.go
+++ b/web/api/v1/http-api-flags_test.go
@@ -32,7 +32,7 @@ import (
 
 func TestHTTP_HTTPFlags(t *testing.T) {
 	// GIVEN: an API and a request for the flag var values.
-	file := "TestHTTP_HTTPFlags.yml"
+	file := t.Name() + ".yml"
 	api := testAPI(t, file)
 	apiMu := sync.RWMutex{}
 	bodyRegex := test.TrimJSON(`

--- a/web/api/v1/http-api-groups_test.go
+++ b/web/api/v1/http-api-groups_test.go
@@ -63,7 +63,7 @@ func seededGroupIDs(t *testing.T, deps *AuthDeps) map[string]string {
 
 func TestAPI_HTTPGroupList(t *testing.T) {
 	// GIVEN: an auth-enabled API.
-	file := "TestAPI_HTTPGroupList.yml"
+	file := t.Name() + ".yml"
 	api, deps, dbConn := testAuthServer(t, file)
 	// AND: a logged-in admin.
 	adminCookie := loginCookie(t, api, "admin", "admin-password")
@@ -114,7 +114,7 @@ func TestAPI_HTTPGroupList(t *testing.T) {
 
 func TestAPI_HTTPGroupCreate(t *testing.T) {
 	// GIVEN: an auth-enabled API.
-	file := "TestAPI_HTTPGroupCreate.yml"
+	file := t.Name() + ".yml"
 	api, deps, _ := testAuthServer(t, file)
 	// AND: a logged-in admin, and a logged-in non-admin.
 	adminCookie := loginCookie(t, api, "admin", "admin-password")
@@ -239,7 +239,7 @@ func TestAPI_HTTPGroupCreate(t *testing.T) {
 
 func TestAPI_HTTPGroupCreate__nameBounds(t *testing.T) {
 	// GIVEN: an auth-enabled API and an admin session.
-	file := "TestAPI_HTTPGroupCreate__nameBounds.yml"
+	file := t.Name() + ".yml"
 	api, _, _ := testAuthServer(t, file)
 	adminCookie := loginCookie(t, api, "admin", "admin-password")
 
@@ -334,7 +334,7 @@ func TestAPI_HTTPGroupCreate__nameBounds(t *testing.T) {
 
 func TestAPI_HTTPGroupGet(t *testing.T) {
 	// GIVEN: an auth-enabled API.
-	file := "TestAPI_HTTPGroupGet.yml"
+	file := t.Name() + ".yml"
 	api, deps, _ := testAuthServer(t, file)
 	// AND: a logged-in admin and a target group.
 	adminCookie := loginCookie(t, api, "admin", "admin-password")
@@ -389,7 +389,7 @@ func TestAPI_HTTPGroupGet(t *testing.T) {
 
 func TestAPI_HTTPGroupUpdate(t *testing.T) {
 	// GIVEN: an auth-enabled API.
-	file := "TestAPI_HTTPGroupUpdate.yml"
+	file := t.Name() + ".yml"
 	api, deps, _ := testAuthServer(t, file)
 	// AND: a logged-in admin.
 	adminCookie := loginCookie(t, api, "admin", "admin-password")
@@ -577,7 +577,7 @@ func TestAPI_HTTPGroupUpdate(t *testing.T) {
 func TestAPI_HTTPGroupUpdate__kicks(t *testing.T) {
 	// GIVEN: an auth-enabled API with WebSocket clients for the admin,
 	// a group member, and an outsider.
-	file := "TestAPI_HTTPGroupUpdate__kicks.yml"
+	file := t.Name() + ".yml"
 	api, deps, _ := testAuthServer(t, file)
 	adminCookie := loginCookie(t, api, "admin", "admin-password")
 	group, err := deps.Store.CreateGroup(t.Context(), "crew", "", nil)
@@ -653,7 +653,7 @@ func TestAPI_HTTPGroupUpdate__kicks(t *testing.T) {
 
 func TestAPI_HTTPGroupDelete(t *testing.T) {
 	// GIVEN: an auth-enabled API.
-	file := "TestAPI_HTTPGroupDelete.yml"
+	file := t.Name() + ".yml"
 	api, deps, _ := testAuthServer(t, file)
 	// AND: a logged-in admin and a target group.
 	adminCookie := loginCookie(t, api, "admin", "admin-password")
@@ -720,7 +720,7 @@ func TestAPI_HTTPGroupDelete(t *testing.T) {
 func TestAPI_HTTPGroupDelete__kicks(t *testing.T) {
 	// GIVEN: an auth-enabled API with WebSocket clients for the admin,
 	// a group member, and an outsider.
-	file := "TestAPI_HTTPGroupDelete__kicks.yml"
+	file := t.Name() + ".yml"
 	api, deps, _ := testAuthServer(t, file)
 	adminCookie := loginCookie(t, api, "admin", "admin-password")
 	group, err := deps.Store.CreateGroup(t.Context(), "crew", "", nil)
@@ -764,7 +764,7 @@ func TestAPI_HTTPGroupDelete__kicks(t *testing.T) {
 
 func TestAPI_HTTPGroupDelete__membershipLookupFailure(t *testing.T) {
 	// GIVEN: an auth-enabled API whose membership table has gone away.
-	file := "TestAPI_HTTPGroupDelete__membershipLookupFailure.yml"
+	file := t.Name() + ".yml"
 	api, deps, dbConn := testAuthServer(t, file)
 	authCtx := adminContext(t, api, deps)
 	target, err := deps.Store.CreateGroup(t.Context(), "doomed", "", nil)
@@ -799,7 +799,7 @@ func TestAPI_HTTPGroupDelete__membershipLookupFailure(t *testing.T) {
 func TestAPI_HTTPGroupUpdate__kickLookupFailure(t *testing.T) {
 	// GIVEN: an auth-enabled API on a store whose membership listing fails
 	// whist the group update itself still succeeds.
-	file := "TestAPI_HTTPGroupUpdate__kickLookupFailure.yml"
+	file := t.Name() + ".yml"
 	api, deps, _ := testAuthServer(t, file)
 	authCtx := adminContext(t, api, deps)
 
@@ -840,7 +840,7 @@ func TestAPI_HTTPGroupUpdate__kickLookupFailure(t *testing.T) {
 
 func TestAPI_HTTPPermissionCatalogue(t *testing.T) {
 	// GIVEN: an auth-enabled API.
-	file := "TestAPI_HTTPPermissionCatalogue.yml"
+	file := t.Name() + ".yml"
 	api, deps, _ := testAuthServer(t, file)
 	// AND: a logged-in admin and viewer.
 	adminCookie := loginCookie(t, api, "admin", "admin-password")

--- a/web/api/v1/http-api-preferences.go
+++ b/web/api/v1/http-api-preferences.go
@@ -1,0 +1,90 @@
+// Copyright [2026] [Argus]
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	"net/http"
+
+	"github.com/release-argus/Argus/auth/store"
+	"github.com/release-argus/Argus/internal/logx"
+	apitype "github.com/release-argus/Argus/web/api/types"
+)
+
+// httpAuthMePreferencesUpdate handles PUT /api/v1/auth/me/preferences: the
+// signed-in user replacing their dashboard preferences. Fields left out
+// of the body go back to inheriting the built-in default; an empty list is an
+// explicit "none", e.g. hide nothing.
+//
+// Response:
+//
+//	200 OK: JSON of the user, their permission grants and the saved preferences.
+//	        Setting nothing discards them, removing the row.
+//	400 Bad Request: on a malformed or oversized body, or an unknown value.
+//	401 Unauthorized: with no authenticated user.
+//	500 Internal Server Error: on a store failure.
+func (api *API) httpAuthMePreferencesUpdate(w http.ResponseWriter, r *http.Request) {
+	logFrom := logx.LogFrom{Primary: "httpAuthMePreferencesUpdate", Secondary: getIP(r)}
+
+	authCtx := api.authCtxOr401(w, r)
+	if authCtx == nil {
+		return
+	}
+
+	var request apitype.PreferencesUpdateRequest
+	if !api.decodeAuthBody(w, r, &request) {
+		return
+	}
+	// The store validates, and its ErrInvalidPreference maps to 400.
+	stored, err := api.auth.Store.SetPreferences(
+		r.Context(),
+		authCtx.User.ID,
+		store.DashboardPreferences{
+			Hide:       request.Hide,
+			View:       request.View,
+			Timestamps: request.Timestamps,
+		},
+	)
+	if err != nil {
+		api.failAuthStoreRequest(w, err, logFrom, "save preferences")
+		return
+	}
+
+	api.writeJSONStatus(w, http.StatusOK, authMe(authCtx, stored), logFrom)
+}
+
+// httpAuthMePreferencesDelete handles DELETE /api/v1/auth/me/preferences: the
+// signed-in user discarding their dashboard preferences, returning to the
+// built-in defaults.
+//
+// Response:
+//
+//	200 OK: JSON of the user and their permission grants, with no preferences.
+//	401 Unauthorized: with no authenticated user.
+//	500 Internal Server Error: on a store failure.
+func (api *API) httpAuthMePreferencesDelete(w http.ResponseWriter, r *http.Request) {
+	logFrom := logx.LogFrom{Primary: "httpAuthMePreferencesDelete", Secondary: getIP(r)}
+
+	authCtx := api.authCtxOr401(w, r)
+	if authCtx == nil {
+		return
+	}
+
+	if err := api.auth.Store.DeletePreferences(r.Context(), authCtx.User.ID); err != nil {
+		api.failAuthStoreRequest(w, err, logFrom, "discard preferences")
+		return
+	}
+
+	api.writeJSONStatus(w, http.StatusOK, authMe(authCtx, nil), logFrom)
+}

--- a/web/api/v1/http-api-preferences_test.go
+++ b/web/api/v1/http-api-preferences_test.go
@@ -1,0 +1,579 @@
+// Copyright [2026] [Argus]
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build unit
+
+package v1
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/release-argus/Argus/auth/store"
+	"github.com/release-argus/Argus/config/decode"
+	"github.com/release-argus/Argus/internal/test"
+	apitype "github.com/release-argus/Argus/web/api/types"
+)
+
+// preferencesPath is the route the signed-in user's preferences live on.
+const preferencesPath = "/api/v1/auth/me/preferences"
+
+// decodeAuthMe parses an '/auth/me'-shaped response body.
+func decodeAuthMe(t *testing.T, prefix string, body []byte) apitype.AuthMe {
+	t.Helper()
+
+	var me apitype.AuthMe
+	if err := decode.Unmarshal("json", body, &me); err != nil {
+		t.Fatalf(
+			"%s\nparse response: %v",
+			prefix, err,
+		)
+	}
+	return me
+}
+
+func TestAPI_AuthMePreferences__roundTrip(t *testing.T) {
+	// GIVEN: an auth-enabled API and a signed-in admin.
+	file := "TestAPI_AuthMePreferences__roundTrip.yml"
+	api, _, _ := testAuthServer(t, file)
+	cookie := loginCookie(t, api, "admin", "admin-password")
+
+	prefix := fmt.Sprintf("%s\nhttpAuthMePreferences()", packageName)
+
+	// WHEN: /auth/me is read before anything is saved.
+	me := decodeAuthMe(t, prefix,
+		serveAuth(api, authedRequest(
+			http.MethodGet, "/api/v1/auth/me",
+			"",
+			cookie,
+		)).Body.Bytes(),
+	)
+
+	// THEN: it carries no preferences.
+	if me.Preferences != nil {
+		t.Errorf(
+			"%s\nunsaved preferences present\ngot: %+v",
+			prefix, *me.Preferences,
+		)
+	}
+
+	// WHEN: preferences are saved.
+	w := serveAuth(api, authedRequest(
+		http.MethodPut, preferencesPath,
+		test.TrimJSON(`{
+			"hide":       ["inactive", "up_to_date"],
+			"view":       "table",
+			"timestamps": ["found"]
+		}`),
+		cookie,
+	))
+
+	// THEN: the response carries them back, in catalogue order.
+	if got, want := w.Code, http.StatusOK; got != want {
+		t.Fatalf(
+			"%s\nstatus mismatch\ngot:  %d - %s\nwant: %d",
+			prefix,
+			got, w.Body.String(),
+			want,
+		)
+	}
+	me = decodeAuthMe(t, prefix, w.Body.Bytes())
+	if me.Preferences == nil {
+		t.Fatalf(
+			"%s\nsaved preferences missing from the response\ngot: %s",
+			prefix, w.Body.String(),
+		)
+	}
+	if testErr := test.AssertSlicesEqual(t,
+		me.Preferences.Hide, []string{store.HideUpToDate, store.HideInactive},
+		prefix, "hide",
+	); testErr != nil {
+		t.Error(testErr)
+	}
+	if testErr := test.AssertSlicesEqual(t,
+		me.Preferences.Timestamps, []string{store.TimestampFound},
+		prefix, "timestamps",
+	); testErr != nil {
+		t.Error(testErr)
+	}
+	if got, want := me.Preferences.View, store.ViewTable; got != want {
+		t.Errorf(
+			"%s\nview mismatch\ngot:  %q\nwant: %q",
+			prefix, got, want,
+		)
+	}
+
+	// AND: /auth/me carries the same preferences.
+	me = decodeAuthMe(t, prefix,
+		serveAuth(api, authedRequest(
+			http.MethodGet, "/api/v1/auth/me",
+			"",
+			cookie,
+		)).Body.Bytes(),
+	)
+	if me.Preferences == nil || me.Preferences.View != store.ViewTable {
+		t.Errorf(
+			"%s\n/auth/me lost the saved preferences\ngot: %+v",
+			prefix, me.Preferences,
+		)
+	}
+
+	// WHEN: they are discarded.
+	w = serveAuth(api, authedRequest(http.MethodDelete, preferencesPath, "", cookie))
+
+	// THEN: the response, and /auth/me, carry none.
+	if got, want := w.Code, http.StatusOK; got != want {
+		t.Fatalf(
+			"%s\ndelete status mismatch\ngot:  %d - %s\nwant: %d",
+			prefix,
+			got, w.Body.String(),
+			want,
+		)
+	}
+	if me := decodeAuthMe(t, prefix, w.Body.Bytes()); me.Preferences != nil {
+		t.Errorf(
+			"%s\npreferences survived the delete\ngot: %+v",
+			prefix, *me.Preferences,
+		)
+	}
+
+	// AND: discarding again is not an error.
+	if w := serveAuth(api, authedRequest(
+		http.MethodDelete, preferencesPath,
+		"",
+		cookie,
+	)); w.Code != http.StatusOK {
+		t.Errorf(
+			"%s\nsecond delete status mismatch\ngot:  %d - %s\nwant: %d",
+			prefix,
+			w.Code, w.Body.String(),
+			http.StatusOK,
+		)
+	}
+}
+
+func TestAPI_AuthMePreferencesUpdate(t *testing.T) {
+	// GIVEN: an auth-enabled API and a signed-in admin.
+	file := "TestAPI_AuthMePreferencesUpdate.yml"
+	api, _, _ := testAuthServer(t, file)
+	cookie := loginCookie(t, api, "admin", "admin-password")
+
+	tests := []struct {
+		name        string
+		body        string
+		noCookie    bool
+		wantStatus  int
+		wantMessage string
+	}{
+		{
+			name: "valid/every field",
+			body: test.TrimJSON(`{
+				"hide":["skipped"],
+				"view":"grid",
+				"timestamps":["deployed","queried"]
+			}`),
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "valid/explicitly hide nothing",
+			body: test.TrimJSON(`{
+				"hide":[],
+				"view":"grid",
+				"timestamps":[]
+			}`),
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "valid/only one field, the rest inherit",
+			body:       `{"view":"table"}`,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:        "invalid/unknown hide name",
+			body:        `{"hide":["upToDate"]}`,
+			wantStatus:  http.StatusBadRequest,
+			wantMessage: `hide: "upToDate" <invalid> (`,
+		},
+		{
+			name:        "invalid/unknown view",
+			body:        `{"view":"list"}`,
+			wantStatus:  http.StatusBadRequest,
+			wantMessage: `view: "list" <invalid> (`,
+		},
+		{
+			name:        "invalid/unknown timestamp name",
+			body:        `{"timestamps":["last_queried"]}`,
+			wantStatus:  http.StatusBadRequest,
+			wantMessage: `timestamps: "last_queried" <invalid> (`,
+		},
+		{
+			name:        "invalid/malformed body",
+			body:        `{"view":`,
+			wantStatus:  http.StatusBadRequest,
+			wantMessage: "parse request",
+		},
+		{
+			name:       "invalid/no session",
+			body:       `{"view":"grid"}`,
+			noCookie:   true,
+			wantStatus: http.StatusUnauthorized,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			prefix := fmt.Sprintf("%s\nhttpAuthMePreferencesUpdate(%s)", packageName, tc.name)
+
+			// WHEN: the preferences are PUT.
+			sessionCookie := cookie
+			if tc.noCookie {
+				sessionCookie = nil
+			}
+			w := serveAuth(api, authedRequest(
+				http.MethodPut, preferencesPath,
+				tc.body,
+				sessionCookie,
+			))
+
+			// THEN: the status is as expected.
+			if got := w.Code; got != tc.wantStatus {
+				t.Fatalf(
+					"%s\nstatus mismatch\ngot:  %d - %s\nwant: %d",
+					prefix, got, w.Body.String(), tc.wantStatus,
+				)
+			}
+
+			// AND: a rejection says which value it objected to.
+			if tc.wantMessage == "" {
+				return
+			}
+			var body map[string]string
+			if err := decode.Unmarshal("json", w.Body.Bytes(), &body); err != nil {
+				t.Fatalf(
+					"%s\nparse error response: %v",
+					prefix, err,
+				)
+			}
+			if !strings.Contains(body["message"], tc.wantMessage) {
+				t.Errorf(
+					"%s\nmessage mismatch\ngot:  %q\nwant it to contain: %q",
+					prefix, body["message"], tc.wantMessage,
+				)
+			}
+		})
+	}
+}
+
+func TestAPI_AuthMePreferences__perUser(t *testing.T) {
+	// GIVEN: an auth-enabled API with two signed-in users.
+	file := "TestAPI_AuthMePreferences__perUser.yml"
+	api, deps, _ := testAuthServer(t, file)
+	createAuthUser(t, deps, "other", "other-password")
+	adminCookie := loginCookie(t, api, "admin", "admin-password")
+	otherCookie := loginCookie(t, api, "other", "other-password")
+
+	prefix := fmt.Sprintf("%s\nhttpAuthMePreferences() per user", packageName)
+
+	// WHEN: one of them saves preferences.
+	if w := serveAuth(api, authedRequest(
+		http.MethodPut, preferencesPath,
+		`{"view":"table"}`,
+		adminCookie,
+	)); w.Code != http.StatusOK {
+		t.Fatalf(
+			"%s\nsave failed\ngot: %d - %s",
+			prefix, w.Code, w.Body.String(),
+		)
+	}
+
+	// THEN: the other user still has none.
+	me := decodeAuthMe(t, prefix,
+		serveAuth(api, authedRequest(
+			http.MethodGet, "/api/v1/auth/me",
+			"",
+			otherCookie,
+		)).Body.Bytes(),
+	)
+	if me.Preferences != nil {
+		t.Errorf(
+			"%s\nanother user's preferences leaked\ngot: %+v",
+			prefix, *me.Preferences,
+		)
+	}
+}
+
+func TestAPI_AuthMePreferencesUpdate__bearerRefused(t *testing.T) {
+	// GIVEN: an auth-enabled API and an admin owning an API token.
+	file := "TestAPI_AuthMePreferencesUpdate__bearerRefused.yml"
+	api, deps, _ := testAuthServer(t, file)
+	authCtx := adminContext(t, api, deps)
+	plaintext, _, err := deps.Store.CreateAPIToken(
+		t.Context(), authCtx.User.ID, "ci", nil,
+	)
+	if err != nil {
+		t.Fatalf(
+			"%s\nsetup CreateAPIToken failed: %v",
+			packageName, err,
+		)
+	}
+
+	prefix := fmt.Sprintf("%s\nhttpAuthMePreferences() from a token", packageName)
+
+	for _, method := range []string{http.MethodPut, http.MethodDelete} {
+		t.Run("method="+method, func(t *testing.T) {
+			// WHEN: the token tries to change the owner's preferences.
+			req := authedRequest(method, preferencesPath, `{"view":"table"}`, nil)
+			req.Header.Set("Authorization", "Bearer "+plaintext)
+			w := serveAuth(api, req)
+
+			// THEN: the request is refused.
+			if got, want := w.Code, http.StatusForbidden; got != want {
+				t.Errorf(
+					"%s\nstatus mismatch\ngot:  %d - %s\nwant: %d",
+					prefix, got, w.Body.String(), want,
+				)
+			}
+		})
+	}
+}
+
+func TestAPI_AuthMePreferences__explicitEmpty(t *testing.T) {
+	// GIVEN: an auth-enabled API and a signed-in admin.
+	file := "TestAPI_AuthMePreferences__explicitEmpty.yml"
+	api, _, _ := testAuthServer(t, file)
+	cookie := loginCookie(t, api, "admin", "admin-password")
+
+	prefix := fmt.Sprintf("%s\nhttpAuthMePreferences() explicit none", packageName)
+
+	// WHEN: empty lists are saved.
+	w := serveAuth(api, authedRequest(http.MethodPut, preferencesPath,
+		`{"hide":[],"view":"grid","timestamps":[]}`, cookie))
+	if got, want := w.Code, http.StatusOK; got != want {
+		t.Fatalf(
+			"%s\nstatus mismatch\ngot:  %d - %s\nwant: %d",
+			prefix, got, w.Body.String(), want,
+		)
+	}
+
+	// THEN: they come back present and empty.
+	for _, body := range []struct {
+		name string
+		read func() []byte
+	}{
+		{
+			name: "PUT response",
+			read: func() []byte {
+				return w.Body.Bytes()
+			},
+		},
+		{
+			name: "later /auth/me",
+			read: func() []byte {
+				return serveAuth(api,
+					authedRequest(http.MethodGet, "/api/v1/auth/me", "", cookie)).Body.Bytes()
+			},
+		},
+	} {
+		me := decodeAuthMe(t, prefix, body.read())
+		if me.Preferences == nil {
+			t.Fatalf(
+				"%s\n%s dropped the saved preferences",
+				prefix, body.name,
+			)
+		}
+		if testErr := test.AssertSlicesEqual(
+			t, me.Preferences.Hide, []string{}, prefix, body.name+" hide",
+		); testErr != nil {
+			t.Error(testErr)
+		}
+		if testErr := test.AssertSlicesEqual(
+			t, me.Preferences.Timestamps, []string{}, prefix, body.name+" timestamps",
+		); testErr != nil {
+			t.Error(testErr)
+		}
+	}
+}
+
+func TestAPI_AuthMePreferences__unauthenticatedAndBrokenStore(t *testing.T) {
+	// GIVEN: an auth-enabled API, an admin, and a handle on its database.
+	file := "TestAPI_AuthMePreferences__unauthenticatedAndBrokenStore.yml"
+	api, deps, dbConn := testAuthServer(t, file)
+	authCtx := adminContext(t, api, deps)
+
+	prefix := fmt.Sprintf("%s\nhttpAuthMePreferences() failure paths", packageName)
+
+	tests := []struct {
+		name    string
+		method  string
+		handler func(http.ResponseWriter, *http.Request)
+	}{
+		{name: "update", method: http.MethodPut, handler: api.httpAuthMePreferencesUpdate},
+		{name: "delete", method: http.MethodDelete, handler: api.httpAuthMePreferencesDelete},
+	}
+
+	// WHEN: each handler is called with no authenticated user.
+	for _, tc := range tests {
+		t.Run("no auth context/"+tc.name, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			tc.handler(recorder,
+				httptest.NewRequest(tc.method, preferencesPath, strings.NewReader(`{"view":"grid"}`)),
+			)
+
+			// THEN: it answers 401.
+			if got, want := recorder.Code, http.StatusUnauthorized; got != want {
+				t.Errorf(
+					"%s\nstatus mismatch\ngot:  %d - %s\nwant: %d",
+					prefix, got, recorder.Body.String(), want,
+				)
+			}
+		})
+	}
+
+	// AND: the store breaks beneath them.
+	_ = dbConn.Close()
+
+	for _, tc := range tests {
+		t.Run("broken store/"+tc.name, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			tc.handler(recorder, withAuthCtx(
+				httptest.NewRequest(tc.method, preferencesPath, strings.NewReader(`{"view":"grid"}`)),
+				authCtx,
+			))
+
+			// THEN: the failure reads as 500.
+			if got, want := recorder.Code, http.StatusInternalServerError; got != want {
+				t.Errorf(
+					"%s\nstatus mismatch\ngot:  %d - %s\nwant: %d",
+					prefix, got, recorder.Body.String(), want,
+				)
+			}
+		})
+	}
+}
+
+func TestAPI_AuthMePreferences__partialSaveInherits(t *testing.T) {
+	// GIVEN: an auth-enabled API and a signed-in admin.
+	file := "TestAPI_AuthMePreferences__partialSaveInherits.yml"
+	api, _, _ := testAuthServer(t, file)
+	cookie := loginCookie(t, api, "admin", "admin-password")
+
+	// WHEN: only the filters are saved.
+	body := `{"hide":["skipped"]}`
+	w := serveAuth(api, authedRequest(
+		http.MethodPut, preferencesPath,
+		body,
+		cookie,
+	))
+	prefix := fmt.Sprintf(
+		"%s\nhttpAuthMePreferences(%s) partial save",
+		packageName, body,
+	)
+	if got, want := w.Code, http.StatusOK; got != want {
+		t.Fatalf(
+			"%s\nstatus mismatch\ngot:  %d - %s\nwant: %d",
+			prefix, got, w.Body.String(), want,
+		)
+	}
+
+	// THEN: the layout and timestamps stay absent, so they keep inheriting.
+	me := decodeAuthMe(t, prefix, w.Body.Bytes())
+	if me.Preferences == nil {
+		t.Fatalf(
+			"%s\nsaved preferences missing\ngot: %s",
+			prefix, w.Body.String(),
+		)
+	}
+	if testErr := test.AssertSlicesEqual(
+		t, me.Preferences.Hide, []string{store.HideSkipped}, prefix, "hide",
+	); testErr != nil {
+		t.Error(testErr)
+	}
+	if testErr := test.AssertSlicesEqual(
+		t, me.Preferences.Timestamps, nil, prefix, "timestamps",
+	); testErr != nil {
+		t.Error(testErr)
+	}
+	if me.Preferences.View != "" {
+		t.Errorf(
+			"%s\nview should be absent\ngot: %q",
+			prefix, me.Preferences.View,
+		)
+	}
+}
+
+func TestAPI_AuthMe__preferencesReadFails(t *testing.T) {
+	// GIVEN: an auth-enabled API and an admin with saved preferences.
+	file := "TestAPI_AuthMe__preferencesReadFails.yml"
+	api, deps, dbConn := testAuthServer(t, file)
+	authCtx := adminContext(t, api, deps)
+	prefs := store.DashboardPreferences{View: store.ViewTable}
+	if _, err := deps.Store.SetPreferences(t.Context(), authCtx.User.ID, prefs); err != nil {
+		t.Fatalf(
+			"%s\nsetup SetPreferences(%s) failed: %v",
+			packageName, prefs, err,
+		)
+	}
+
+	prefix := fmt.Sprintf("%s\npreferences read failure", packageName)
+
+	// AND: reading them now fails.
+	if _, err := dbConn.ExecContext(t.Context(), `DROP TABLE user_preferences;`); err != nil {
+		t.Fatalf(
+			"%s drop table failed: %v",
+			prefix, err,
+		)
+	}
+
+	// WHEN: the caller signs in.
+	body := `{"username":"admin","password":"admin-password"}`
+	w := serveAuth(api, httptest.NewRequest(
+		http.MethodPost, "/api/v1/auth/login",
+		strings.NewReader(body),
+	))
+
+	// THEN: sign-in still succeeds, without the preferences it could not read.
+	if got, want := w.Code, http.StatusOK; got != want {
+		t.Fatalf(
+			"%s\nlogin should degrade, not fail\ngot:  %d - %s\nwant: %d",
+			prefix, got, w.Body.String(), want,
+		)
+	}
+	if me := decodeAuthMe(t, prefix, w.Body.Bytes()); me.Preferences != nil {
+		t.Errorf(
+			"%s\nlogin carried preferences it could not read\ngot: %+v",
+			prefix, *me.Preferences,
+		)
+	}
+
+	// WHEN: /auth/me is read instead.
+	recorder := httptest.NewRecorder()
+	api.httpAuthMe(recorder, withAuthCtx(
+		httptest.NewRequest(
+			http.MethodGet, "/api/v1/auth/me",
+			nil,
+		),
+		authCtx,
+	))
+
+	// THEN: it fails rather than reporting preferences the user has not lost.
+	if got, want := recorder.Code, http.StatusInternalServerError; got != want {
+		t.Errorf(
+			"%s\nstatus mismatch\ngot:  %d - %s\nwant: %d",
+			prefix, got, recorder.Body.String(), want,
+		)
+	}
+}

--- a/web/api/v1/http-api-preferences_test.go
+++ b/web/api/v1/http-api-preferences_test.go
@@ -48,8 +48,7 @@ func decodeAuthMe(t *testing.T, prefix string, body []byte) apitype.AuthMe {
 
 func TestAPI_AuthMePreferences__roundTrip(t *testing.T) {
 	// GIVEN: an auth-enabled API and a signed-in admin.
-	file := "TestAPI_AuthMePreferences__roundTrip.yml"
-	api, _, _ := testAuthServer(t, file)
+	api, _, _ := testAuthServer(t, t.Name()+".yml")
 	cookie := loginCookie(t, api, "admin", "admin-password")
 
 	prefix := fmt.Sprintf("%s\nhttpAuthMePreferences()", packageName)
@@ -168,8 +167,7 @@ func TestAPI_AuthMePreferences__roundTrip(t *testing.T) {
 
 func TestAPI_AuthMePreferencesUpdate(t *testing.T) {
 	// GIVEN: an auth-enabled API and a signed-in admin.
-	file := "TestAPI_AuthMePreferencesUpdate.yml"
-	api, _, _ := testAuthServer(t, file)
+	api, _, _ := testAuthServer(t, t.Name()+".yml")
 	cookie := loginCookie(t, api, "admin", "admin-password")
 
 	tests := []struct {
@@ -280,8 +278,7 @@ func TestAPI_AuthMePreferencesUpdate(t *testing.T) {
 
 func TestAPI_AuthMePreferences__perUser(t *testing.T) {
 	// GIVEN: an auth-enabled API with two signed-in users.
-	file := "TestAPI_AuthMePreferences__perUser.yml"
-	api, deps, _ := testAuthServer(t, file)
+	api, deps, _ := testAuthServer(t, t.Name()+".yml")
 	createAuthUser(t, deps, "other", "other-password")
 	adminCookie := loginCookie(t, api, "admin", "admin-password")
 	otherCookie := loginCookie(t, api, "other", "other-password")
@@ -318,8 +315,7 @@ func TestAPI_AuthMePreferences__perUser(t *testing.T) {
 
 func TestAPI_AuthMePreferencesUpdate__bearerRefused(t *testing.T) {
 	// GIVEN: an auth-enabled API and an admin owning an API token.
-	file := "TestAPI_AuthMePreferencesUpdate__bearerRefused.yml"
-	api, deps, _ := testAuthServer(t, file)
+	api, deps, _ := testAuthServer(t, t.Name()+".yml")
 	authCtx := adminContext(t, api, deps)
 	plaintext, _, err := deps.Store.CreateAPIToken(
 		t.Context(), authCtx.User.ID, "ci", nil,
@@ -353,8 +349,7 @@ func TestAPI_AuthMePreferencesUpdate__bearerRefused(t *testing.T) {
 
 func TestAPI_AuthMePreferences__explicitEmpty(t *testing.T) {
 	// GIVEN: an auth-enabled API and a signed-in admin.
-	file := "TestAPI_AuthMePreferences__explicitEmpty.yml"
-	api, _, _ := testAuthServer(t, file)
+	api, _, _ := testAuthServer(t, t.Name()+".yml")
 	cookie := loginCookie(t, api, "admin", "admin-password")
 
 	prefix := fmt.Sprintf("%s\nhttpAuthMePreferences() explicit none", packageName)
@@ -410,8 +405,7 @@ func TestAPI_AuthMePreferences__explicitEmpty(t *testing.T) {
 
 func TestAPI_AuthMePreferences__unauthenticatedAndBrokenStore(t *testing.T) {
 	// GIVEN: an auth-enabled API, an admin, and a handle on its database.
-	file := "TestAPI_AuthMePreferences__unauthenticatedAndBrokenStore.yml"
-	api, deps, dbConn := testAuthServer(t, file)
+	api, deps, dbConn := testAuthServer(t, t.Name()+".yml")
 	authCtx := adminContext(t, api, deps)
 
 	prefix := fmt.Sprintf("%s\nhttpAuthMePreferences() failure paths", packageName)
@@ -467,8 +461,7 @@ func TestAPI_AuthMePreferences__unauthenticatedAndBrokenStore(t *testing.T) {
 
 func TestAPI_AuthMePreferences__partialSaveInherits(t *testing.T) {
 	// GIVEN: an auth-enabled API and a signed-in admin.
-	file := "TestAPI_AuthMePreferences__partialSaveInherits.yml"
-	api, _, _ := testAuthServer(t, file)
+	api, _, _ := testAuthServer(t, t.Name()+".yml")
 	cookie := loginCookie(t, api, "admin", "admin-password")
 
 	// WHEN: only the filters are saved.
@@ -517,8 +510,7 @@ func TestAPI_AuthMePreferences__partialSaveInherits(t *testing.T) {
 
 func TestAPI_AuthMe__preferencesReadFails(t *testing.T) {
 	// GIVEN: an auth-enabled API and an admin with saved preferences.
-	file := "TestAPI_AuthMe__preferencesReadFails.yml"
-	api, deps, dbConn := testAuthServer(t, file)
+	api, deps, dbConn := testAuthServer(t, t.Name()+".yml")
 	authCtx := adminContext(t, api, deps)
 	prefs := store.DashboardPreferences{View: store.ViewTable}
 	if _, err := deps.Store.SetPreferences(t.Context(), authCtx.User.ID, prefs); err != nil {

--- a/web/api/v1/http-api-service_test.go
+++ b/web/api/v1/http-api-service_test.go
@@ -36,7 +36,7 @@ import (
 
 func TestAPI_HTTPServiceOrderGet(t *testing.T) {
 	// GIVEN: an API and a request for the service order.
-	file := "TestAPI_HTTPServiceOrderGet.yml"
+	file := t.Name() + ".yml"
 	api := testAPI(t, file)
 	apiMu := sync.RWMutex{}
 
@@ -106,7 +106,7 @@ func TestAPI_HTTPServiceOrderGet(t *testing.T) {
 
 func TestAPI_HTTPServiceOrderGet__filteredByGrants(t *testing.T) {
 	// GIVEN: an auth-enabled API.
-	file := "TestAPI_HTTPServiceOrderGet__filteredByGrants.yml"
+	file := t.Name() + ".yml"
 	api, deps, _ := testAuthServer(t, file) // Config holds service "test".
 
 	// AND: users whose grants cover all, some, one, or none of the services.
@@ -218,7 +218,7 @@ func TestAPI_HTTPServiceOrderGet__filteredByGrants(t *testing.T) {
 
 func TestAPI_HTTPServiceOrderSet(t *testing.T) {
 	// GIVEN: an API and a request to set the service order.
-	file := "TestAPI_HTTPServiceOrderSet.yml"
+	file := t.Name() + ".yml"
 	api := testAPI(t, file)
 	apiMu := sync.RWMutex{}
 
@@ -365,9 +365,9 @@ func TestAPI_HTTPServiceOrderSet(t *testing.T) {
 }
 
 func TestAPI_HTTPServiceSummary(t *testing.T) {
-	testSVC := testService(t, "TestAPI_HTTPServiceSummary", "url", "url", true)
+	testSVC := testService(t, t.Name(), "url", "url", true)
 	// GIVEN: an API and a request for detail of a service.
-	file := "TestAPI_HTTPServiceSummary.yml"
+	file := t.Name() + ".yml"
 	api := testAPI(t, file)
 	api.Config.Service[testSVC.ID] = testSVC
 	api.Config.Order = append(api.Config.Order, testSVC.ID)

--- a/web/api/v1/http-api-status_test.go
+++ b/web/api/v1/http-api-status_test.go
@@ -33,7 +33,7 @@ import (
 func TestHTTP_HTTPWebSocketToken(t *testing.T) {
 	// GIVEN: an API without Basic Auth (wsTokens is nil).
 	prefix := fmt.Sprintf("%q\nAPI.httpWebSocketToken()", packageName)
-	file := "TestHTTP_HTTPWebSocketToken.yml"
+	file := t.Name() + ".yml"
 	api := testAPI(t, file)
 
 	// WHEN: a request is made for a WebSocket token.
@@ -168,7 +168,7 @@ func TestHTTP_HTTPWebSocketToken__authGated(t *testing.T) {
 
 func TestHTTP_HTTPRuntimeInfo(t *testing.T) {
 	// GIVEN: an API and a request for the runtime info.
-	file := "TestHTTP_HTTPRuntimeInfo.yml"
+	file := t.Name() + ".yml"
 	api := testAPI(t, file)
 	apiMu := sync.RWMutex{}
 	bodyRegex := test.TrimJSON(`

--- a/web/api/v1/http-api-tokens_test.go
+++ b/web/api/v1/http-api-tokens_test.go
@@ -32,7 +32,7 @@ func TestAPI_HTTPAPITokenList(t *testing.T) {
 	prefix := fmt.Sprintf("%s\nhttpAPITokenList()", packageName)
 
 	// GIVEN: an auth-enabled API.
-	file := "TestAPI_HTTPAPITokenList.yml"
+	file := t.Name() + ".yml"
 	api, deps, dbConn := testAuthServer(t, file)
 	// AND: a logged-in admin (owning a token).
 	adminCookie := loginCookie(t, api, "admin", "admin-password")
@@ -118,7 +118,7 @@ func TestAPI_HTTPAPITokenList(t *testing.T) {
 
 func TestAPI_HTTPAPITokenCreate(t *testing.T) {
 	// GIVEN: an auth-enabled API.
-	file := "TestAPI_HTTPAPITokenCreate.yml"
+	file := t.Name() + ".yml"
 	api, deps, dbConn := testAuthServer(t, file)
 	// AND: a logged-in admin.
 	adminCookie := loginCookie(t, api, "admin", "admin-password")
@@ -294,7 +294,7 @@ func TestAPI_HTTPAPITokenCreate(t *testing.T) {
 
 func TestAPI_HTTPAPITokenDelete(t *testing.T) {
 	// GIVEN: an auth-enabled API.
-	file := "TestAPI_HTTPAPITokenDelete.yml"
+	file := t.Name() + ".yml"
 	api, deps, _ := testAuthServer(t, file)
 	// AND: a logged-in admin (owning a token).
 	adminCookie := loginCookie(t, api, "admin", "admin-password")
@@ -372,7 +372,7 @@ func TestAPI_HTTPAPITokenDelete(t *testing.T) {
 
 func TestAPI_HTTPAPIToken__bearerCannotManageTokens(t *testing.T) {
 	// GIVEN: an auth-enabled API and an admin owning a plaintext API token.
-	file := "TestAPI_HTTPAPIToken__bearerCannotManageTokens.yml"
+	file := t.Name() + ".yml"
 	api, deps, _ := testAuthServer(t, file)
 	authCtx := adminContext(t, api, deps)
 	plaintext, token, err := deps.Store.CreateAPIToken(

--- a/web/api/v1/http-api-users_test.go
+++ b/web/api/v1/http-api-users_test.go
@@ -36,7 +36,7 @@ import (
 
 func TestAPI_HTTPUserList(t *testing.T) {
 	// GIVEN: an auth-enabled API.
-	file := "TestAPI_HTTPUserList.yml"
+	file := t.Name() + ".yml"
 	api, deps, dbConn := testAuthServer(t, file)
 	// AND: a logged-in admin and a second user.
 	adminCookie := loginCookie(t, api, "admin", "admin-password")
@@ -88,7 +88,7 @@ func TestAPI_HTTPUserList(t *testing.T) {
 
 func TestAPI_HTTPUserCreate(t *testing.T) {
 	// GIVEN: an auth-enabled API.
-	file := "TestAPI_HTTPUserCreate.yml"
+	file := t.Name() + ".yml"
 	api, _, _ := testAuthServer(t, file)
 	// AND: a logged-in admin.
 	adminCookie := loginCookie(t, api, "admin", "admin-password")
@@ -219,7 +219,7 @@ func TestAPI_HTTPUserCreate(t *testing.T) {
 
 func TestAPI_HTTPUserCreate__fieldBounds(t *testing.T) {
 	// GIVEN: an auth-enabled API and an admin session.
-	file := "TestAPI_HTTPUserCreate__fieldBounds.yml"
+	file := t.Name() + ".yml"
 	api, _, _ := testAuthServer(t, file)
 	adminCookie := loginCookie(t, api, "admin", "admin-password")
 
@@ -314,7 +314,7 @@ func TestAPI_HTTPUserCreate__fieldBounds(t *testing.T) {
 
 func TestAPI_HTTPUserGet(t *testing.T) {
 	// GIVEN: an auth-enabled API.
-	file := "TestAPI_HTTPUserGet.yml"
+	file := t.Name() + ".yml"
 	api, deps, _ := testAuthServer(t, file)
 	// AND: a logged-in admin and a target user.
 	adminCookie := loginCookie(t, api, "admin", "admin-password")
@@ -362,7 +362,7 @@ func TestAPI_HTTPUserGet(t *testing.T) {
 
 func TestAPI_HTTPUserUpdate(t *testing.T) {
 	// GIVEN: an auth-enabled API.
-	file := "TestAPI_HTTPUserUpdate.yml"
+	file := t.Name() + ".yml"
 	api, deps, _ := testAuthServer(t, file)
 	// AND: a logged-in admin and logged-in target users.
 	adminCookie := loginCookie(t, api, "admin", "admin-password")
@@ -566,7 +566,7 @@ func TestAPI_HTTPUserUpdate(t *testing.T) {
 
 func TestAPI_HTTPUserUpdate__kicks(t *testing.T) {
 	// GIVEN: an auth-enabled API with WebSocket clients for the admin and a member.
-	file := "TestAPI_HTTPUserUpdate__kicks.yml"
+	file := t.Name() + ".yml"
 	api, deps, _ := testAuthServer(t, file)
 	adminCookie := loginCookie(t, api, "admin", "admin-password")
 	member := createAuthUser(t, deps, "member", "member-password", store.GroupOperator)
@@ -624,7 +624,7 @@ func TestAPI_HTTPUserUpdate__kicks(t *testing.T) {
 
 func TestAPI_HTTPUserDelete(t *testing.T) {
 	// GIVEN: an auth-enabled API.
-	file := "TestAPI_HTTPUserDelete.yml"
+	file := t.Name() + ".yml"
 	api, deps, _ := testAuthServer(t, file)
 	// AND: a logged-in admin, viewer, and targets.
 	adminCookie := loginCookie(t, api, "admin", "admin-password")
@@ -735,7 +735,7 @@ func TestAPI_HTTPUserDelete(t *testing.T) {
 
 func TestAPI_HTTPUserDelete__kicks(t *testing.T) {
 	// GIVEN: an auth-enabled API with WebSocket clients for the admin and a doomed user.
-	file := "TestAPI_HTTPUserDelete__kicks.yml"
+	file := t.Name() + ".yml"
 	api, deps, _ := testAuthServer(t, file)
 	adminCookie := loginCookie(t, api, "admin", "admin-password")
 	doomed := createAuthUser(t, deps, "doomed", "doomed-password")
@@ -767,7 +767,7 @@ func TestAPI_HTTPUserDelete__kicks(t *testing.T) {
 
 func TestAPI_HTTPUserDelete__cascadeFailure(t *testing.T) {
 	// GIVEN: an auth-enabled API with a user to delete.
-	file := "TestAPI_HTTPUserDelete__cascadeFailure.yml"
+	file := t.Name() + ".yml"
 	api, deps, dbConn := testAuthServer(t, file)
 	adminCookie := loginCookie(t, api, "admin", "admin-password")
 	victim := createAuthUser(t, deps, "victim", "victim-password")

--- a/web/api/v1/http-ui.go
+++ b/web/api/v1/http-ui.go
@@ -29,6 +29,7 @@ import (
 func (api *API) SetupRoutesNodeJS() {
 	nodeRoutes := []string{
 		"/account",
+		"/account/defaults",
 		"/account/profile",
 		"/account/tokens",
 		"/admin",

--- a/web/api/v1/http-ui_test.go
+++ b/web/api/v1/http-ui_test.go
@@ -50,6 +50,12 @@ func TestHTTP_SetupRoutesNodeJS(t *testing.T) {
 			wantContent: "text/html",
 		},
 		{
+			name:        "account defaults route",
+			route:       "/account/defaults",
+			wantStatus:  http.StatusOK,
+			wantContent: "text/html",
+		},
+		{
 			name:        "admin users route",
 			route:       "/admin/users",
 			wantStatus:  http.StatusOK,

--- a/web/api/v1/http.go
+++ b/web/api/v1/http.go
@@ -74,6 +74,12 @@ func (api *API) SetupRoutesAPI() {
 		//   PATCH, change your own account (gated on the current password).
 		v1Router.HandleFunc("/auth/me",
 			api.requireSessionAuth(api.httpAuthMeUpdate)).Methods(http.MethodPatch)
+		//   PUT, replace the dashboard display defaults of the authenticated user.
+		v1Router.HandleFunc("/auth/me/preferences",
+			api.requireSessionAuth(api.httpAuthMePreferencesUpdate)).Methods(http.MethodPut)
+		//   DELETE, back to the built-in display defaults for the authenticated user.
+		v1Router.HandleFunc("/auth/me/preferences",
+			api.requireSessionAuth(api.httpAuthMePreferencesDelete)).Methods(http.MethodDelete)
 		// Users - CRUD.
 		v1Router.HandleFunc("/users",
 			api.requireAdmin(api.httpUserList)).Methods(http.MethodGet)

--- a/web/api/v1/http_test.go
+++ b/web/api/v1/http_test.go
@@ -467,7 +467,7 @@ func TestAPI_SetupWebSocket(t *testing.T) {
 
 func TestAPI_SetupWebSocket__originCheck(t *testing.T) {
 	// GIVEN: an auth-enabled API, and a logged-in admin.
-	file := "TestAPI_SetupWebSocket__originCheck.yml"
+	file := t.Name() + ".yml"
 	api, _, _ := testAuthServer(t, file)
 	cookie := loginCookie(t, api, "admin", "admin-password")
 	server := httptest.NewServer(api.BaseRouter)
@@ -580,7 +580,7 @@ func TestAPI_SetupWebSocket__originUncheckedWithoutAuth(t *testing.T) {
 
 func TestAPI_SetupWebSocket__sessionAuth(t *testing.T) {
 	// GIVEN: an auth-enabled API wired for session auth, and a logged-in admin.
-	file := "TestAPI_SetupWebSocket__sessionAuth.yml"
+	file := t.Name() + ".yml"
 	api, deps, _ := testAuthServer(t, file)
 	cookie := loginCookie(t, api, "admin", "admin-password")
 	adminID := adminContext(t, api, deps).User.ID

--- a/web/api/v1/middleware-auth_test.go
+++ b/web/api/v1/middleware-auth_test.go
@@ -1897,17 +1897,19 @@ func TestAPI_SetupRoutesAPI__everyRouteIsGuarded(t *testing.T) {
 	// selfServiceRoutes are the routes that answer a grantless session and filter
 	// to the caller's own account and grants.
 	selfServiceRoutes := map[string]bool{
-		"POST   /api/v1/auth/login":    true,
-		"GET    /api/v1/auth/setup":    true,
-		"POST   /api/v1/auth/setup":    true,
-		"POST   /api/v1/auth/logout":   true,
-		"GET    /api/v1/auth/me":       true,
-		"PATCH  /api/v1/auth/me":       true,
-		"GET    /api/v1/tokens":        true,
-		"POST   /api/v1/tokens":        true,
-		"DELETE /api/v1/tokens/{id}":   true,
-		"GET    /api/v1/ws-token":      true,
-		"GET    /api/v1/service/order": true,
+		"POST   /api/v1/auth/login":          true,
+		"GET    /api/v1/auth/setup":          true,
+		"POST   /api/v1/auth/setup":          true,
+		"POST   /api/v1/auth/logout":         true,
+		"GET    /api/v1/auth/me":             true,
+		"PATCH  /api/v1/auth/me":             true,
+		"PUT    /api/v1/auth/me/preferences": true,
+		"DELETE /api/v1/auth/me/preferences": true,
+		"GET    /api/v1/tokens":              true,
+		"POST   /api/v1/tokens":              true,
+		"DELETE /api/v1/tokens/{id}":         true,
+		"GET    /api/v1/ws-token":            true,
+		"GET    /api/v1/service/order":       true,
 	}
 	const methodLen = 6
 

--- a/web/api/v1/middleware-auth_test.go
+++ b/web/api/v1/middleware-auth_test.go
@@ -94,7 +94,7 @@ func TestAuthContextFrom(t *testing.T) {
 
 func TestAPI_AuthMiddleware(t *testing.T) {
 	// GIVEN: an auth-enabled API.
-	file := "TestAPI_AuthMiddleware.yml"
+	file := t.Name() + ".yml"
 	api, _, _ := testAuthServer(t, file)
 	cookie := loginCookie(t, api, "admin", "admin-password")
 
@@ -256,7 +256,7 @@ func TestAPI_AuthCtxOr401(t *testing.T) {
 
 func TestAPI_Authenticate(t *testing.T) {
 	// GIVEN: an auth-enabled API.
-	file := "TestAPI_Authenticate.yml"
+	file := t.Name() + ".yml"
 	api, deps, _ := testAuthServer(t, file)
 	// AND: a session cookie and API token.
 	cookie := loginCookie(t, api, "admin", "admin-password")
@@ -427,7 +427,7 @@ func TestBearerToken(t *testing.T) {
 
 func TestAPI_AuthenticateAPIToken(t *testing.T) {
 	// GIVEN: an auth-enabled API.
-	file := "TestAPI_AuthenticateAPIToken.yml"
+	file := t.Name() + ".yml"
 	api, deps, dbConn := testAuthServer(t, file)
 	// AND: a live token.
 	adminCtx := adminContext(t, api, deps)
@@ -528,7 +528,7 @@ func TestAPI_AuthenticateAPIToken(t *testing.T) {
 
 func TestAPI_AuthenticateSession(t *testing.T) {
 	// GIVEN: an auth-enabled API.
-	file := "TestAPI_AuthenticateSession.yml"
+	file := t.Name() + ".yml"
 	api, deps, _ := testAuthServer(t, file)
 	// AND: a live session.
 	adminCtx := adminContext(t, api, deps)
@@ -588,7 +588,7 @@ func TestAPI_AuthenticateSession(t *testing.T) {
 
 func TestAPI_VerifyLocalCredentials(t *testing.T) {
 	// GIVEN: an auth-enabled API.
-	file := "TestAPI_VerifyLocalCredentials.yml"
+	file := t.Name() + ".yml"
 	api, deps, _ := testAuthServer(t, file)
 
 	prefix := fmt.Sprintf("%s\nverifyLocalCredentials()", packageName)
@@ -654,7 +654,7 @@ func TestAPI_VerifyLocalCredentials(t *testing.T) {
 
 func TestAPI_ContextForUser(t *testing.T) {
 	// GIVEN: an auth-enabled API with enabled and disabled users.
-	file := "TestAPI_ContextForUser.yml"
+	file := t.Name() + ".yml"
 	api, deps, dbConn := testAuthServer(t, file)
 	adminCtx := adminContext(t, api, deps)
 	sleeper := createAuthUser(t, deps, "sleeper", "sleeper-password")
@@ -736,7 +736,7 @@ func TestAPI_ContextForUser(t *testing.T) {
 
 func TestAPI__auth__scopedGrants(t *testing.T) {
 	// GIVEN: an auth-enabled API.
-	file := "TestAPI_Auth__ScopedGrants.yml"
+	file := t.Name() + ".yml"
 	api, deps, _ := testAuthServer(t, file)
 	api.Config.OrderMu.Lock()
 	api.Config.Service["tagged"] = &service.Service{
@@ -838,7 +838,7 @@ func TestAPI__auth__scopedGrants(t *testing.T) {
 
 func TestAPI__auth__GuardAnyScopeOf(t *testing.T) {
 	// GIVEN: an auth-enabled API.
-	file := "TestAPI_Auth__GuardAnyScopeOf.yml"
+	file := t.Name() + ".yml"
 	api, deps, _ := testAuthServer(t, file)
 
 	// AND: a user whose only grant is a single service-scoped service:update -
@@ -932,7 +932,7 @@ func TestAPI__auth__GuardAnyScopeOf(t *testing.T) {
 
 func TestAPI__auth__permissionChangesApplyImmediately(t *testing.T) {
 	// GIVEN: an auth-enabled API.
-	file := "TestAPI__auth__permissionChangesApplyImmediately.yml"
+	file := t.Name() + ".yml"
 	api, deps, _ := testAuthServer(t, file)
 
 	// AND: a logged-in user in a group with grants.
@@ -997,7 +997,7 @@ func TestAPI__auth__permissionChangesApplyImmediately(t *testing.T) {
 
 func TestAPI_OriginCheckMiddleware__secFetchSite(t *testing.T) {
 	// GIVEN: an auth-enabled API and a logged-in session.
-	file := "TestAPI_OriginCheckMiddleware__secFetchSite.yml"
+	file := t.Name() + ".yml"
 	api, _, _ := testAuthServer(t, file)
 	cookie := loginCookie(t, api, "admin", "admin-password")
 
@@ -1174,7 +1174,7 @@ func TestOriginCheckMiddleware(t *testing.T) {
 
 func TestAPI_Guard(t *testing.T) {
 	// GIVEN: an auth-enabled API.
-	file := "TestAPI_Guard.yml"
+	file := t.Name() + ".yml"
 	api, deps, _ := testAuthServer(t, file)
 	// AND: an admin.
 	adminCtx := adminContext(t, api, deps)
@@ -1295,7 +1295,7 @@ func TestAPI_Guard(t *testing.T) {
 
 func TestAPI_RequireAdmin(t *testing.T) {
 	// GIVEN: an auth-enabled API.
-	file := "TestAPI_RequireAdmin.yml"
+	file := t.Name() + ".yml"
 	api, deps, _ := testAuthServer(t, file)
 
 	// AND: an admin.
@@ -1386,7 +1386,7 @@ func TestAPI_RequireAdmin(t *testing.T) {
 
 func TestAPI_ReadableServices(t *testing.T) {
 	// GIVEN: an auth-enabled API with tagged services
-	file := "TestAPI_ReadableServices.yml"
+	file := t.Name() + ".yml"
 	api, deps, _ := testAuthServer(t, file)
 	api.Config.OrderMu.Lock()
 	api.Config.Service["test"] = &service.Service{}
@@ -1543,7 +1543,7 @@ func TestAPI_ReadableServices(t *testing.T) {
 
 func TestAPI_ActionableServices(t *testing.T) {
 	// GIVEN: an auth-enabled API with a service.
-	file := "TestAPI_ActionableServices.yml"
+	file := t.Name() + ".yml"
 	api, deps, _ := testAuthServer(t, file)
 
 	// AND: users of differing service_action:execute scopes.
@@ -1682,7 +1682,7 @@ func TestAPI_KickWebSocketClients(t *testing.T) {
 	}
 
 	// GIVEN: an API without auth/hub wiring.
-	file := "TestAPI_KickWebSocketClients.yml"
+	file := t.Name() + ".yml"
 	apiValue := testAPI(t, file)
 	apiNoAuth := &apiValue
 	client := &Client{
@@ -1739,7 +1739,7 @@ func TestAPI_KickWebSocketClients(t *testing.T) {
 
 func TestAPI_ServiceTarget(t *testing.T) {
 	// GIVEN: an auth-enabled API whose config holds a tagged service.
-	file := "TestAPI_ServiceTarget.yml"
+	file := t.Name() + ".yml"
 	api, _, _ := testAuthServer(t, file)
 	api.Config.OrderMu.Lock()
 	api.Config.Service["tagged"] = &service.Service{
@@ -1808,7 +1808,7 @@ func TestAPI_ServiceTarget(t *testing.T) {
 
 func TestAPI_SetupRoutesAPI__openRoutesSkipAuthentication(t *testing.T) {
 	// GIVEN: an auth-enabled API.
-	file := "TestAPI_SetupRoutesAPI__openRoutesSkipAuthentication.yml"
+	file := t.Name() + ".yml"
 	api, _, _ := testAuthServer(t, file)
 
 	// AND: the routes that answer without a session, and ones that must not.
@@ -1889,7 +1889,7 @@ func TestAPI_SetupRoutesAPI__openRoutesSkipAuthentication(t *testing.T) {
 
 func TestAPI_SetupRoutesAPI__everyRouteIsGuarded(t *testing.T) {
 	// GIVEN: an auth-enabled API, and a user with zero grants.
-	file := "TestAPI_SetupRoutesAPI__everyRouteIsGuarded.yml"
+	file := t.Name() + ".yml"
 	api, deps, _ := testAuthServer(t, file)
 	createAuthUser(t, deps, "loner", "loner-password")
 	cookie := loginCookie(t, api, "loner", "loner-password")
@@ -2035,8 +2035,7 @@ func TestAPI_DemoMiddleware(t *testing.T) {
 			if srv.routePrefix != "" {
 				opts = append(opts, withRoutePrefix(srv.routePrefix))
 			}
-			file := "TestAPI_DemoMiddleware" +
-				strings.ReplaceAll(srv.routePrefix, "/", "_") + ".yml"
+			file := strings.ReplaceAll(t.Name(), "/", "_") + ".yml"
 			api, deps, _ := testAuthServer(t, file, opts...)
 			if _, err := deps.Store.CreateGroup(
 				t.Context(), "demo", "", demoGrants(),
@@ -2180,7 +2179,7 @@ func TestAPI_DemoMiddleware__disarmed(t *testing.T) {
 			t.Parallel()
 
 			// AND: an API configured that way, with a member and a non-member.
-			file := "TestAPI_DemoMiddleware__disarmed_" + tc.group + ".yml"
+			file := strings.ReplaceAll(t.Name(), "/", "_") + ".yml"
 			api, deps, _ := testAuthServer(t, file, withDemoGroup(tc.group))
 			if _, err := deps.Store.CreateGroup(
 				t.Context(), "demo", "", demoGrants(),
@@ -2219,7 +2218,7 @@ func TestAPI_DemoMiddleware__disarmed(t *testing.T) {
 
 func TestAPI_DemoMiddleware__logoutStillWorks(t *testing.T) {
 	// GIVEN: an auth-enabled API and a logged-in demo user.
-	file := "TestAPI_DemoMiddleware__logoutStillWorks.yml"
+	file := t.Name() + ".yml"
 	api, deps, _ := testAuthServer(t, file, withDemoGroup("demo"))
 	if _, err := deps.Store.CreateGroup(
 		t.Context(), "demo", "", demoGrants(),

--- a/web/api/v1/util.go
+++ b/web/api/v1/util.go
@@ -208,7 +208,8 @@ func (api *API) failAuthStoreRequest(
 	case errors.Is(err, store.ErrNotFound):
 		failRequest(&w, fmt.Errorf("%s failed: not found", action), http.StatusNotFound)
 	case errors.Is(err, store.ErrUnknownGroup),
-		errors.Is(err, store.ErrInvalidGrant):
+		errors.Is(err, store.ErrInvalidGrant),
+		errors.Is(err, store.ErrInvalidPreference):
 		failRequest(&w, fmt.Errorf("%s failed: %w", action, err), http.StatusBadRequest)
 	case errors.Is(err, store.ErrUsernameTaken),
 		errors.Is(err, store.ErrGroupNameTaken),

--- a/web/api/v1/yaml_help_test.go
+++ b/web/api/v1/yaml_help_test.go
@@ -26,7 +26,9 @@ import (
 
 func writeFile(path string, data string) {
 	data = strings.TrimPrefix(data, "\n")
-	_ = os.WriteFile(path, []byte(data), 0644)
+	if err := os.WriteFile(path, []byte(data), 0644); err != nil {
+		panic(err)
+	}
 }
 
 func testYAML_Argus(path string) {

--- a/web/ui/react-app/playwright.config.ts
+++ b/web/ui/react-app/playwright.config.ts
@@ -38,6 +38,7 @@ const MUTATING_TEST_TIMEOUT = 90_000;
 const AUTH_SPECS = [
 	'auth.spec.ts',
 	'auth-account.spec.ts',
+	'auth-defaults.spec.ts',
 	'auth-permissions.spec.ts',
 	'auth-responsive.spec.ts',
 ];

--- a/web/ui/react-app/src/App.tsx
+++ b/web/ui/react-app/src/App.tsx
@@ -23,6 +23,7 @@ import { WebSocketProvider } from '@/contexts/websocket';
 import { notifyUnauthorised } from '@/lib/auth-events';
 import { QUERY_KEYS } from '@/lib/query-keys';
 import {
+	AccountDefaultsPage,
 	AccountPage,
 	ApprovalsPage,
 	ConfigPage,
@@ -104,6 +105,7 @@ const ProtectedApp = (): ReactElement => {
 								<Route element={<SettingsLayout />}>
 									<Route element={<Navigate replace to="profile" />} index />
 									<Route element={<AccountPage />} path="profile" />
+									<Route element={<AccountDefaultsPage />} path="defaults" />
 									<Route element={<TokensPage />} path="tokens" />
 								</Route>
 							</Route>

--- a/web/ui/react-app/src/components/approvals/toolbar/filter-dropdown.tsx
+++ b/web/ui/react-app/src/components/approvals/toolbar/filter-dropdown.tsx
@@ -28,7 +28,6 @@ import {
 	ACTIVE_HIDE_VALUES,
 	APPROVALS_TOOLBAR_VIEW,
 	approvalsToolbarViewOptions,
-	DEFAULT_HIDE_VALUE,
 	HideValue,
 	type HideValueType,
 	TABLE_COLUMNS_ORDER_STORAGE_KEY,
@@ -49,13 +48,14 @@ type HideOptionKey = (typeof toolbarHideOptions)[number]['key'];
  *
  * A dropdown component for toggling visibility filters on services.
  * It lists all `HIDE_OPTIONS`, allowing users to show or hide specific statuses,
- * and includes a reset option to restore default visibility (`DEFAULT_HIDE_VALUE`).
+ * and includes a reset option to restore the default visibility.
  */
 const FilterDropdown: FC = () => {
 	const queryClient = useQueryClient();
 	const {
 		values,
 		cardTimestamps,
+		defaultHide,
 		toggleCardTimestamp,
 		setHide,
 		setView,
@@ -159,8 +159,8 @@ const FilterDropdown: FC = () => {
 	);
 
 	const handleResetHideFilters = useCallback(() => {
-		setHide(DEFAULT_HIDE_VALUE);
-	}, [setHide]);
+		setHide(defaultHide);
+	}, [defaultHide, setHide]);
 
 	// biome-ignore lint/correctness/useExhaustiveDependencies: queryClient stable.
 	const handleResetColumns = useCallback(() => {
@@ -230,7 +230,7 @@ const FilterDropdown: FC = () => {
 							handleResetHideFilters();
 						}}
 					>
-						Reset
+						Reset filters
 					</DropdownMenuItem>
 				</DropdownMenuGroup>
 				{values.view === APPROVALS_TOOLBAR_VIEW.GRID.value && (
@@ -294,7 +294,7 @@ const FilterDropdown: FC = () => {
 									handleResetColumns();
 								}}
 							>
-								Reset
+								Reset columns
 							</DropdownMenuItem>
 						</DropdownMenuGroup>
 					</>

--- a/web/ui/react-app/src/components/approvals/toolbar/toolbar-context.tsx
+++ b/web/ui/react-app/src/components/approvals/toolbar/toolbar-context.tsx
@@ -9,6 +9,7 @@ import type { DataTableFeatures } from '@/components/ui/data-table';
 import type {
 	ApprovalsToolbarOptions,
 	CardTimestampType,
+	HideValueType,
 	ToolbarViewOption,
 } from '@/constants/toolbar';
 import type { TagsTriType } from '@/types/util';
@@ -24,6 +25,8 @@ export type ToolbarContextValue = {
 	setTags: (value: TagsTriType) => void;
 	/* Sets the 'hide' value in the URL */
 	setHide: (value: number[]) => void;
+	/* The 'hide' filters to fall back to, saved by the user or built in */
+	defaultHide: HideValueType[];
 	/* Sets the 'view' value in the URL */
 	setView: (value: ToolbarViewOption) => void;
 	/* Toggles the 'editMode' value in the URL */

--- a/web/ui/react-app/src/constants/toolbar.ts
+++ b/web/ui/react-app/src/constants/toolbar.ts
@@ -44,13 +44,52 @@ export const ACTIVE_HIDE_VALUES: HideValueType[] = [
 	HideValue.Skipped,
 ] as const;
 
-/* Hide option filters for the toolbar. */
+/* Hide option filters for the toolbar. `key` is also how the API names them. */
 export const toolbarHideOptions = [
-	{ key: 'upToDate', label: 'Hide up to date', value: HideValue.UpToDate },
+	{ key: 'up_to_date', label: 'Hide up to date', value: HideValue.UpToDate },
 	{ key: 'updatable', label: 'Hide updatable', value: HideValue.Updatable },
 	{ key: 'skipped', label: 'Hide skipped', value: HideValue.Skipped },
 	{ key: 'inactive', label: 'Hide inactive', value: HideValue.Inactive },
 ] as const;
+
+export type HideName = (typeof toolbarHideOptions)[number]['key'];
+
+/**
+ * Maps the API's hide names onto the values the dashboard filters by.
+ *
+ * @param names - The hide names to map.
+ * @returns Their values.
+ */
+export const hideValuesFromNames = (
+	names: readonly string[],
+): HideValueType[] =>
+	toolbarHideOptions
+		.filter(({ key }) => names.includes(key))
+		.map(({ value }) => value);
+
+/**
+ * Sorts hide values into a fixed order, so one built by toggling can be
+ * compared against one built from the defaults.
+ *
+ * @param values - The hide values to sort.
+ * @returns The values, in ascending order.
+ */
+export const sortHideValues = (
+	values: readonly HideValueType[],
+): HideValueType[] => [...values].sort((a, b) => a - b);
+
+/**
+ * Maps the dashboard's hide values onto the names the API uses.
+ *
+ * @param values - The hide values to map.
+ * @returns Their names, in a fixed order.
+ */
+export const hideNamesFromValues = (
+	values: readonly HideValueType[],
+): HideName[] =>
+	toolbarHideOptions
+		.filter(({ value }) => values.includes(value))
+		.map(({ key }) => key);
 
 /* Default hide value filters for the toolbar. */
 export const DEFAULT_HIDE_VALUE: HideValueType[] = [

--- a/web/ui/react-app/src/contexts/auth.tsx
+++ b/web/ui/react-app/src/contexts/auth.tsx
@@ -16,6 +16,7 @@ import {
 	type Action,
 	ADMIN_GROUP,
 	type AuthMe,
+	type DashboardPreferences,
 	type Grant,
 	type Resource,
 } from '@/types/auth';
@@ -44,6 +45,8 @@ type PermissionTarget = {
 type AuthContextProps = {
 	status: AuthStatus;
 	user?: AuthMe['user'];
+	/** The user's saved dashboard preferences, if they have any. */
+	preferences?: DashboardPreferences;
 	permissions: Grant[];
 	/** Whether the user belongs to the admin group. */
 	isAdmin: boolean;
@@ -262,6 +265,7 @@ export const AuthProvider = (props: AuthProviderProps) => {
 			login,
 			logout,
 			permissions,
+			preferences: me?.preferences,
 			setup,
 			status,
 			user: me?.user,

--- a/web/ui/react-app/src/pages/account/defaults/index.tsx
+++ b/web/ui/react-app/src/pages/account/defaults/index.tsx
@@ -1,0 +1,251 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { type ReactElement, useEffect } from 'react';
+import { Controller } from 'react-hook-form';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Label } from '@/components/ui/label';
+import { TextOrLoading } from '@/components/ui/loading-ellipsis';
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
+import {
+	approvalsToolbarViewOptions,
+	DEFAULT_CARD_TIMESTAMPS,
+	DEFAULT_HIDE_VALUE,
+	DEFAULT_VIEW_VALUE,
+	hideNamesFromValues,
+	type ToolbarViewOption,
+	toolbarHideOptions,
+	toolbarTimestampOptions,
+} from '@/constants/toolbar';
+import { useAuth } from '@/contexts/auth';
+import useZodForm from '@/hooks/use-zod-form';
+import { QUERY_KEYS } from '@/lib/query-keys';
+import {
+	type DefaultsFormValues,
+	defaultsSchema,
+} from '@/pages/account/defaults/schema';
+import { GroupHeading, GroupRule } from '@/pages/account/group';
+import type { AuthMe, DashboardPreferences } from '@/types/auth';
+import * as authAPI from '@/utils/api/auth';
+import { clearCardTimestamps } from '@/utils/card-timestamps';
+import { getErrorMessage } from '@/utils/errors';
+
+const valuesFor = (preferences?: DashboardPreferences): DefaultsFormValues => ({
+	hide: preferences?.hide ?? hideNamesFromValues(DEFAULT_HIDE_VALUE),
+	timestamps: preferences?.timestamps ?? [...DEFAULT_CARD_TIMESTAMPS],
+	view: preferences?.view ?? DEFAULT_VIEW_VALUE,
+});
+
+/** Adds value, or drops it if already there. */
+const toggled = <T extends string>(list: T[], value: T, on: boolean): T[] =>
+	on ? [...list, value] : list.filter((item) => item !== value);
+
+type ToggleRowProps = {
+	id: string;
+	label: string;
+	checked: boolean;
+	onCheckedChange: (checked: boolean) => void;
+};
+
+const ToggleRow = ({ id, label, checked, onCheckedChange }: ToggleRowProps) => (
+	<div className="flex items-center gap-2">
+		<Checkbox
+			checked={checked}
+			id={id}
+			onCheckedChange={(next) => onCheckedChange(next === true)}
+		/>
+		<Label className="font-normal" htmlFor={id}>
+			{label}
+		</Label>
+	</div>
+);
+
+/**
+ * The signed-in user's dashboard preferences.
+ */
+export const Defaults = (): ReactElement => {
+	const { preferences } = useAuth();
+	const queryClient = useQueryClient();
+	const form = useZodForm({
+		defaultValues: valuesFor(preferences),
+		schema: defaultsSchema,
+	});
+	const { isDirty } = form.formState;
+
+	// Re-seed only an untouched form.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: form is stable.
+	useEffect(() => {
+		if (form.formState.isDirty) return;
+		form.reset(valuesFor(preferences));
+	}, [preferences]);
+
+	const applied = (me: AuthMe, message: string) => {
+		queryClient.setQueryData(QUERY_KEYS.AUTH.ME(), me);
+		form.reset(valuesFor(me.preferences));
+		clearCardTimestamps();
+		toast.success(message);
+	};
+
+	const save = useMutation({
+		mutationFn: (values: DefaultsFormValues) =>
+			authAPI.updatePreferences(values),
+		onError: (error) =>
+			toast.error('Failed to save defaults', {
+				description: getErrorMessage(error),
+			}),
+		onSuccess: (me: AuthMe) => applied(me, 'Dashboard defaults saved'),
+	});
+
+	const reset = useMutation({
+		mutationFn: authAPI.resetPreferences,
+		onError: (error) =>
+			toast.error('Failed to reset defaults', {
+				description: getErrorMessage(error),
+			}),
+		onSuccess: (me: AuthMe) => applied(me, 'Dashboard defaults reset'),
+	});
+
+	const pending = save.isPending || reset.isPending;
+	const inertStyle =
+		'aria-disabled:pointer-events-none aria-disabled:opacity-50';
+	const saveInert = pending || !isDirty;
+	const resetInert = pending || !preferences;
+
+	return (
+		<form
+			className="flex flex-col gap-6"
+			onSubmit={form.handleSubmit((values) => {
+				if (saveInert) return;
+				save.mutate(values);
+			})}
+		>
+			<Card>
+				<CardContent className="grid gap-6">
+					<section className="grid gap-4">
+						<GroupHeading
+							description="Which services the dashboard shows when you open it without filters in the URL. A link carrying filters still wins."
+							id="defaults-filters-heading"
+							title="Filters"
+						/>
+						<Controller
+							control={form.control}
+							name="hide"
+							render={({ field }) => (
+								<fieldset
+									aria-labelledby="defaults-filters-heading"
+									className="grid gap-3 sm:grid-cols-2"
+								>
+									{toolbarHideOptions.map(({ key, label }) => (
+										<ToggleRow
+											checked={field.value.includes(key)}
+											id={`defaults-hide-${key}`}
+											key={key}
+											label={label}
+											onCheckedChange={(on) =>
+												field.onChange(toggled(field.value, key, on))
+											}
+										/>
+									))}
+								</fieldset>
+							)}
+						/>
+					</section>
+
+					<GroupRule />
+
+					<section className="grid gap-4">
+						<GroupHeading
+							description="The layout the dashboard opens in."
+							id="defaults-layout-heading"
+							title="Layout"
+						/>
+						<Controller
+							control={form.control}
+							name="view"
+							render={({ field }) => (
+								<ToggleGroup
+									aria-labelledby="defaults-layout-heading"
+									className="w-fit"
+									onValueChange={(view: ToolbarViewOption | '') => {
+										if (!view) return;
+										field.onChange(view);
+									}}
+									type="single"
+									value={field.value}
+									variant="outline"
+								>
+									{approvalsToolbarViewOptions.map(
+										({ icon: Icon, label, value }) => (
+											<ToggleGroupItem
+												aria-label={label}
+												key={value}
+												value={value}
+											>
+												<Icon className="h-4 w-4" />
+												{label}
+											</ToggleGroupItem>
+										),
+									)}
+								</ToggleGroup>
+							)}
+						/>
+					</section>
+
+					<GroupRule />
+
+					<section className="grid gap-4">
+						<GroupHeading
+							description="The timestamps shown under each service card, in the grid layout only."
+							id="defaults-timestamps-heading"
+							title="Timestamps"
+						/>
+						<Controller
+							control={form.control}
+							name="timestamps"
+							render={({ field }) => (
+								<fieldset
+									aria-labelledby="defaults-timestamps-heading"
+									className="grid gap-3 sm:grid-cols-2"
+								>
+									{toolbarTimestampOptions.map(({ key, label }) => (
+										<ToggleRow
+											checked={field.value.includes(key)}
+											id={`defaults-timestamp-${key}`}
+											key={key}
+											label={label}
+											onCheckedChange={(on) =>
+												field.onChange(toggled(field.value, key, on))
+											}
+										/>
+									))}
+								</fieldset>
+							)}
+						/>
+					</section>
+				</CardContent>
+			</Card>
+
+			<div className="flex gap-2">
+				<Button aria-disabled={saveInert} className={inertStyle} type="submit">
+					<TextOrLoading loading={save.isPending} text="Save changes" />
+				</Button>
+				<Button
+					aria-disabled={resetInert}
+					className={inertStyle}
+					onClick={() => {
+						if (resetInert) return;
+						reset.mutate();
+					}}
+					type="button"
+					variant="outline"
+				>
+					<TextOrLoading
+						loading={reset.isPending}
+						text="Reset to Argus defaults"
+					/>
+				</Button>
+			</div>
+		</form>
+	);
+};

--- a/web/ui/react-app/src/pages/account/defaults/schema.ts
+++ b/web/ui/react-app/src/pages/account/defaults/schema.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod';
+import {
+	approvalsToolbarViewOptions,
+	type CardTimestampType,
+	type HideName,
+	type ToolbarViewOption,
+	toolbarHideOptions,
+	toolbarTimestampOptions,
+} from '@/constants/toolbar';
+
+const HIDE_NAMES = toolbarHideOptions.map(({ key }) => key) as [
+	HideName,
+	...HideName[],
+];
+const TIMESTAMP_NAMES = toolbarTimestampOptions.map(({ key }) => key) as [
+	CardTimestampType,
+	...CardTimestampType[],
+];
+const VIEW_VALUES = approvalsToolbarViewOptions.map(({ value }) => value) as [
+	ToolbarViewOption,
+	...ToolbarViewOption[],
+];
+
+export const defaultsSchema = z.object({
+	hide: z.array(z.enum(HIDE_NAMES)),
+	timestamps: z.array(z.enum(TIMESTAMP_NAMES)),
+	view: z.enum(VIEW_VALUES),
+});
+
+export type DefaultsFormValues = z.infer<typeof defaultsSchema>;

--- a/web/ui/react-app/src/pages/account/group.tsx
+++ b/web/ui/react-app/src/pages/account/group.tsx
@@ -1,0 +1,27 @@
+import type { ReactElement } from 'react';
+import { Separator } from '@/components/ui/separator';
+
+type GroupHeadingProps = {
+	title: string;
+	description: string;
+	id?: string;
+};
+
+export const GroupHeading = ({
+	title,
+	description,
+	id,
+}: GroupHeadingProps): ReactElement => (
+	<div className="grid gap-1">
+		<h3 className="font-semibold text-base" id={id}>
+			{title}
+		</h3>
+		<p className="text-muted-foreground text-sm">{description}</p>
+	</div>
+);
+
+export const GroupRule = (): ReactElement => (
+	<div className="-mx-4">
+		<Separator />
+	</div>
+);

--- a/web/ui/react-app/src/pages/account/layout.tsx
+++ b/web/ui/react-app/src/pages/account/layout.tsx
@@ -1,4 +1,9 @@
-import { ChevronDown, KeyRound, UserCircle } from 'lucide-react';
+import {
+	ChevronDown,
+	KeyRound,
+	SlidersHorizontal,
+	UserCircle,
+} from 'lucide-react';
 import type { ReactElement } from 'react';
 import { Link, NavLink, Outlet, useLocation } from 'react-router';
 import { Button } from '@/components/ui/button';
@@ -12,6 +17,7 @@ import { cn } from '@/lib/utils';
 
 const SECTIONS = [
 	{ icon: UserCircle, label: 'Account', to: '/account/profile' },
+	{ icon: SlidersHorizontal, label: 'Defaults', to: '/account/defaults' },
 	{ icon: KeyRound, label: 'API Tokens', to: '/account/tokens' },
 ];
 

--- a/web/ui/react-app/src/pages/account/profile/index.tsx
+++ b/web/ui/react-app/src/pages/account/profile/index.tsx
@@ -11,11 +11,11 @@ import { Field, FieldDescription, FieldError } from '@/components/ui/field';
 import { Input } from '@/components/ui/input';
 import { TextOrLoading } from '@/components/ui/loading-ellipsis';
 import { MaskedInput } from '@/components/ui/masked-input';
-import { Separator } from '@/components/ui/separator';
 import { useAuth } from '@/contexts/auth';
 import usePasswordMismatch from '@/hooks/use-password-mismatch';
 import useZodForm from '@/hooks/use-zod-form';
 import { QUERY_KEYS } from '@/lib/query-keys';
+import { GroupHeading, GroupRule } from '@/pages/account/group';
 import {
 	type AccountFormValues,
 	accountSchema,
@@ -66,25 +66,6 @@ const formFor = (user?: AuthUser): AccountFormValues => ({
 	email: user?.email ?? '',
 	password: '',
 });
-
-type GroupHeadingProps = {
-	title: string;
-	description: string;
-};
-
-const GroupHeading = ({ title, description }: GroupHeadingProps) => (
-	<div className="grid gap-1">
-		<h3 className="font-semibold text-base">{title}</h3>
-		<p className="text-muted-foreground text-sm">{description}</p>
-	</div>
-);
-
-/** Divides the card's groups. */
-const GroupRule = () => (
-	<div className="-mx-4">
-		<Separator />
-	</div>
-);
 
 /**
  * The signed-in user's own account details. Every change is confirmed with
@@ -160,7 +141,8 @@ export const Account = (): ReactElement => {
 		<form
 			className="flex flex-col gap-6"
 			onSubmit={form.handleSubmit((values) => {
-				if (passwordsMismatch) return;
+				if (passwordsMismatch || save.isPending || !changed || !currentPassword)
+					return;
 				form.clearErrors('root');
 				save.mutate(values);
 			})}
@@ -335,13 +317,17 @@ export const Account = (): ReactElement => {
 			</Card>
 
 			{/* Left, not right: the toaster occupies the bottom-right corner. */}
-			{changed && (
-				<div className="flex">
-					<Button disabled={save.isPending || !currentPassword} type="submit">
-						<TextOrLoading loading={save.isPending} text="Save changes" />
-					</Button>
-				</div>
-			)}
+			{/* aria-disabled rather than disabled: disabling a focused button blurs
+			    it, so the keyboard user would lose their place on every save. */}
+			<div className="flex">
+				<Button
+					aria-disabled={save.isPending || !changed || !currentPassword}
+					className="aria-disabled:pointer-events-none aria-disabled:opacity-50"
+					type="submit"
+				>
+					<TextOrLoading loading={save.isPending} text="Save changes" />
+				</Button>
+			</div>
 		</form>
 	);
 };

--- a/web/ui/react-app/src/pages/approvals/index.tsx
+++ b/web/ui/react-app/src/pages/approvals/index.tsx
@@ -9,14 +9,18 @@ import {
 	APPROVALS_TOOLBAR_VIEW,
 	type ApprovalsToolbarOptions,
 	type CardTimestampType,
+	DEFAULT_CARD_TIMESTAMPS,
 	DEFAULT_HIDE_VALUE,
 	DEFAULT_VIEW_VALUE,
 	HideValue,
 	type HideValueType,
+	hideValuesFromNames,
 	isToolbarViewOption,
+	sortHideValues,
 	type ToolbarViewOption,
 	URL_PARAMS,
 } from '@/constants/toolbar';
+import { useAuth } from '@/contexts/auth';
 import { useServices } from '@/hooks/use-services';
 import { useSortableServices } from '@/hooks/use-sortable-services';
 import { GridLayout } from '@/pages/approvals/layouts/grid';
@@ -29,12 +33,15 @@ import {
 } from '@/utils/card-timestamps';
 import { visibleServices as getVisibleServices } from '@/utils/visible-services';
 
-const toolbarDefaults: ApprovalsToolbarOptions = {
-	editMode: false,
-	hide: DEFAULT_HIDE_VALUE,
+const toolbarFixedDefaults = {
 	search: '',
-	tags: { exclude: [], include: [] },
-	view: DEFAULT_VIEW_VALUE,
+	tags: { exclude: [], include: [] } as TagsTriType,
+};
+
+type DisplayDefaults = {
+	hide: HideValueType[];
+	timestamps: CardTimestampType[];
+	view: ToolbarViewOption;
 };
 
 /**
@@ -45,9 +52,24 @@ export const Approvals = (): ReactElement => {
 	// Signal for resetting table sorting when order is reset.
 	const [resetSortingSignal, setResetSortingSignal] = useState(0);
 
+	const { preferences } = useAuth();
+	const [defaults] = useState<DisplayDefaults>(() => {
+		const savedView = preferences?.view ?? null;
+
+		return {
+			hide: sortHideValues(
+				preferences?.hide
+					? hideValuesFromNames(preferences.hide)
+					: DEFAULT_HIDE_VALUE,
+			),
+			timestamps: preferences?.timestamps ?? [...DEFAULT_CARD_TIMESTAMPS],
+			view: isToolbarViewOption(savedView) ? savedView : DEFAULT_VIEW_VALUE,
+		};
+	});
+
 	const toolbarOptions: ApprovalsToolbarOptions = useMemo(() => {
 		const search =
-			searchParams.get(URL_PARAMS.SEARCH) ?? toolbarDefaults.search;
+			searchParams.get(URL_PARAMS.SEARCH) ?? toolbarFixedDefaults.search;
 
 		// Extract tags from URL.
 		const tagsIncludeQueryParam = searchParams.get(URL_PARAMS.TAGS_INCLUDE);
@@ -60,12 +82,12 @@ export const Approvals = (): ReactElement => {
 							exclude: JSON.parse(tagsExcludeQueryParam ?? '[]') as string[],
 							include: JSON.parse(tagsIncludeQueryParam ?? '[]') as string[],
 						}
-					: toolbarDefaults.tags;
+					: toolbarFixedDefaults.tags;
 		} catch (e) {
 			toast.error('Failed to parse tags from URL', {
 				description: `Error: ${e instanceof Error ? e.message : String(e)}`,
 			});
-			tags = toolbarDefaults.tags;
+			tags = toolbarFixedDefaults.tags;
 		}
 
 		const editMode = searchParams.has(URL_PARAMS.EDIT_MODE);
@@ -74,7 +96,7 @@ export const Approvals = (): ReactElement => {
 		const hideQueryParam = searchParams.get(URL_PARAMS.HIDE);
 		let hide: HideValueType[] = [];
 		if (hideQueryParam === null) {
-			hide = [...toolbarDefaults.hide];
+			hide = [...defaults.hide];
 		} else if (hideQueryParam) {
 			try {
 				const parsedHide: unknown = JSON.parse(hideQueryParam);
@@ -99,10 +121,10 @@ export const Approvals = (): ReactElement => {
 		const rawView = searchParams.get(URL_PARAMS.VIEW);
 		const view: ApprovalsToolbarOptions['view'] = isToolbarViewOption(rawView)
 			? rawView
-			: toolbarDefaults.view;
+			: defaults.view;
 
 		return { editMode, hide, search, tags, view };
-	}, [searchParams]);
+	}, [defaults, searchParams]);
 
 	const {
 		order,
@@ -166,16 +188,20 @@ export const Approvals = (): ReactElement => {
 					updateURLParam(key, value, false);
 					break;
 				case URL_PARAMS.HIDE:
-					updateURLParam(key, value, DEFAULT_HIDE_VALUE);
+					updateURLParam(
+						key,
+						sortHideValues(value as HideValueType[]),
+						defaults.hide,
+					);
 					break;
 				case URL_PARAMS.VIEW:
-					updateURLParam(key, value, DEFAULT_VIEW_VALUE);
+					updateURLParam(key, value, defaults.view);
 					break;
 				default:
 					break;
 			}
 		},
-		[updateURLParam],
+		[defaults, updateURLParam],
 	);
 
 	// Reset service order and table sorting.
@@ -232,8 +258,9 @@ export const Approvals = (): ReactElement => {
 		useState<ColumnVisibilityState>({});
 
 	// Timestamps shown at the bottom of the service card..
-	const [cardTimestamps, setCardTimestamps] =
-		useState<CardTimestampType[]>(loadCardTimestamps);
+	const [cardTimestamps, setCardTimestamps] = useState<CardTimestampType[]>(
+		() => loadCardTimestamps(defaults.timestamps),
+	);
 	const toggleCardTimestamp = useCallback((value: CardTimestampType) => {
 		setCardTimestamps((current) => {
 			const next = current.includes(value)
@@ -248,6 +275,7 @@ export const Approvals = (): ReactElement => {
 		<ToolbarProvider
 			value={{
 				cardTimestamps,
+				defaultHide: defaults.hide,
 				hasOrderChanged,
 				onSaveOrder: handleSaveOrder,
 				setHide,

--- a/web/ui/react-app/src/pages/index.tsx
+++ b/web/ui/react-app/src/pages/index.tsx
@@ -1,3 +1,4 @@
+export { Defaults as AccountDefaultsPage } from './account/defaults';
 export { SettingsLayout } from './account/layout';
 export { Account as AccountPage } from './account/profile';
 export { Tokens as TokensPage } from './account/tokens';

--- a/web/ui/react-app/src/types/auth.ts
+++ b/web/ui/react-app/src/types/auth.ts
@@ -2,6 +2,12 @@
  * Auth types, mirroring the API shapes in `web/api/types/auth.go`.
  */
 
+import type {
+	CardTimestampType,
+	HideName,
+	ToolbarViewOption,
+} from '@/constants/toolbar';
+
 // Single source of truth for the RBAC catalogue, so the zod schema and the
 // types stay in lockstep (mirrors the Go catalogue in auth/rbac).
 export const RESOURCES = [
@@ -54,9 +60,16 @@ export type AuthUser = {
 	updated_at: string;
 };
 
+export type DashboardPreferences = {
+	hide?: HideName[];
+	view?: ToolbarViewOption;
+	timestamps?: CardTimestampType[];
+};
+
 export type AuthMe = {
 	user: AuthUser;
 	permissions: Grant[] | null;
+	preferences?: DashboardPreferences;
 };
 
 export type AuthGroup = {

--- a/web/ui/react-app/src/utils/api/auth.ts
+++ b/web/ui/react-app/src/utils/api/auth.ts
@@ -13,6 +13,7 @@ import type {
 	GroupCreateRequest,
 	GroupPatchRequest,
 	LoginRequest,
+	PreferencesUpdateRequest,
 	SetupRequest,
 	SetupState,
 	UserCreateRequest,
@@ -59,6 +60,20 @@ export const updateAccount = (patch: AccountUpdateRequest) =>
 		body: JSON.stringify(patch),
 		method: 'PATCH',
 		url: `${API_BASE}/auth/me`,
+	});
+
+// Dashboard preferences of the signed-in user.
+export const updatePreferences = (preferences: PreferencesUpdateRequest) =>
+	fetchJSON<AuthMe>({
+		body: JSON.stringify(preferences),
+		method: 'PUT',
+		url: `${API_BASE}/auth/me/preferences`,
+	});
+
+export const resetPreferences = () =>
+	fetchJSON<AuthMe>({
+		method: 'DELETE',
+		url: `${API_BASE}/auth/me/preferences`,
 	});
 
 // Users.

--- a/web/ui/react-app/src/utils/api/types/requests/auth.ts
+++ b/web/ui/react-app/src/utils/api/types/requests/auth.ts
@@ -2,6 +2,11 @@
  * Auth API request payloads. Entity/response shapes live in `@/types/auth`.
  */
 
+import type {
+	CardTimestampType,
+	HideName,
+	ToolbarViewOption,
+} from '@/constants/toolbar';
 import type { Grant } from '@/types/auth';
 
 export type LoginRequest = {
@@ -70,4 +75,15 @@ export type GroupPatchRequest = {
 export type APITokenCreateRequest = {
 	name: string;
 	expires_in?: string;
+};
+
+/**
+ * PUT /auth/me/preferences - the signed-in user's dashboard preferences. An
+ * omitted field inherits the built-in default; an empty list is an explicit
+ * none.
+ */
+export type PreferencesUpdateRequest = {
+	hide?: HideName[];
+	view?: ToolbarViewOption;
+	timestamps?: CardTimestampType[];
 };

--- a/web/ui/react-app/src/utils/card-timestamps.ts
+++ b/web/ui/react-app/src/utils/card-timestamps.ts
@@ -1,7 +1,6 @@
 import {
 	CARD_TIMESTAMPS_STORAGE_KEY,
 	type CardTimestampType,
-	DEFAULT_CARD_TIMESTAMPS,
 	toolbarTimestampOptions,
 } from '@/constants/toolbar';
 
@@ -10,11 +9,14 @@ import {
  * An empty string means every timestamp was switched off, which is distinct
  * from the key being absent (never configured).
  *
+ * @param defaults - The timestamps to show when this browser has no preference.
  * @returns The enabled timestamps.
  */
-export const loadCardTimestamps = (): CardTimestampType[] => {
+export const loadCardTimestamps = (
+	defaults: readonly CardTimestampType[],
+): CardTimestampType[] => {
 	const stored = localStorage.getItem(CARD_TIMESTAMPS_STORAGE_KEY);
-	if (stored === null) return [...DEFAULT_CARD_TIMESTAMPS];
+	if (stored === null) return [...defaults];
 
 	const enabled = new Set(stored.split(',').filter(Boolean));
 	return toolbarTimestampOptions
@@ -29,4 +31,11 @@ export const loadCardTimestamps = (): CardTimestampType[] => {
  */
 export const persistCardTimestamps = (timestamps: CardTimestampType[]) => {
 	localStorage.setItem(CARD_TIMESTAMPS_STORAGE_KEY, timestamps.join(','));
+};
+
+/**
+ * Drops this browser's timestamp choice, so the saved default applies again.
+ */
+export const clearCardTimestamps = () => {
+	localStorage.removeItem(CARD_TIMESTAMPS_STORAGE_KEY);
 };

--- a/web/ui/react-app/tests/auth-defaults.spec.ts
+++ b/web/ui/react-app/tests/auth-defaults.spec.ts
@@ -1,0 +1,240 @@
+import {
+	type APIRequestContext,
+	type BrowserContext,
+	expect,
+	test,
+} from '@playwright/test';
+import {
+	ADMIN_PASSWORD,
+	ADMIN_USER,
+	cleanupByName,
+	cleanupStack,
+	RUN_ID,
+	SERVICE,
+	signedInContext,
+} from './fixtures/auth';
+import { expectServiceLoaded, serviceCard } from './fixtures/dashboard';
+
+/**
+ * Dashboard display defaults e2e specs - run only in the `chromium-auth`
+ * project, against the auth-enabled Argus instance.
+ *
+ * Scope: what a user saves at /account/defaults, and how the approvals
+ * dashboard applies it.
+ */
+
+const PASSWORD = 'e2e-defaults-password';
+
+test.describe('Dashboard defaults', () => {
+	let adminAPI: APIRequestContext;
+	const cleanup = cleanupStack();
+
+	/**
+	 * Creates a user, registering its removal, and returns its username.
+	 * In the viewer group, so the dashboard has services to lay out.
+	 */
+	const createUser = async (suffix: string) => {
+		const username = `e2e-defaults-${suffix}-${RUN_ID}`;
+		cleanupByName(cleanup, adminAPI, 'users', username);
+		const created = await adminAPI.post('api/v1/users', {
+			data: { groups: ['viewer'], password: PASSWORD, username: username },
+		});
+		expect(created.status(), `create ${username}`).toBe(201);
+		return username;
+	};
+
+	/** A signed-in browser context for username. */
+	const sessionFor = async (
+		browser: Parameters<typeof signedInContext>[0],
+		username: string,
+	): Promise<BrowserContext> => {
+		const context = await signedInContext(browser, username, PASSWORD);
+		cleanup.add(() => context.close());
+		return context;
+	};
+
+	test.beforeAll(async ({ browser }) => {
+		const adminContext = await signedInContext(
+			browser,
+			ADMIN_USER,
+			ADMIN_PASSWORD,
+		);
+		cleanup.add(() => adminContext.close());
+		adminAPI = adminContext.request;
+	});
+
+	test.afterAll(async () => {
+		await cleanup.run();
+	});
+
+	test('saved defaults apply to a clean dashboard URL', async ({ browser }) => {
+		// GIVEN: a user on the defaults page, with nothing saved.
+		const username = await createUser('apply');
+		const page = await (await sessionFor(browser, username)).newPage();
+		await page.goto('/account/defaults');
+
+		// WHEN: the table layout and an extra filter are saved.
+		await page.getByRole('radio', { name: 'Table' }).click();
+		await page.getByRole('checkbox', { name: 'Hide up to date' }).click();
+		const save = page.getByRole('button', { name: 'Save changes' });
+		await save.click();
+		await expect(page.getByText('Dashboard defaults saved')).toBeVisible();
+
+		// AND: the button keeps focus.
+		await expect(save).toBeFocused();
+		await expect(save).toHaveAttribute('aria-disabled', 'true');
+
+		// THEN: a clean /approvals opens in the table layout.
+		await page.goto('/approvals');
+		await expect(page.getByRole('table')).toBeVisible();
+
+		// AND: the URL stays clean - the defaults are not echoed into it.
+		expect(new URL(page.url()).search).toBe('');
+
+		// AND: the saved filter is the one the dropdown reports.
+		await page.getByRole('button', { name: 'Filter shown services' }).click();
+		await expect(
+			page.getByRole('menuitemcheckbox', { name: 'Hide up to date' }),
+		).toBeChecked();
+		await page.keyboard.press('Escape');
+
+		// AND: they survive a reload, so they came from the account.
+		await page.reload();
+		await expect(page.getByRole('table')).toBeVisible();
+	});
+
+	test('a URL param still overrides the saved default', async ({ browser }) => {
+		// GIVEN: a user who defaults to the table layout.
+		const username = await createUser('override');
+		const page = await (await sessionFor(browser, username)).newPage();
+		await page.goto('/account/defaults');
+		await page.getByRole('radio', { name: 'Table' }).click();
+		await page.getByRole('button', { name: 'Save changes' }).click();
+		await expect(page.getByText('Dashboard defaults saved')).toBeVisible();
+
+		// WHEN: the dashboard is opened with an explicit layout.
+		await page.goto('/approvals?view=grid');
+
+		// THEN: the link view wins.
+		await expect(
+			page.getByRole('heading', { exact: true, name: SERVICE }),
+		).toBeVisible();
+		await expect(page.getByRole('table')).toHaveCount(0);
+	});
+
+	test('the toolbar Reset returns to the saved filters', async ({
+		browser,
+	}) => {
+		// GIVEN: a user who defaults to hiding up-to-date services.
+		const username = await createUser('toolbar-reset');
+		const page = await (await sessionFor(browser, username)).newPage();
+		await page.goto('/account/defaults');
+		await page.getByRole('checkbox', { name: 'Hide up to date' }).click();
+		await page.getByRole('button', { name: 'Save changes' }).click();
+		await expect(page.getByText('Dashboard defaults saved')).toBeVisible();
+
+		// WHEN: that filter is turned off on the dashboard, then Reset is used.
+		await page.goto('/approvals');
+		await page.getByRole('button', { name: 'Filter shown services' }).click();
+		await page
+			.getByRole('menuitemcheckbox', { name: 'Hide up to date' })
+			.click();
+		await expect(
+			page.getByRole('menuitemcheckbox', { name: 'Hide up to date' }),
+		).not.toBeChecked();
+		await page.getByRole('menuitem', { name: 'Reset filters' }).click();
+
+		// THEN: it comes back.
+		await expect(
+			page.getByRole('menuitemcheckbox', { name: 'Hide up to date' }),
+		).toBeChecked();
+	});
+
+	test('each control group carries its heading as its name', async ({
+		browser,
+	}) => {
+		// GIVEN: a user on the defaults page.
+		const username = await createUser('a11y');
+		const page = await (await sessionFor(browser, username)).newPage();
+		await page.goto('/account/defaults');
+
+		// THEN: every group of controls is announced with what it configures.
+		await expect(
+			page.getByRole('radiogroup', { name: 'Layout' }),
+		).toBeVisible();
+		await expect(page.getByRole('group', { name: 'Filters' })).toBeVisible();
+		await expect(page.getByRole('group', { name: 'Timestamps' })).toBeVisible();
+	});
+
+	test('a saved timestamp choice applies to the cards', async ({ browser }) => {
+		// GIVEN: a user on the defaults page.
+		const username = await createUser('timestamps');
+		const page = await (await sessionFor(browser, username)).newPage();
+		await page.goto('/account/defaults');
+
+		// WHEN: only the 'found' timestamp is left on, and saved.
+		await page.getByRole('checkbox', { name: 'Show queried' }).click();
+		await page.getByRole('checkbox', { name: 'Show found' }).click();
+		await page.getByRole('button', { name: 'Save changes' }).click();
+		await expect(page.getByText('Dashboard defaults saved')).toBeVisible();
+
+		// THEN: the card shows that timestamp and no other.
+		await page.goto('/approvals');
+		await expectServiceLoaded(page, SERVICE);
+		const lines = serviceCard(page, SERVICE).locator('[data-timestamp]');
+		await expect(lines).toHaveCount(1);
+		await expect(lines.first()).toHaveAttribute('data-timestamp', 'found');
+	});
+
+	test('a saved empty filter set hides nothing', async ({ browser }) => {
+		// GIVEN: a user on the defaults page.
+		const username = await createUser('nofilters');
+		const page = await (await sessionFor(browser, username)).newPage();
+		await page.goto('/account/defaults');
+
+		// WHEN: every filter is off - an explicit none, not "inherit".
+		await page.getByRole('checkbox', { name: 'Hide inactive' }).click();
+		await page.getByRole('button', { name: 'Save changes' }).click();
+		await expect(page.getByText('Dashboard defaults saved')).toBeVisible();
+
+		// THEN: a clean /approvals applies the empty set rather than the built-in
+		// default, so nothing is filtered out.
+		await page.goto('/approvals');
+		await page.getByRole('button', { name: 'Filter shown services' }).click();
+		for (const label of [
+			'Hide up to date',
+			'Hide updatable',
+			'Hide skipped',
+			'Hide inactive',
+		])
+			await expect(
+				page.getByRole('menuitemcheckbox', { exact: true, name: label }),
+			).not.toBeChecked();
+	});
+
+	test('reset discards the saved defaults', async ({ browser }) => {
+		// GIVEN: a user who has saved the table layout as default.
+		const username = await createUser('reset');
+		const page = await (await sessionFor(browser, username)).newPage();
+		await page.goto('/account/defaults');
+		await page.getByRole('radio', { name: 'Table' }).click();
+		await page.getByRole('button', { name: 'Save changes' }).click();
+		await expect(page.getByText('Dashboard defaults saved')).toBeVisible();
+
+		// WHEN: they reset the defaults.
+		await page.getByRole('button', { name: 'Reset to Argus defaults' }).click();
+		await expect(page.getByText('Dashboard defaults reset')).toBeVisible();
+
+		// AND: the button keeps focus.
+		const reset = page.getByRole('button', { name: 'Reset to Argus defaults' });
+		await expect(reset).toHaveAttribute('aria-disabled', 'true');
+		await expect(reset).toBeFocused();
+
+		// AND: the dashboard is back to the grid layout.
+		await page.goto('/approvals');
+		await expect(
+			page.getByRole('heading', { exact: true, name: SERVICE }),
+		).toBeVisible();
+		await expect(page.getByRole('table')).toHaveCount(0);
+	});
+});

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -215,8 +215,8 @@ func TestAccessibleHTTPS(t *testing.T) {
 		},
 	}
 	cfg := testConfig(t, filepath.Join(t.TempDir(), "config.yml"))
-	cfg.Settings.Web.CertFile = "TestAccessibleHTTPS_Cert.pem"
-	cfg.Settings.Web.KeyFile = "TestAccessibleHTTPS_Key.pem"
+	cfg.Settings.Web.CertFile = t.Name() + "_Cert.pem"
+	cfg.Settings.Web.KeyFile = t.Name() + "_Key.pem"
 	_ = generateCertFiles(cfg.Settings.Web.CertFile, cfg.Settings.Web.KeyFile)
 	t.Cleanup(func() {
 		_ = os.Remove(cfg.Settings.Web.CertFile)

--- a/web/yaml_help_test.go
+++ b/web/yaml_help_test.go
@@ -25,7 +25,9 @@ import (
 
 func writeFile(path string, data string) {
 	data = strings.TrimPrefix(data, "\n")
-	_ = os.WriteFile(path, []byte(data), 0644)
+	if err := os.WriteFile(path, []byte(data), 0644); err != nil {
+		panic(err)
+	}
 }
 
 func testYAML_Argus(path string) {

--- a/webhook/header_test.go
+++ b/webhook/header_test.go
@@ -42,7 +42,7 @@ func TestHeaders_UnmarshalYAML(t *testing.T) {
 			name:     "empty",
 			data:     "",
 			errRegex: `^$`,
-			expected: Headers{},
+			expected: nil,
 		},
 		{
 			name:     "single map Header",

--- a/webhook/init_test.go
+++ b/webhook/init_test.go
@@ -180,7 +180,7 @@ func TestWebhook_Init(t *testing.T) {
 	svcStatus.Init(
 		0, 0, 1,
 		status.ServiceInfo{
-			ID: "TestWebhook_Init",
+			ID: t.Name(),
 		},
 		&dashboard.Options{
 			WebURL: "https://example.com",

--- a/webhook/verify.go
+++ b/webhook/verify.go
@@ -98,7 +98,7 @@ func (w *Webhook) CheckValues() (error, bool) {
 	if whType == "" {
 		errs = append(
 			errs,
-			polymorphic.ErrInvalidType{
+			polymorphic.ErrInvalidValue{
 				Key:     "type",
 				Allowed: supportedTypes,
 			},
@@ -170,7 +170,7 @@ func (b *Base) CheckValues() (error, bool) {
 	if b.Type != "" && !slices.Contains(supportedTypes, b.Type) {
 		errs = append(
 			errs,
-			polymorphic.ErrInvalidType{
+			polymorphic.ErrInvalidValue{
 				Key:     "type",
 				Value:   b.Type,
 				Allowed: supportedTypes,


### PR DESCRIPTION
dashboard defaults:
- 'view' mode
- 'hide' options
- 'timestamp' options

`user_preferences` table
| user_id | hide | view | timestamps | created_at | updated_at
| --- | --- | --- | --- | --- | --- |
| USERNAME | up_to_date,updatable,skipped,inactive | grid | deployed,found,queried | X | Y

<img width="1136" height="687" alt="image" src="https://github.com/user-attachments/assets/0b753dbb-7250-4c54-a0ad-c6730e7b7f63" />
